### PR TITLE
Prevent malicious file download on tailscale

### DIFF
--- a/server/service/network/tailscale.go
+++ b/server/service/network/tailscale.go
@@ -68,7 +68,7 @@ func (s *Service) InstallTailscale(c *gin.Context) {
 	}
 
 	const (
-		downloadUrl = "http://cdn.sipeed.com/nanokvm/resources/tailscale_riscv64.zip"
+		downloadUrl = "https://cdn.sipeed.com/nanokvm/resources/tailscale_riscv64.zip"
 		workspace   = "/root/.tailscale"
 	)
 


### PR DESCRIPTION
If the network is compromised and `cdn.sipeed.com` is redirected to attacker's domain, malicious file can be deployed onto NanoKVM since it's transferred over https. It would be nice to just keep this as https since CDN already supports https at the moment.