### PR TITLE
Fix login title font

### DIFF
--- a/web/src/pages/auth/login/index.tsx
+++ b/web/src/pages/auth/login/index.tsx
@@ -63,13 +63,14 @@ export const Login = () => {
       <Head title={t('head.login')} />
 
       <div className="flex h-screen w-screen flex-col items-center justify-center">
-        <h2 className="text-xl font-semibold text-neutral-100">{t('auth.login')}</h2>
 
         <Form
           style={{ minWidth: 300, maxWidth: 500 }}
           initialValues={{ remember: true }}
           onFinish={login}
         >
+          <h2 className="text-xl font-semibold text-neutral-100 text-center">{t('auth.login')}</h2>
+
           <Form.Item
             name="username"
             rules={[{ required: true, message: t('auth.noEmptyUsername'), min: 1 }]}


### PR DESCRIPTION
I noticed the title of the login page has an font which doesn't match the rest of the application.
Moving this into the `<Form>` element makes it slightly better for accessibility & appearance.

![image](https://github.com/user-attachments/assets/8d4b295f-6700-4cad-96cc-baf96df450a1)