### PR TITLE
Add configuration option for custom ICE servers

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -47,6 +47,15 @@ authentication: enable
 # JWT secret key configuration
 # If left empty, a random key will be generated on each server start
 secretKey: ""
+
+# Address for custom STUN server
+stun: stun.l.google.com:19302
+
+# Address and authentication for custom TURN server
+turn:
+    turnAddr: turn.cloudflare.com:3478
+    turnUser: example_user
+    turnCred: example_cred
 ```
 
 

--- a/server/README_JA.md
+++ b/server/README_JA.md
@@ -47,6 +47,13 @@ authentication: enable
 # JWT 秘密鍵の設定
 # 空のままにすると、サーバー起動時にランダムな鍵が生成されます
 secretKey: ""
+
+stun: stun.l.google.com:19302
+
+turn:
+    turnAddr: turn.cloudflare.com:3478
+    turnUser: example_user
+    turnCred: example_cred
 ```
 
 ## コンパイルとデプロイ

--- a/server/README_ZH.md
+++ b/server/README_ZH.md
@@ -45,6 +45,13 @@ authentication: enable
 # JWT 密钥
 # 如果不设置，则每次服务启动时使用随机生成的密钥。
 secretKey: ""
+
+stun: stun.l.google.com:19302
+
+turn:
+    turnAddr: turn.cloudflare.com:3478
+    turnUser: example_user
+    turnCred: example_cred
 ```
 
 ## 编译部署

--- a/server/config/default.go
+++ b/server/config/default.go
@@ -14,5 +14,11 @@ var defaultConfig = &Config{
 		Level: "info",
 		File:  "stdout",
 	},
+	Stun: "stun.l.google.com:19302",
+	Turn: Turn{
+		TurnAddr: "turn.cloudflare.com:3478",
+		TurnUser: "",
+		TurnCred: "",
+	},
 	Authentication: "enable",
 }

--- a/server/config/types.go
+++ b/server/config/types.go
@@ -7,6 +7,8 @@ type Config struct {
 	Logger         Logger `yaml:"logger"`
 	Authentication string `yaml:"authentication"`
 	SecretKey      string `yaml:"secretKey"`
+	Stun           string `yaml:"stun"`
+	Turn           Turn   `yaml:"turn"`
 
 	Hardware Hardware `yaml:"-"`
 }
@@ -24,6 +26,12 @@ type Port struct {
 type Cert struct {
 	Crt string `yaml:"crt"`
 	Key string `yaml:"key"`
+}
+
+type Turn struct {
+	TurnAddr string `yaml:"turnAddr"`
+	TurnUser string `yaml:"turnUser"`
+	TurnCred string `yaml:"turnCred"`
 }
 
 type Hardware struct {


### PR DESCRIPTION
This adds an option to the server configuration file (`server.yaml`) to set custom ICE servers (STUN and TURN). If any of the fields for either server are not configured, the connection will just be established without them.

I'm happy to listen to any feedback or change the way this is implemented if preferred.

I, unfortunately, am unable to properly translate the comments for the various server READMEs so I only added the options there. If anyone is able to provide proper translations, I will happily update those to reflect that,