### PR TITLE
Fix password updated check

### DIFF
--- a/server/service/auth/password.go
+++ b/server/service/auth/password.go
@@ -70,7 +70,9 @@ func (s *Service) IsPasswordUpdated(c *gin.Context) {
 	err = bcrypt.CompareHashAndPassword([]byte(account.Password), []byte("admin"))
 
 	rsp.OkRspWithData(c, &proto.IsPasswordUpdatedRsp{
-		IsUpdated: err == nil,
+		// If the hash is not valid, still assume it's not updated
+		// The error we want to see is password and hash not matching
+		IsUpdated: err == bcrypt.ErrMismatchedHashAndPassword,
 	})
 }
 


### PR DESCRIPTION
The current check is inverted, meaning that IsUpdated is true for the default "admin" password, but false for everything else. This causes the user to be endlessly annoyed to change their password, but only after they already changed it.

Looking at the docs for [bcrypt](https://pkg.go.dev/golang.org/x/crypto/bcrypt#CompareHashAndPassword), we see that `CompareHashAndPassword ` returns nil on success (meaning password and hash are the same). So, password being updated means the return value should **not** be nil.