### PR TITLE
Use format logger where needed

### DIFF
--- a/server/config/hardware.go
+++ b/server/config/hardware.go
@@ -85,7 +85,7 @@ func getHardware() (h Hardware) {
 
 	default:
 		h = HWAlpha
-		log.Error("Unsupported hardware version: %s", version)
+		log.Errorf("Unsupported hardware version: %s", version)
 	}
 
 	return

--- a/server/service/stream/frame-rate.go
+++ b/server/service/stream/frame-rate.go
@@ -42,7 +42,7 @@ func GetFrameRateCounter() *FrameRateCounter {
 				data := fmt.Sprintf("%d", counter.fps)
 				err := os.WriteFile("/kvmapp/kvm/now_fps", []byte(data), 0o666)
 				if err != nil {
-					log.Errorf("failed to wirte fps: %s", err)
+					log.Errorf("failed to write fps: %s", err)
 				}
 			}
 		}()

--- a/server/service/vm/gpio.go
+++ b/server/service/vm/gpio.go
@@ -46,7 +46,7 @@ func (s *Service) SetGpio(c *gin.Context) {
 		return
 	}
 
-	log.Debugf("gpio %s set sucessfully", device)
+	log.Debugf("gpio %s set successfully", device)
 	rsp.OkRsp(c)
 }
 

--- a/server/service/vm/memory.go
+++ b/server/service/vm/memory.go
@@ -30,7 +30,7 @@ func (s *Service) SetMemoryLimit(c *gin.Context) {
 	}
 
 	rsp.OkRsp(c)
-	log.Debug("set memory limit successful, enabled: %t, limit: %s", req.Enabled, req.Limit)
+	log.Debugf("set memory limit successful, enabled: %t, limit: %d", req.Enabled, req.Limit)
 }
 
 func (s *Service) GetMemoryLimit(c *gin.Context) {

--- a/server/service/vm/script.go
+++ b/server/service/vm/script.go
@@ -112,7 +112,7 @@ func (s *Service) RunScript(c *gin.Context) {
 	}
 
 	if err != nil {
-		log.Errorf("run script %s faile: %s", req.Name, err)
+		log.Errorf("run script %s failed: %s", req.Name, err.Error())
 		rsp.ErrRsp(c, -2, "run script failed")
 		return
 	}


### PR DESCRIPTION
* Fix format directives found without a formatting logger
* Fix spelling
* Fix type of req.Limit