### PR TITLE
Optimize vb pools

### DIFF
--- a/vision/components/kvm/src/kvm_vision.cpp
+++ b/vision/components/kvm/src/kvm_vision.cpp
@@ -1432,6 +1432,13 @@ int kvmv_read_img(uint16_t _width, uint16_t _height, uint8_t _type, uint16_t _ql
 
         // img exist
         // Encode
+        if(kvmv_cfg.venc_type == VENC_MJPEG && kvmv_cfg.venc_type != _type){
+            mmf_enc_jpg_deinit(0);
+        }
+        if(kvmv_cfg.venc_type == VENC_H264 && kvmv_cfg.venc_type != _type){
+            mmf_del_venc_channel(kvm_venc.mmf_venc_chn);
+            kvm_venc.enc_h264_init = 0;
+        }
         if(_type == VENC_H264 && kvmv_cfg.venc_type != _type){
             kvm_venc.enc_h264_init = 1;
             // debug("[kvmv] change to h264\n");

--- a/vision/components/kvm_mmf/src/kvm_mmf.cpp
+++ b/vision/components/kvm_mmf/src/kvm_mmf.cpp
@@ -663,12 +663,12 @@ static CVI_S32 _mmf_sys_init(SIZE_S stSize)
 
 	// vi
 	u32BlkSize = COMMON_GetPicBufferSize(stSize.u32Width, stSize.u32Height, PIXEL_FORMAT_UYVY,
-		DATA_BITWIDTH_12, enCompressMode, DEFAULT_ALIGN);
+		DATA_BITWIDTH_8, enCompressMode, DEFAULT_ALIGN);
 	u32BlkRotSize = COMMON_GetPicBufferSize(stSize.u32Height, stSize.u32Width, PIXEL_FORMAT_UYVY,
-		DATA_BITWIDTH_12, enCompressMode, DEFAULT_ALIGN);
+		DATA_BITWIDTH_8, enCompressMode, DEFAULT_ALIGN);
 	u32BlkSize = MAX(u32BlkSize, u32BlkRotSize);
 	stVbConf.astCommPool[MMF_VB_VI_ID].u32BlkSize	= u32BlkSize;
-	stVbConf.astCommPool[MMF_VB_VI_ID].u32BlkCnt	= 4;
+	stVbConf.astCommPool[MMF_VB_VI_ID].u32BlkCnt	= 3;
 	stVbConf.astCommPool[MMF_VB_VI_ID].enRemapMode	= VB_REMAP_MODE_CACHED;
 	stVbConf.u32MaxPoolCnt = 1;
 


### PR DESCRIPTION
This will reduce the required ION size to 35M (and allows to change the memmap to give 196M for the OS)
- Change vi pool DATA_BITWIDTH_12 to DATA_BITWIDTH_8
- Reduce vi pool block count from  to 3
- Destroy JPEG pool when switching to H264 and vice versa
