### PR TITLE
Minor Init.d Cleanup

### DIFF
--- a/kvmapp/system/init.d/S03usbdev
+++ b/kvmapp/system/init.d/S03usbdev
@@ -106,7 +106,7 @@ start_usb_dev(){
             fi
     fi
 
-    ls /sys/class/udc/ | cat > UDC
+    ls /sys/class/udc/ > UDC
     echo device > /proc/cviusb/otg_role
 }
 

--- a/kvmapp/system/init.d/S30eth
+++ b/kvmapp/system/init.d/S30eth
@@ -14,22 +14,20 @@ start() {
     if [ -e /boot/eth.nodhcp ] 
     then
         [ -e /boot/eth.nodhcp ] &&
-            cat /boot/eth.nodhcp | while read inet gw
-            do
+            while read -r inet gw; do
                 addr=${inet%/*}
                 netid=${inet#*/}
-                [ -z $gw ] &&
-                gw=$( echo $addr| ( IFS='.' read a b c d; echo $((
-                    (((((($a<<8)+$b)<<8)+$c)<<8)+$d)
-                        & (((1<<$netid)-1)<<(32-$netid))
-                    ))
-                )) &&
-                gw=$(($gw>>24&0xff)).$(($gw>>16&0xff)).$(($gw>>8&0xff)).$((1+( $gw>>0&0xff )))
+
+                if [ -z "$gw" ]; then
+                    IFS='.' read -r a b c d <<< "$addr"
+                    gw=$(( (((((($a << 8) + $b) << 8) + $c) << 8) + $d) & (((1 << $netid) - 1) << (32 - $netid)) ))
+                    gw=$(( (gw >> 24) & 0xff )).$(( (gw >> 16) & 0xff )).$(( (gw >> 8) & 0xff )).$(( 1 + (gw & 0xff) ))
+                fi
 
                 arping -Dqc2 -Ieth0 $addr || continue
                 ip a add $inet brd + dev eth0
                 ip r add default via $gw dev eth0
-                cat > /etc/resolve.conf << EOF
+                cat > /etc/resolv.conf << EOF
 nameserver $gw
 nameserver 8.8.8.8
 nameserver 114.114.114.114
@@ -53,7 +51,7 @@ EOF
 }
 stop() {
     [[ ! -e "/run/udhcpc.eth0.pid" ]] && echo "udhcpc is not running..." && exit 1
-    kill `cat /run/udhcpc.eth0.pid`
+    kill "$(cat /run/udhcpc.eth0.pid)"
     rm /run/udhcpc.eth0.pid
 }
 

--- a/kvmapp/system/init.d/S50sshd
+++ b/kvmapp/system/init.d/S50sshd
@@ -12,18 +12,11 @@ PIDFILE="/var/run/sshd.pid"
 umask 077
 
 startssh() {
-    # Generate keys if missing
+    # Generate SSH keys if they do not exist
     [ ! -f /etc/ssh/ssh_host_rsa_key ] && /usr/bin/ssh-keygen -A
-
-    # Prevent multiple instances using PID check
-    if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
-        echo "sshd already running"
-        exit 0
-    fi
 
     printf "Starting sshd: "
     /usr/sbin/sshd
-    echo $! > "$PIDFILE"  # Store the PID of sshd
     touch /var/lock/sshd
     echo "OK"
 }
@@ -44,9 +37,7 @@ start() {
 
 stop() {
     printf "Stopping sshd: "
-    if [ -f "$PIDFILE" ]; then
-        kill "$(cat "$PIDFILE")" 2>/dev/null && rm -f "$PIDFILE"
-    fi
+    killall sshd 2>/dev/null
     rm -f /var/lock/sshd
     echo "OK"
 }
@@ -67,12 +58,10 @@ case "$1" in
         restart
         ;;
     permanent_on)
-        [ ! -e /etc/kvm/ssh_stop ] && { echo "SSH is already enabled"; exit 0; }
         rm -f /etc/kvm/ssh_stop
         start
         ;;
     permanent_off)
-        [ -e /etc/kvm/ssh_stop ] && { echo "SSH is already disabled"; exit 0; }
         touch /etc/kvm/ssh_stop
         stop
         ;;

--- a/kvmapp/system/init.d/S50sshd
+++ b/kvmapp/system/init.d/S50sshd
@@ -3,67 +3,82 @@
 # sshd        Starts sshd.
 #
 
-# Make sure the ssh-keygen progam exists
-[ -f /usr/bin/ssh-keygen ] || exit 0
+# Ensure required binaries exist
+[ -x /usr/bin/ssh-keygen ] || exit 0
+[ -x /usr/sbin/sshd ] || exit 1
+
+PIDFILE="/var/run/sshd.pid"
 
 umask 077
 
 startssh() {
-	/usr/bin/ssh-keygen -A
+    # Generate keys if missing
+    [ ! -f /etc/ssh/ssh_host_rsa_key ] && /usr/bin/ssh-keygen -A
 
-	printf "Starting sshd: "
-	/usr/sbin/sshd
-	touch /var/lock/sshd
-	echo "OK"
+    # Prevent multiple instances using PID check
+    if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
+        echo "sshd already running"
+        exit 0
+    fi
+
+    printf "Starting sshd: "
+    /usr/sbin/sshd
+    echo $! > "$PIDFILE"  # Store the PID of sshd
+    touch /var/lock/sshd
+    echo "OK"
 }
+
 start() {
-	# Create any missing keys
-    if [ -e /etc/kvm/ssh_stop ]
-	then
-		if [ -e /boot/start_ssh_once ]
-		then
-			rm /boot/start_ssh_once
-			startssh
-		else
-			echo "SSH does not start"
-		fi
-	else
-		startssh
-	fi
+    if [ -e /etc/kvm/ssh_stop ]; then
+        if [ -e /boot/start_ssh_once ]; then
+            rm -f /boot/start_ssh_once
+            startssh
+        else
+            echo "SSH does not start"
+            exit 0
+        fi
+    else
+        startssh
+    fi
 }
+
 stop() {
-	printf "Stopping sshd: "
-	killall sshd
-	rm -f /var/lock/sshd
-	echo "OK"
+    printf "Stopping sshd: "
+    if [ -f "$PIDFILE" ]; then
+        kill "$(cat "$PIDFILE")" 2>/dev/null && rm -f "$PIDFILE"
+    fi
+    rm -f /var/lock/sshd
+    echo "OK"
 }
+
 restart() {
-	stop
-	start
+    stop
+    start
 }
 
 case "$1" in
-  start)
-	start
-	;;
-  stop)
-	stop
-	;;
-  restart|reload)
-	restart
-	;;
-  permanent_on)
-    rm /etc/kvm/ssh_stop
-	start
-    ;;
-  permanent_off)
-    touch /etc/kvm/ssh_stop
-	stop
-    ;;
-  *)
-	echo "Usage: $0 {start|stop|restart|permanent_on|permanent_off}"
-	exit 1
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    restart|reload)
+        restart
+        ;;
+    permanent_on)
+        [ ! -e /etc/kvm/ssh_stop ] && { echo "SSH is already enabled"; exit 0; }
+        rm -f /etc/kvm/ssh_stop
+        start
+        ;;
+    permanent_off)
+        [ -e /etc/kvm/ssh_stop ] && { echo "SSH is already disabled"; exit 0; }
+        touch /etc/kvm/ssh_stop
+        stop
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|restart|permanent_on|permanent_off}"
+        exit 1
 esac
 
-exit $?
-
+exit 0

--- a/kvmapp/system/init.d/S50sshd
+++ b/kvmapp/system/init.d/S50sshd
@@ -15,10 +15,10 @@ startssh() {
     # Generate SSH keys if they do not exist
     [ ! -f /etc/ssh/ssh_host_rsa_key ] && /usr/bin/ssh-keygen -A
 
-    printf "Starting sshd: "
-    /usr/sbin/sshd
-    touch /var/lock/sshd
-    echo "OK"
+            printf "Starting sshd: "
+            /usr/sbin/sshd
+            touch /var/lock/sshd
+            echo "OK"
 }
 
 start() {
@@ -36,15 +36,15 @@ start() {
 }
 
 stop() {
-    printf "Stopping sshd: "
-    killall sshd 2>/dev/null
-    rm -f /var/lock/sshd
-    echo "OK"
+            printf "Stopping sshd: "
+            killall sshd 2>/dev/null
+            rm -f /var/lock/sshd
+            echo "OK"
 }
 
 restart() {
-    stop
-    start
+            stop
+            start
 }
 
 case "$1" in

--- a/kvmapp/system/init.d/S50sshd
+++ b/kvmapp/system/init.d/S50sshd
@@ -15,10 +15,10 @@ startssh() {
     # Generate SSH keys if they do not exist
     [ ! -f /etc/ssh/ssh_host_rsa_key ] && /usr/bin/ssh-keygen -A
 
-            printf "Starting sshd: "
-            /usr/sbin/sshd
-            touch /var/lock/sshd
-            echo "OK"
+        printf "Starting sshd: "
+        /usr/sbin/sshd
+        touch /var/lock/sshd
+        echo "OK"
 }
 
 start() {
@@ -36,15 +36,15 @@ start() {
 }
 
 stop() {
-            printf "Stopping sshd: "
-            killall sshd 2>/dev/null
-            rm -f /var/lock/sshd
-            echo "OK"
+        printf "Stopping sshd: "
+        killall sshd 2>/dev/null
+        rm -f /var/lock/sshd
+        echo "OK"
 }
 
 restart() {
-            stop
-            start
+        stop
+        start
 }
 
 case "$1" in

--- a/kvmapp/system/init.d/S95nanokvm
+++ b/kvmapp/system/init.d/S95nanokvm
@@ -1,42 +1,57 @@
 #!/bin/sh
-# nanokvm Rev3.0
+# nanokvm Rev3.1
 
 case "$1" in
   start)
     echo -n kvm > /boot/hostname.prefix
-    cp /mnt/data/sensor_cfg.ini.LT /mnt/data/sensor_cfg.ini
 
-    str_value=$(cat /sys/class/cvi-base/base_uid | awk '{print $2}')
-    first_uint=$(echo $str_value | cut -d'_' -f1)
-    second_uint=$(echo $str_value | cut -d'_' -f2)
-    result="$first_uint$second_uint"
-    echo $result > /device_key
+    # Copy sensor config if the file exists
+    [ -f /mnt/data/sensor_cfg.ini.LT ] && cp /mnt/data/sensor_cfg.ini.LT /mnt/data/sensor_cfg.ini
 
+    # Generate unique device key
+    if [ -f /sys/class/cvi-base/base_uid ]; then
+        str_value=$(awk '{print $2}' /sys/class/cvi-base/base_uid)
+        first_uint=$(echo "$str_value" | cut -d'_' -f1)
+        second_uint=$(echo "$str_value" | cut -d'_' -f2)
+        echo "$first_uint$second_uint" > /device_key
+    fi
+
+    # Set iptables rules (skip if already present)
+    iptables -C INPUT -i eth0 -p tcp --dport 80 -m state --state NEW,ESTABLISHED -j ACCEPT 2>/dev/null || \
     iptables -A INPUT -i eth0 -p tcp --dport 80 -m state --state NEW,ESTABLISHED -j ACCEPT
+
+    iptables -C OUTPUT -o eth0 -p tcp --sport 80 -m state --state ESTABLISHED -j ACCEPT 2>/dev/null || \
     iptables -A OUTPUT -o eth0 -p tcp --sport 80 -m state --state ESTABLISHED -j ACCEPT
+
+    iptables -C OUTPUT -o eth0 -p tcp --dport 22 -m state --state NEW,ESTABLISHED -j ACCEPT 2>/dev/null || \
     iptables -A OUTPUT -o eth0 -p tcp --dport 22 -m state --state NEW,ESTABLISHED -j ACCEPT
+
+    iptables -C INPUT -i eth0 -p tcp --sport 22 -m state --state ESTABLISHED -j ACCEPT 2>/dev/null || \
     iptables -A INPUT -i eth0 -p tcp --sport 22 -m state --state ESTABLISHED -j ACCEPT
+
+    iptables -C OUTPUT -o eth0 -p tcp --sport 8000 -m state --state ESTABLISHED -j DROP 2>/dev/null || \
     iptables -A OUTPUT -o eth0 -p tcp --sport 8000 -m state --state ESTABLISHED -j DROP
 
+    # Start services
     cp -r /kvmapp/kvm_system /tmp/
     /tmp/kvm_system/kvm_system &
-    
+
     cp -r /kvmapp/server /tmp/
     /tmp/server/NanoKVM-Server &
-  ;;
+    ;;
+
   stop)
     killall kvm_system
     killall NanoKVM-Server
-    rm -r /tmp/kvm_system
-    rm -r /tmp/server
+    rm -r /tmp/kvm_system /tmp/server
     echo "OK"
-  ;;
+    ;;
+
   restart)
     killall kvm_system
     killall NanoKVM-Server
-    rm -r /tmp/kvm_system
-    rm -r /tmp/server
-    
+    rm -r /tmp/kvm_system /tmp/server
+
     cp -r /kvmapp/kvm_system /tmp/
     /tmp/kvm_system/kvm_system &
 
@@ -44,7 +59,11 @@ case "$1" in
     /tmp/server/NanoKVM-Server &
 
     sync
-
     echo "OK"
-  ;;
+    ;;
+    
+  *)
+    echo "Usage: $0 {start|stop|restart}"
+    exit 1
+    ;;
 esac

--- a/kvmapp/system/init.d/S95nanokvm
+++ b/kvmapp/system/init.d/S95nanokvm
@@ -38,14 +38,14 @@ case "$1" in
 
     cp -r /kvmapp/server /tmp/
     /tmp/server/NanoKVM-Server &
-    ;;
+   ;;
 
   stop)
     killall kvm_system
     killall NanoKVM-Server
     rm -r /tmp/kvm_system /tmp/server
     echo "OK"
-    ;;
+   ;;
 
   restart)
     killall kvm_system
@@ -60,10 +60,10 @@ case "$1" in
 
     sync
     echo "OK"
-    ;;
+   ;;
     
   *)
     echo "Usage: $0 {start|stop|restart}"
     exit 1
-    ;;
+  ;;
 esac


### PR DESCRIPTION
I did some really minor cleanup of the init.d configs. There may a few changes I missed, but this is the gist. 
- S03usbdev: Removed erroneous cat command
- S30eth: refactored to remove subshell
- S30eth: Fixed spelling error for /etc/resolv.conf (not /etc/resolve.conf)
- S50shd: Number of small changes
- S95nanokvm: Checked for IPtables rules before implementing to prevent duplicates.
