### PR TITLE
support: kvm_system: fix 'const char' and 'std::nullptr_t' comparsion

### DIFF
--- a/support/sg2002/kvm_system/main/lib/system_state/system_state.cpp
+++ b/support/sg2002/kvm_system/main/lib/system_state/system_state.cpp
@@ -51,7 +51,7 @@ int get_ip_addr(ip_addr_t ip_type)
 	switch (ip_type){
 		case ETH_IP: // eth_addr
 			if(strcmp(ip_address()["eth0"].c_str(), (char*)kvm_sys_state.eth_addr) != 0){
-				if(*(ip_address()["eth0"].c_str()) == NULL){
+				if(*(ip_address()["eth0"].c_str()) == 0){
 					printf("can`t get ip addr\r\n");
 					kvm_sys_state.eth_addr[0] = 0;
 					return 0;
@@ -66,7 +66,7 @@ int get_ip_addr(ip_addr_t ip_type)
 			return 1;
 		case WiFi_IP: // wifi_addr
 			if(strcmp(ip_address()["wlan0"].c_str(), (char*)kvm_sys_state.wifi_addr) != 0){
-				if(*(ip_address()["wlan0"].c_str()) == NULL){
+				if(*(ip_address()["wlan0"].c_str()) == 0){
 					printf("can`t get ip addr\r\n");
 					kvm_sys_state.wifi_addr[0] = 0;
 					return 0;
@@ -80,7 +80,7 @@ int get_ip_addr(ip_addr_t ip_type)
 			}
 			return 1;
 		case Tailscale_IP: // tail_addr
-			if(*(ip_address()["tailscale0"].c_str()) == NULL){
+			if(*(ip_address()["tailscale0"].c_str()) == 0){
 				printf("can`t get ip addr\r\n");
 				kvm_sys_state.tail_addr[0] = 0;
 				return 0;
@@ -93,7 +93,7 @@ int get_ip_addr(ip_addr_t ip_type)
 			printf("\r\n");
 			return 1;
 		case RNDIS_IP: // rndis_addr
-			if(*(ip_address()["usb0"].c_str()) == NULL){
+			if(*(ip_address()["usb0"].c_str()) == 0){
 				printf("can`t get ip addr\r\n");
 				kvm_sys_state.rndis_addr[0] = 0;
 				return 0;


### PR DESCRIPTION
*(ip_address()["eth0"].c_str()) can not be NULL because the first char is referenced, which is 0 if the string is empty.