### PR TITLE
support: kvm_system: add return value to get_ping_allow_state

### DIFF
--- a/support/sg2002/kvm_system/main/lib/system_state/system_state.cpp
+++ b/support/sg2002/kvm_system/main/lib/system_state/system_state.cpp
@@ -43,6 +43,8 @@ int get_ping_allow_state()
 	} else {
 		kvm_sys_state.ping_allow = 1;
 	}
+
+	return kvm_sys_state.ping_allow;
 }
 
 // net_port
@@ -465,4 +467,6 @@ void kvm_update_tailscale_state(void)
 uint8_t ion_free_space(void)
 {
 	//cat /sys/kernel/debug/ion/cvi_carveout_heap_dump/summary | grep "usage rate:" | awk '{print $2}'
+
+	return 0;
 }


### PR DESCRIPTION
… and ion_free_space

int get_ping_allow_state() needs a return value (or should be changed to void get_ping_allow_state()).
Before this change kvm_system consumed 50-90% of the CPU now it is below 1% again.