### PR TITLE
Resolve typo in eth config that breaks dns resolving.

### DIFF
--- a/kvmapp/system/init.d/S30eth
+++ b/kvmapp/system/init.d/S30eth
@@ -29,7 +29,7 @@ start() {
                 arping -Dqc2 -Ieth0 $addr || continue
                 ip a add $inet brd + dev eth0
                 ip r add default via $gw dev eth0
-                cat > /etc/resolve.conf << EOF
+                cat > /etc/resolv.conf << EOF
 nameserver $gw
 nameserver 8.8.8.8
 nameserver 114.114.114.114


### PR DESCRIPTION
Fixed a typo that creates incorrect resolve.conf file instead of resolv.conf file.

DNS seems to work once this is fixed. 