### PR TITLE
Virtual Media Changes

### DIFF
--- a/kvmapp/system/init.d/S03usbdev
+++ b/kvmapp/system/init.d/S03usbdev
@@ -82,8 +82,10 @@ start_usb_dev(){
         ln -s functions/hid.GS2 configs/c.1
     fi
 
-    if [ -e /boot/usb.disk0 ]
+    # dedicated for media
+    if [ ! -e /boot/usb.disk0.disabled ]
     then
+            touch /boot/usb.disk0
             mkdir functions/mass_storage.disk0
             ln -s functions/mass_storage.disk0 configs/c.1/
             echo 1 > functions/mass_storage.disk0/lun.0/removable
@@ -95,15 +97,18 @@ start_usb_dev(){
             disk=$(cat /boot/usb.disk0)
             if [ -z "${disk}" ]
             then
-                    # if [ ! -e /mnt/usbdisk.img ]
-                    # then
-                    #         fallocate -l 8G /mnt/usbdisk.img
-                    #         mkfs.vfat /mnt/usbdisk.img
-                    # fi
-                    echo /dev/mmcblk0p3 > functions/mass_storage.disk0/lun.0/file
+                    echo "" > functions/mass_storage.disk0/lun.0/file
             else
                     cat /boot/usb.disk0 > functions/mass_storage.disk0/lun.0/file
             fi
+    fi
+
+    # mount data partition
+    if [ -e /boot/usb.disk1 ]
+    then
+            mkdir functions/mass_storage.disk1
+            ln -s functions/mass_storage.disk1 configs/c.1/
+            echo /dev/mmcblk0p3 > functions/mass_storage.disk1/lun.0/file
     fi
 
     ls /sys/class/udc/ | cat > UDC

--- a/server/service/storage/image.go
+++ b/server/service/storage/image.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	imageDirectory = "/data"
-	imageNone      = "/dev/mmcblk0p3"
+	imageNone      = ""
 	cdromFlag      = "/sys/kernel/config/usb_gadget/g0/functions/mass_storage.disk0/lun.0/cdrom"
 	mountDevice    = "/sys/kernel/config/usb_gadget/g0/functions/mass_storage.disk0/lun.0/file"
 	roFlag         = "/sys/kernel/config/usb_gadget/g0/functions/mass_storage.disk0/lun.0/ro"
@@ -105,8 +105,9 @@ func (s *Service) MountImage(c *gin.Context) {
 
 	// reset usb
 	commands := []string{
-		"echo > /sys/kernel/config/usb_gadget/g0/UDC",
-		"ls /sys/class/udc/ | cat > /sys/kernel/config/usb_gadget/g0/UDC",
+		// this should not be required for media change, reset of the full gadget can break hid on some devices
+		//"echo > /sys/kernel/config/usb_gadget/g0/UDC",
+		//"ls /sys/class/udc/ | cat > /sys/kernel/config/usb_gadget/g0/UDC",
 	}
 
 	for _, command := range commands {

--- a/server/service/vm/virtual-device.go
+++ b/server/service/vm/virtual-device.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	virtualNetwork = "/boot/usb.rndis0"
-	virtualDisk    = "/boot/usb.disk0"
+	virtualDisk    = "/boot/usb.disk1"
 )
 
 var (
@@ -32,15 +32,15 @@ var (
 	}
 
 	mountDiskCommands = []string{
-		"touch /boot/usb.disk0",
+		"touch /boot/usb.disk1",
 		"/etc/init.d/S03usbdev stop",
 		"/etc/init.d/S03usbdev start",
 	}
 
 	unmountDiskCommands = []string{
 		"/etc/init.d/S03usbdev stop",
-		"rm -rf /sys/kernel/config/usb_gadget/g0/configs/c.1/mass_storage.disk0",
-		"rm /boot/usb.disk0",
+		"rm -rf /sys/kernel/config/usb_gadget/g0/configs/c.1/mass_storage.disk1",
+		"rm /boot/usb.disk1",
 		"/etc/init.d/S03usbdev start",
 	}
 )


### PR DESCRIPTION
This PR's goal is to help address issues i have, only with specific hardware, losing HID connectivity when virtual media is inserted. 

As part of debugging this problem, i split the mounting of SD card (virtual media toggle in settings) from iso virtual media. 

This allows for SD card mounting to remain off (most cases i suspect people won't require it). 
But still inject CDROM / boot media as required. 

This change also removes the full reset of the USB gadget when boot media is inserted / ejected

I have tested, but only on the one device where i have had issues, and it seems to resolve them in most cases.
Multiple mass storage devices when both SD and boot media are attached. 
Boot media can be changed without "replug" events on hid devices.

Unmount of media thats in use does still fail (as it did before) and may require a hid reset to force. 

I can see a fix has been merged https://patchwork.kernel.org/project/linux-usb/patch/20220711102956.19642-1-mdevaev@gmail.com/ which would allow for reliable unmounting of media. However thats not available in the current kernel version used. 