### PR TITLE
Make HDMI toggle state persist across reboots

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -16,6 +16,7 @@ import (
 	"NanoKVM-Server/middleware"
 	"NanoKVM-Server/router"
 	"NanoKVM-Server/service/vm/jiggler"
+	"NanoKVM-Server/utils"
 
 	"github.com/gin-gonic/gin"
 	cors "github.com/rs/cors/wrapper/gin"
@@ -38,7 +39,9 @@ func initialize() {
 	vision := common.GetKvmVision()
 	vision.SetHDMI(false)
 	time.Sleep(10 * time.Millisecond)
-	vision.SetHDMI(true)
+	if !utils.IsHdmiDisabled() {
+		vision.SetHDMI(true)
+	}
 
 	// run mouse jiggler
 	jiggler.GetJiggler().Run()

--- a/server/service/vm/hdmi.go
+++ b/server/service/vm/hdmi.go
@@ -5,12 +5,11 @@ import (
 
 	"NanoKVM-Server/common"
 	"NanoKVM-Server/proto"
+	"NanoKVM-Server/utils"
 
 	"github.com/gin-gonic/gin"
 	log "github.com/sirupsen/logrus"
 )
-
-var hdmiEnabled = true
 
 func (s *Service) ResetHdmi(c *gin.Context) {
 	var rsp proto.Response
@@ -20,7 +19,7 @@ func (s *Service) ResetHdmi(c *gin.Context) {
 	vision.SetHDMI(false)
 	time.Sleep(1 * time.Second)
 	vision.SetHDMI(true)
-	hdmiEnabled = true
+	utils.PersistHDMIEnabled()
 
 	rsp.OkRsp(c)
 	log.Debug("reset hdmi")
@@ -32,7 +31,7 @@ func (s *Service) EnableHdmi(c *gin.Context) {
 	vision := common.GetKvmVision()
 
 	vision.SetHDMI(true)
-	hdmiEnabled = true
+	utils.PersistHDMIEnabled()
 
 	rsp.OkRsp(c)
 	log.Debug("enable hdmi")
@@ -44,7 +43,7 @@ func (s *Service) DisableHdmi(c *gin.Context) {
 	vision := common.GetKvmVision()
 
 	vision.SetHDMI(false)
-	hdmiEnabled = false
+	utils.PersistHDMIDisabled()
 
 	rsp.OkRsp(c)
 	log.Debug("disable hdmi")
@@ -54,7 +53,7 @@ func (s *Service) GetHdmiState(c *gin.Context) {
 	var rsp proto.Response
 
 	rsp.OkRspWithData(c, &proto.GetGetHdmiStateRsp{
-		Enabled: hdmiEnabled,
+		Enabled: !utils.IsHdmiDisabled(),
 	})
 
 	log.Debug("get hdmi state")

--- a/server/utils/hdmi.go
+++ b/server/utils/hdmi.go
@@ -1,0 +1,38 @@
+package utils
+
+import (
+	"os"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	HDMIDisableFile = "/etc/kvm/hdmi_disable"
+)
+
+func PersistHDMIDisabled() {
+	f, err := os.OpenFile(HDMIDisableFile, os.O_CREATE|os.O_RDONLY, 0644)
+	if err != nil {
+		log.Error("failed to create hdmi disable file:", err)
+		return
+	}
+	f.Close()
+}
+
+func PersistHDMIEnabled() {
+	if err := os.Remove(HDMIDisableFile); err != nil {
+		log.Error("failed to remove hdmi disable file:", err)
+		return
+	}
+}
+
+func IsHdmiDisabled() bool {
+	if _, err := os.Stat(HDMIDisableFile); err != nil {
+		if os.IsNotExist(err) {
+			return false // HDMI is enabled
+		}
+		log.Error("failed to check hdmi disable file:", err)
+		return false // Assume HDMI is enabled on error
+	}
+	return true // HDMI is disabled
+}


### PR DESCRIPTION
Currently the HDMI disable is only active for the lifetime of the server process. 
Now that it has been moved into settings, it should really be persistent.