### PR TITLE
fix(hid): Add automatic reset on write failure

### DIFF
--- a/server/service/hid/hid.go
+++ b/server/service/hid/hid.go
@@ -5,17 +5,13 @@ import (
 	"sync"
 )
 
-var (
-	hid     *Hid
-	hidOnce sync.Once
-)
-
 type Hid struct {
 	g0         *os.File
 	g1         *os.File
 	g2         *os.File
 	kbMutex    sync.Mutex
 	mouseMutex sync.Mutex
+	service    *Service
 }
 
 func (h *Hid) Lock() {
@@ -28,9 +24,8 @@ func (h *Hid) Unlock() {
 	h.mouseMutex.Unlock()
 }
 
-func GetHid() *Hid {
-	hidOnce.Do(func() {
-		hid = &Hid{}
-	})
-	return hid
+func newHid(s *Service) *Hid {
+	return &Hid{
+		service: s,
+	}
 }

--- a/server/service/hid/operation.go
+++ b/server/service/hid/operation.go
@@ -63,7 +63,10 @@ func (h *Hid) Write(file *os.File, data []byte) {
 			log.Debugf("hid already closed, reopen it...")
 			h.OpenNoLock()
 		} else {
-			log.Errorf("write to hid failed: %s", err)
+			log.Errorf("write to hid failed: %s, reseting...", err)
+			if err := h.service.resetHID(); err != nil {
+				log.Errorf("reset hid failed: %s", err)
+			}
 		}
 
 		return

--- a/server/service/hid/reset.go
+++ b/server/service/hid/reset.go
@@ -9,66 +9,56 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (s *Service) Reset(c *gin.Context) {
-	var rsp proto.Response
-
+func (s *Service) resetHID() error {
 	// reset USB
 	f, err := os.OpenFile("/sys/kernel/config/usb_gadget/g0/UDC", os.O_WRONLY, 0644)
 	if err != nil {
 		log.Errorf("open /sys/kernel/config/usb_gadget/g0/UDC failed: %s", err)
-		rsp.ErrRsp(c, -1, "open usb gadget file failed")
-		return
+		return err
 	}
+	defer f.Close()
+
 	err = f.Truncate(0)
 	if err != nil {
-		_ = f.Close()
 		log.Errorf("truncate /sys/kernel/config/usb_gadget/g0/UDC failed: %s", err)
-		rsp.ErrRsp(c, -1, "truncate usb gadget file failed")
-		return
+		return err
 	}
 	_, err = f.Seek(0, 0)
 	if err != nil {
-		_ = f.Close()
 		log.Errorf("seek to 0 failed: %s", err)
-		rsp.ErrRsp(c, -1, "seek to 0 in usb gadget file failed")
-		return
+		return err
 	}
 	_, err = f.WriteString("\n")
 	if err != nil {
-		_ = f.Close()
 		log.Errorf("write to /sys/kernel/config/usb_gadget/g0/UDC failed: %s", err)
-		rsp.ErrRsp(c, -1, "write to usb gadget file failed")
-		return
+		return err
 	}
-	_ = f.Close()
 
 	time.Sleep(1 * time.Second)
 
 	devices, err := os.ReadDir("/sys/class/udc/")
 	if err != nil {
 		log.Errorf("read udc directory failed: %s", err)
-		rsp.ErrRsp(c, -1, "read udc directory failed")
-		return
+		return err
 	}
 
-	f, err = os.OpenFile("/sys/kernel/config/usb_gadget/g0/UDC", os.O_WRONLY, 0644)
-	if err != nil {
-		log.Errorf("open /sys/kernel/config/usb_gadget/g0/UDC failed: %s", err)
-		rsp.ErrRsp(c, -1, "open usb gadget file failed")
-		return
-	}
 	for _, device := range devices {
 		_, err = f.WriteString(device.Name() + "\n")
 		if err != nil {
-			_ = f.Close()
 			log.Errorf("write to /sys/kernel/config/usb_gadget/g0/UDC failed: %s", err)
-			rsp.ErrRsp(c, -1, "write to usb gadget file failed")
-			return
+			return err
 		}
 	}
 
-	_ = f.Close()
-
-	rsp.OkRsp(c)
 	log.Debugf("reset hid success")
+	return nil
+}
+
+func (s *Service) Reset(c *gin.Context) {
+	var rsp proto.Response
+	if err := s.resetHID(); err != nil {
+		rsp.ErrRsp(c, -1, "hid reset failed")
+		return
+	}
+	rsp.OkRsp(c)
 }

--- a/server/service/hid/service.go
+++ b/server/service/hid/service.go
@@ -1,11 +1,20 @@
 package hid
 
+var (
+	GHid *Hid
+)
+
 type Service struct {
 	hid *Hid
 }
 
+func (s *Service) GetHid() *Hid {
+	return s.hid
+}
+
 func NewService() *Service {
-	return &Service{
-		hid: GetHid(),
-	}
+	s := &Service{}
+	s.hid = newHid(s)
+	GHid = s.hid
+	return s
 }

--- a/server/service/vm/virtual-device.go
+++ b/server/service/vm/virtual-device.go
@@ -94,7 +94,7 @@ func (s *Service) UpdateVirtualDevice(c *gin.Context) {
 		return
 	}
 
-	h := hid.GetHid()
+	h := hid.GHid
 	h.Lock()
 	h.CloseNoLock()
 	defer func() {


### PR DESCRIPTION
When the host computer reboots, the NanoKVM's USB gadget can get into a bad state, causing writes to the HID devices to fail. This results in the keyboard and mouse becoming unresponsive.

This change improves the error handling in the HID write function. If a write fails for any reason other than the file being closed, it will now trigger a full reset of the USB gadget. This should make the HID functionality more resilient and prevent it from getting stuck in a bad state.

This fixes the following issues:
- https://github.com/sipeed/NanoKVM/issues/593
- https://github.com/sipeed/NanoKVM/issues/220
- https://github.com/sipeed/NanoKVM/issues/582
- https://github.com/sipeed/NanoKVM/issues/480