### PR TITLE
feat: NIC MAC address to be persistent

### DIFF
--- a/kvmapp/system/init.d/S00nic-mac
+++ b/kvmapp/system/init.d/S00nic-mac
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+
+
+generate_mac() {
+    local input="$1"
+    local hash=$(echo -n "$input" | md5sum | awk '{print $1}')
+    local mac="${hash:0:2}:${hash:2:2}:${hash:4:2}:${hash:6:2}:${hash:8:2}:${hash:10:2}"
+    local first_byte=$(printf "%02x" $(( 0x${hash:0:2} & 0xfe | 0x02 )))
+    mac="${first_byte}:${hash:2:2}:${hash:4:2}:${hash:6:2}:${hash:8:2}:${hash:10:2}"
+
+    echo "$mac"
+}
+
+
+if [ "$1" != "start" ];then
+    return 0
+fi;
+
+if [ ! -f /sys/class/cvi-base/base_uid ];then
+    insmod /mnt/system/ko/soph_sys.ko
+    insmod /mnt/system/ko/soph_base.ko
+fi;
+
+mac=$(generate_mac `cat /sys/class/cvi-base/base_uid` | awk '{print $2}')
+macchanger --mac=$mac eth0
+return 0
+

--- a/support/sg2002/kvm_system/main/lib/system_init/system_init.cpp
+++ b/support/sg2002/kvm_system/main/lib/system_init/system_init.cpp
@@ -56,6 +56,7 @@ void new_app_init(void)
 	system("cp -f /kvmapp/system/update-nanokvm.py /etc/kvm/");
 	system("rm -f /etc/init.d/S02udisk");
 	system("cp -f /kvmapp/system/init.d/S00kmod /etc/init.d/");
+	system("cp -f /kvmapp/system/init.d/S00nic-mac /etc/init.d/");
 	system("cp -f /kvmapp/system/init.d/S01fs /etc/init.d/");
 	system("cp -f /kvmapp/system/init.d/S03usbdev /etc/init.d/");
 	system("cp -f /kvmapp/system/init.d/S15kvmhwd /etc/init.d/");


### PR DESCRIPTION
NanoKVM kept exhausting the DHCP server's IP pool because it generated a new MAC address on every boot.  

This PR ensures that NanoKVM generates a consistent MAC address derived from a broad UUID.