### PR TITLE
Fix oled_sleep_param only retaining lowest 8-bits of value

### DIFF
--- a/support/sg2002/kvm_system/main/include/config.h
+++ b/support/sg2002/kvm_system/main/include/config.h
@@ -95,10 +95,11 @@ typedef struct {
 	int8_t type = -1;				// cat /kvmapp/kvm/type
 	int8_t now_fps = -1;			// cat /kvmapp/kvm/now_fps
 	int16_t qlty = -1;				// cat /kvmapp/kvm/qlty
-    uint8_t oled_sleep_param = 0;
+    uint16_t oled_sleep_param = 0;
     uint8_t oled_sleep_state = 0;	// 0:wakeup; 1:sleep;
 	uint64_t oled_sleep_start = 0;
 	uint64_t ue_patch_state = 0;
 } kvm_oled_state_t;
 
 #endif // CONFIG_H_
+


### PR DESCRIPTION
Providing oled_sleep_param with a 16-bit value (i.e. >256), results unpredictable display sleep times as only the low 8-bits are retained due to uint8_t (i.e. 5 minutes 300 seconds; shuts off in ~44s /  300s - 256s), this patch switches to uint16_t which should allow for up to sleeps of up to 65535 seconds.

(P.S. the code was edited on github web, as it seems the code base has messed up line-endings (CRLF) then result in `git diff` showing up with `^M`, which I don't know if it that would make compiler barf...  please convert the code to proper LF endings) 