### PR TITLE
fix: support Alt-Shift key combination for layout switching in virtual keyboard

### DIFF
--- a/web/src/pages/desktop/virtual-keyboard/index.tsx
+++ b/web/src/pages/desktop/virtual-keyboard/index.tsx
@@ -101,6 +101,8 @@ export const VirtualKeyboard = () => {
   // Release key
   function onKeyReleased(key: string) {
     if (modifierKeys.includes(key)) {
+      setActiveModifierKeys(activeModifierKeys.filter((k) => k !== key));
+      sendModifierKeyUp();
       return;
     }
 
@@ -174,13 +176,14 @@ export const VirtualKeyboard = () => {
 
   // Release modifier keys
   function sendModifierKeyUp() {
-    if (activeModifierKeys.length === 0) return;
+    let modifier = 0;
 
-    activeModifierKeys.forEach(() => {
-      send(0, 0);
+    activeModifierKeys.forEach((modifierKey) => {
+      const key = specialKeyMap.get(modifierKey)!;
+      modifier |= getModifierBit(key)!;
     });
 
-    setActiveModifierKeys([]);
+    send(modifier, 0);
   }
 
   function send(modifier: number, code: number) {


### PR DESCRIPTION
## Summary
- Modifier keys are now properly released when user releases them
- sendModifierKeyUp() now sends current modifier state instead of clearing it
- Allows users to press Alt then Shift (or vice versa) to switch keyboard layouts

## Issue
Fixes #688 - Users were unable to switch keyboard layouts using Alt-Shift combination in virtual keyboard. Modifier keys only worked when combined with a third key press.

## Changes
- Modified `onKeyReleased()` to update active modifier keys state and send new state when a modifier key is released
- Modified `sendModifierKeyUp()` to calculate and send current modifier bitmap instead of clearing all modifiers