### PR TITLE
Fix: Allow frontend to check if authentication is disabled (#301)

### DIFF
--- a/server/proto/application.go
+++ b/server/proto/application.go
@@ -12,3 +12,8 @@ type GetPreviewRsp struct {
 type SetPreviewReq struct {
 	Enable bool `validate:"omitempty"`
 }
+
+type GetAuthStatusRsp struct {
+	Enabled bool `json:"enabled"`
+}
+

--- a/server/router/application.go
+++ b/server/router/application.go
@@ -17,4 +17,6 @@ func applicationRouter(r *gin.Engine) {
 
 	api.GET("/application/preview", service.GetPreview)  // get preview updates state
 	api.POST("/application/preview", service.SetPreview) // set preview updates state
+
+	r.GET("/api/application/auth/status", service.GetAuthStatus) // get authentication status (no token required)
 }

--- a/server/service/application/version.go
+++ b/server/service/application/version.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"NanoKVM-Server/config"
 	"NanoKVM-Server/proto"
 
 	"github.com/gin-gonic/gin"
@@ -88,3 +89,17 @@ func getLatest() (*Latest, error) {
 	log.Debugf("get application latest version: %s", latest.Version)
 	return &latest, nil
 }
+
+func (s *Service) GetAuthStatus(c *gin.Context) {
+	var rsp proto.Response
+
+	"NanoKVM-Server/config"
+
+	conf := config.GetInstance()
+	enabled := conf.Authentication != "disable"
+
+	rsp.OkRspWithData(c, &proto.GetAuthStatusRsp{
+		Enabled: enabled,
+	})
+}
+

--- a/web/src/api/application.ts
+++ b/web/src/api/application.ts
@@ -37,3 +37,9 @@ export function setPreviewUpdates(enable: boolean) {
 export function getPreviewUpdates() {
   return http.get('/api/application/preview');
 }
+
+// get authentication status
+export function getAuthStatus() {
+  return http.get('/api/application/auth/status');
+}
+

--- a/web/src/components/auth.tsx
+++ b/web/src/components/auth.tsx
@@ -1,10 +1,36 @@
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import { Navigate } from 'react-router-dom';
 
 import { existToken } from '@/lib/cookie.ts';
+import { getAuthStatus } from '@/api/application.ts';
 
 export const ProtectedRoute = ({ children }: { children: ReactNode }) => {
+  const [isLoading, setIsLoading] = useState(true);
+  const [isAuthEnabled, setIsAuthEnabled] = useState(true);
   const hasToken = existToken();
+
+  useEffect(() => {
+    const checkAuthStatus = async () => {
+      try {
+        const rsp = await getAuthStatus();
+        setIsAuthEnabled(rsp.data.enabled);
+      } catch (err) {
+        setIsAuthEnabled(true);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    checkAuthStatus();
+  }, []);
+
+  if (isLoading) {
+    return null;
+  }
+
+  if (!isAuthEnabled) {
+    return <>{children}</>;
+  }
 
   if (!hasToken) {
     return <Navigate to={'/auth/login'} replace />;
@@ -12,3 +38,4 @@ export const ProtectedRoute = ({ children }: { children: ReactNode }) => {
 
   return children;
 };
+


### PR DESCRIPTION
## Summary
- Added new API endpoint `/api/application/auth/status` that returns whether authentication is enabled or disabled
- Modified `ProtectedRoute` component to check auth status and skip authentication when disabled

## Fixes Issue #301
When `authentication: disable` is set in server config, frontend was still requiring users to login.

## Changes
- Added `GetAuthStatusRsp` proto structure
- Added `GetAuthStatus()` handler in application service
- Added route for `/api/application/auth/status` (no token required)
- Updated frontend `auth.tsx` to check auth status before requiring token
- Added `getAuthStatus()` API function in `application.ts`