### PR TITLE
Fix: Add persistent flag to prevent mDNS from restarting (#442)

### DIFF
--- a/kvmapp/system/init.d/S50avahi-daemon
+++ b/kvmapp/system/init.d/S50avahi-daemon
@@ -3,8 +3,14 @@
 # avahi-daemon init script
 
 DAEMON=/usr/sbin/avahi-daemon
+DISABLED_FLAG=/etc/kvm/mdns_disabled
+
 case "$1" in
     start)
+	if [ -f "$DISABLED_FLAG" ]; then
+		echo "mDNS is disabled, skipping avahi-daemon start"
+		exit 0
+	fi
 	$DAEMON -c || $DAEMON -D
 	;;
     stop)


### PR DESCRIPTION
## Summary
- Added persistent flag file `/etc/kvm/mdns_disabled` to prevent avahi-daemon from auto-restarting
- When mDNS is disabled, flag is created and init script checks for it before starting avahi-daemon

## Fixes Issue #442
mDNS continued to work after being disabled because avahi-daemon was restarted by systemd/init mechanisms.

## Changes
- Modified `S50avahi-daemon` init script to check for `/etc/kvm/mdns_disabled` flag
- Added `AvahiDaemonDisabledFlag` constant
- Updated `EnableMdns` to remove flag file when enabling
- Updated `DisableMdns` to create flag file when disabling
- Removed init script removal from `DisableMdns` (not needed with flag approach)