### PR TITLE
Fix: Show error messages for virtual device toggle failures

### DIFF
--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -324,6 +324,7 @@ const en = {
         diskDesc: 'Mount SD card on the remote host',
         network: 'Virtual Network',
         networkDesc: 'Mount virtual network card on the remote host',
+        updateFailed: 'Failed to update virtual device. Please try again.',
         reboot: 'Reboot',
         rebootDesc: 'Are you sure you want to reboot NanoKVM?',
         okBtn: 'Yes',

--- a/web/src/pages/desktop/menu/settings/device/virtual-devices.tsx
+++ b/web/src/pages/desktop/menu/settings/device/virtual-devices.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 
 import { getHidMode } from '@/api/hid.ts';
 import * as api from '@/api/virtual-device.ts';
+import { message } from 'antd';
 
 export const VirtualDevices = () => {
   const { t } = useTranslation();
@@ -53,13 +54,13 @@ export const VirtualDevices = () => {
     try {
       const rsp = await api.updateVirtualDevice(device);
       if (rsp.code !== 0) {
-        console.log(rsp.msg);
+        message.error(rsp.msg || t('settings.device.updateFailed'));
         return;
       }
 
       await getVirtualDevice();
     } catch (err) {
-      console.log(err);
+      message.error(t('settings.device.updateFailed'));
     } finally {
       setLoading('');
     }


### PR DESCRIPTION
## Summary
- Added user-facing error messages when Virtual Disk or Virtual Network toggle operations fail
- Previously errors were only logged to console, causing silent failures with loading spinner

## Fixes Issue #704
When toggling Virtual Disk or Virtual Network failed, users saw a loading spinner with no error message.

## Changes
- Modified `web/src/pages/desktop/menu/settings/device/virtual-devices.tsx`:
  - Added `message.error()` calls for API errors
  - Added `message.error()` calls for catch blocks
- Added translation key `settings.device.updateFailed` in `web/src/i18n/locales/en.ts`