### PR TITLE
fix: don't expose eMMC as USB mass storage when no image is mounted

### DIFF
--- a/kvmapp/system/init.d/S03usbdev
+++ b/kvmapp/system/init.d/S03usbdev
@@ -106,17 +106,15 @@ start_usb_dev(){
             fi
             echo "NanoKVM USB Mass Storage0520" > functions/mass_storage.disk0/lun.0/inquiry_string
             disk=$(cat /boot/usb.disk0)
-            if [ -z "${disk}" ]
+            if [ -n "${disk}" ]
             then
-                    # if [ ! -e /mnt/usbdisk.img ]
-                    # then
-                    #         fallocate -l 8G /mnt/usbdisk.img
-                    #         mkfs.vfat /mnt/usbdisk.img
-                    # fi
-                    echo /dev/mmcblk0p3 > functions/mass_storage.disk0/lun.0/file
-            else
                     cat /boot/usb.disk0 > functions/mass_storage.disk0/lun.0/file
             fi
+            # When usb.disk0 is empty, no backing file is set. The device
+            # reports "no media" (removable=1). Previously this defaulted to
+            # /dev/mmcblk0p3, exposing the NanoKVM's raw eMMC partition as a
+            # USB disk — causing Legacy BIOS systems to hang during boot.
+            # See: https://github.com/sipeed/NanoKVM/issues/633
     fi
 
     ls /sys/class/udc/ | cat > UDC


### PR DESCRIPTION
## Summary

When `/boot/usb.disk0` exists but is empty (the default out-of-box state), the NanoKVM exposes its raw eMMC partition (`/dev/mmcblk0p3`) as a USB mass storage device. This causes **Legacy BIOS systems to hang during boot** — the BIOS attempts to boot from the device, reads invalid data (no MBR signature), and enters a HLT loop. The system becomes completely unresponsive; no keyboard input is accepted, and the only recovery is a physical power cycle.

This affects any NanoKVM connected to a Legacy BIOS system in its default configuration — a zero-config out-of-box bug.

The same behavior occurs when an ISO image is unmounted via the web UI: `image.go` re-mounts `/dev/mmcblk0p3` as the "no image" fallback, re-exposing the eMMC.

## Changes

### `kvmapp/system/init.d/S03usbdev`
- When `/boot/usb.disk0` is empty, **do not set a backing file** for `lun.0/file`
- The mass_storage device (with `removable=1`) reports "no media inserted"
- BIOS handles this safely by skipping to the next boot device
- When `usb.disk0` contains a path, that path is used as before (no behavior change)

### `server/service/storage/image.go`
- Remove `imageNone` constant (`/dev/mmcblk0p3`)
- When unmounting an image (empty `req.File`), the device **stays unmounted** instead of falling back to the eMMC partition
- `GetMountedImage` retains backward compatibility by still treating `mmcblk0p3` as "no image" for devices that haven't rebooted after the update

### `server/service/vm/virtual-device.go` (no changes needed)
- With the `S03usbdev` fix, toggling "Virtual Disk" ON correctly creates the mass_storage gadget with no media. Users then mount ISOs through the existing UI.

## Root Cause

Three code paths wrote `/dev/mmcblk0p3` to the USB gadget's backing file:

1. **`S03usbdev`** (line 116): `echo /dev/mmcblk0p3 > functions/mass_storage.disk0/lun.0/file` — when the gate file is empty
2. **`image.go`** (line 114): `image = imageNone` — when unmounting an ISO
3. **`virtual-device.go`** (line 35): `touch /boot/usb.disk0` — creates the empty gate file that triggers (1)

The eMMC partition contains a Linux ext4/exfat filesystem with no MBR. When Legacy BIOS reads sector 0 and finds no `0x55AA` boot signature, some implementations (notably ASRock) enter a HLT loop instead of trying the next boot device.

## Testing

**Workaround tested in production** (2026-01-30) on ASRock DeskMini A300 (Legacy BIOS P3.70, Ryzen 5 3400G) with NanoKVM (Image v1.4.0 / App 2.3.4):

- **Before fix**: System hangs at blinking cursor after PXE ROM exit. CPU in HLT loop. No keyboard response. Only recoverable via physical power cycle.
- **Workaround applied**: Deleted `/boot/usb.disk0` on NanoKVM → only HID + RNDIS functions present → BIOS proceeds normally through boot order → **system boots successfully**.

The code changes in this PR implement the same logic as the workaround (empty gate file = no backing file) but at the correct code level, preserving the virtual USB disk feature for users who mount actual ISO images.

## Related Issues

Fixes #633
Refs #385, #438, #187