### PR TITLE
S03usbdev: derive USB serial number from SoC hardware UID

### DIFF
--- a/kvmapp/system/init.d/S03usbdev
+++ b/kvmapp/system/init.d/S03usbdev
@@ -24,7 +24,13 @@ start_usb_dev(){
         echo 0x1009 > idProduct
     fi
     mkdir strings/0x409
-    echo '0123456789ABCDEF' > strings/0x409/serialnumber
+    if [ -f /sys/class/cvi-base/base_uid ]; then
+        _uid=$(awk '{print $2}' /sys/class/cvi-base/base_uid)
+        _serial=$(echo "$_uid" | tr -d '_')
+        echo "$_serial" > strings/0x409/serialnumber
+    else
+        echo '0123456789ABCDEF' > strings/0x409/serialnumber
+    fi
     echo 'sipeed' > strings/0x409/manufacturer
     echo 'NanoKVM' > strings/0x409/product
 


### PR DESCRIPTION
The USB gadget serial number was hardcoded to '0123456789ABCDEF', meaning every NanoKVM device presented the same serial to the host.

Read the SoC unique identifier from /sys/class/cvi-base/base_uid on each boot and concatenate its two halves into a single hex string for use as the USB serial number. Falls back to the old hardcoded value if the UID file is not present.

This gives each device a stable, hardware-derived serial number without requiring any persistent state, and satisfies the USB Mass Storage requirement of at least 12 characters. This means you can query the USB interface on the machine the KVM is plugged into to find out _which_ NanoKVM is plugged in, instead of that there is a NanoKVM plugged in.

Test plan:

Installed script on two NanoKVMs with:
    scp kvmapp/system/init.d/S03usbdev root@kvm04:/etc/init.d/S03usbdev

Plugged into a Linux machine, before I got:

```
[jake@li-bl-eq14-1:~]$ nix shell nixpkgs#usbutils --command lsusb -v | grep NanoKVM -A 50
Bus 003 Device 006: ID 3346:1009 sipeed NanoKVM
Negotiated speed: High Speed (480Mbps)
Device Descriptor:
...
  idVendor           0x3346 sipeed
  idProduct          0x1009 NanoKVM
  bcdDevice            5.10
  iManufacturer           1 sipeed
  iProduct                2 NanoKVM
  iSerial                 3 0123456789ABCDEF
```

After the update, I get the same, but the serial number is now unique per device. I unplugged the devices and plugged them back in, this is now a consistent and unique identifier between my NanoKVMs from the host device.