### PR TITLE
fix(network): request DHCP classless static routes (option 121) in udhcp

### DIFF
--- a/kvmapp/system/init.d/S30eth
+++ b/kvmapp/system/init.d/S30eth
@@ -39,7 +39,7 @@ start() {
         done < /boot/eth.nodhcp
 
         ip a show dev eth0 | grep inet > /dev/null || {
-            udhcpc -i eth0 -t 3 -T 1 -A 5 -b -p /run/udhcpc.eth0.pid &>/dev/null
+            udhcpc -i eth0 -t 3 -T 1 -A 5 -b -O 121 -p /run/udhcpc.eth0.pid &>/dev/null
             ip a show dev eth0 | grep inet > /dev/null
         } || {
             inet=$RESERVE_INET
@@ -47,7 +47,7 @@ start() {
             ip a add "$inet" brd + dev eth0
         } || exit 1
     else
-        udhcpc -i eth0 -t 10 -T 1 -A 5 -b -p /run/udhcpc.eth0.pid &
+        udhcpc -i eth0 -t 10 -T 1 -A 5 -b -O 121 -p /run/udhcpc.eth0.pid &
     fi
 }
 


### PR DESCRIPTION
udhcpc does not request DHCP option 121 (classless static routes) by default. This prevents administrators from pushing specific routes without a default gateway, which is needed for isolated network segments where devices should only reach selected subnets.

Add -O 121 flag to both udhcpc invocations in S30eth. The existing default.script already handles staticroutes correctly per RFC 3442.