### PR TITLE
perf: move runtime state files from SD card to tmpfs

### DIFF
--- a/server/service/network/wifi.go
+++ b/server/service/network/wifi.go
@@ -19,7 +19,7 @@ const (
 	WiFiSSID       = "/etc/kvm/wifi.ssid"
 	WiFiPasswd     = "/etc/kvm/wifi.pass"
 	WiFiConnect    = "/kvmapp/kvm/wifi_try_connect"
-	WiFiStateFile  = "/kvmapp/kvm/wifi_state"
+	WiFiStateFile  = "/tmp/kvm/wifi_state"
 	WiFiScript     = "/etc/init.d/S30wifi"
 )
 

--- a/server/service/stream/frame_rate.go
+++ b/server/service/stream/frame_rate.go
@@ -40,7 +40,7 @@ func GetFrameRateCounter() *FrameRateCounter {
 				counter.mutex.Unlock()
 
 				data := fmt.Sprintf("%d", counter.fps)
-				err := os.WriteFile("/kvmapp/kvm/now_fps", []byte(data), 0o666)
+				err := os.WriteFile("/tmp/kvm/now_fps", []byte(data), 0o666)
 				if err != nil {
 					log.Errorf("failed to write fps: %s", err)
 				}

--- a/support/sg2002/additional/kvm/src/kvm_vision.cpp
+++ b/support/sg2002/additional/kvm/src/kvm_vision.cpp
@@ -36,8 +36,8 @@
 #define kvmv_data_buffer_size   4
 #define Try_rounds_HDMI_err_res 5
 
-#define vi_width_path           "/kvmapp/kvm/width"
-#define vi_height_path          "/kvmapp/kvm/height"
+#define vi_width_path           "/tmp/kvm/width"
+#define vi_height_path          "/tmp/kvm/height"
 #define hdmi_mode_path          "/etc/kvm/hdmi_mode"
 #define hdmi_state_path         "/proc/lt_int"
 #define watchdog_mode_path      "/etc/kvm/watchdog"
@@ -340,8 +340,8 @@ int get_manual_resolution(void)
     int res = 0;
 
     // get res
-    if(access("/kvmapp/kvm/width", F_OK) == 0){
-        fp = fopen("/kvmapp/kvm/width", "r");
+    if(access("/tmp/kvm/width", F_OK) == 0){
+        fp = fopen("/tmp/kvm/width", "r");
         fseek(fp, 0, SEEK_END);
         file_size = ftell(fp); 
         fseek(fp, 0, SEEK_SET);
@@ -352,8 +352,8 @@ int get_manual_resolution(void)
     } else {
         tmp_width = 1920;
     }
-    if(access("/kvmapp/kvm/height", F_OK) == 0){
-        fp = fopen("/kvmapp/kvm/height", "r");
+    if(access("/tmp/kvm/height", F_OK) == 0){
+        fp = fopen("/tmp/kvm/height", "r");
         fseek(fp, 0, SEEK_END);
         file_size = ftell(fp); 
         fseek(fp, 0, SEEK_SET);
@@ -1697,12 +1697,12 @@ int kvmv_read_img(uint16_t _width, uint16_t _height, uint8_t _type, uint16_t _ql
 			if(kvmv_cfg.cam_state == 0) {
 				kvmv_cfg.cam_state = 1;
                 kvmv_cfg.hdmi_cable_state = 1;
-				system("echo 1 > /kvmapp/kvm/state");
+				system("echo 1 > /tmp/kvm/state");
 			}
         } else {
 			if(kvmv_cfg.cam_state == 1) {
 				kvmv_cfg.cam_state = 0;
-				system("echo 0 > /kvmapp/kvm/state");
+				system("echo 0 > /tmp/kvm/state");
 			}
 			delete img;
             debug("[kvmv]can`t get img...\n");

--- a/support/sg2002/additional/sophgo-middleware/v2/sample/common/sample_common_sensor.c
+++ b/support/sg2002/additional/sophgo-middleware/v2/sample/common/sample_common_sensor.c
@@ -689,8 +689,8 @@ CVI_S32 SAMPLE_COMM_SNS_GetPicSize(PIC_SIZE_E enPicSize, SIZE_S *pstSize)
 		uint8_t RW_Data[35];
 		FILE *fp;
 		int file_size;
-		if(access("/kvmapp/kvm/width", F_OK) == 0){
-			fp = fopen("/kvmapp/kvm/width", "r");
+		if(access("/tmp/kvm/width", F_OK) == 0){
+			fp = fopen("/tmp/kvm/width", "r");
 			fseek(fp, 0, SEEK_END);
 			file_size = ftell(fp); 
 			fseek(fp, 0, SEEK_SET);
@@ -701,8 +701,8 @@ CVI_S32 SAMPLE_COMM_SNS_GetPicSize(PIC_SIZE_E enPicSize, SIZE_S *pstSize)
 		} else {
 			pstSize->u32Width = 1920;
 		}
-		if(access("/kvmapp/kvm/height", F_OK) == 0){
-			fp = fopen("/kvmapp/kvm/height", "r");
+		if(access("/tmp/kvm/height", F_OK) == 0){
+			fp = fopen("/tmp/kvm/height", "r");
 			fseek(fp, 0, SEEK_END);
 			file_size = ftell(fp); 
 			fseek(fp, 0, SEEK_SET);

--- a/support/sg2002/kvm_system/main/include/config.h
+++ b/support/sg2002/kvm_system/main/include/config.h
@@ -57,10 +57,10 @@ typedef struct {
 	int8_t  rndis_state = -1;		// (exist?) /sys/kernel/config/usb_gadget/g0/configs/c.1/rndis.usb0
 	int8_t  udisk_state = -1;		// (exist?) /sys/kernel/config/usb_gadget/g0/configs/c.1/mass_storage.disk0
 	int8_t  host_pwr_state = -1;	// cat /sys/class/gpio/gpio504/value
-	int16_t hdmi_width = 0;			// cat /kvmapp/kvm/width
-	int16_t hdmi_height = 0;		// cat /kvmapp/kvm/height
+	int16_t hdmi_width = 0;			// cat /tmp/kvm/width
+	int16_t hdmi_height = 0;		// cat /tmp/kvm/height
 	int8_t type = 0;				// cat /kvmapp/kvm/type
-	int8_t now_fps = 0;				// cat /kvmapp/kvm/now_fps
+	int8_t now_fps = 0;				// cat /tmp/kvm/now_fps
 	int16_t qlty = 0;				// cat /kvmapp/kvm/qlty
 	int8_t oled_thread_running = 0;
 	int8_t key_thread_running = 0;
@@ -90,10 +90,10 @@ typedef struct {
 	int8_t  rndis_state = -1;		// (exist?) /sys/kernel/config/usb_gadget/g0/configs/c.1/rndis.usb0
 	int8_t  udisk_state = -1;		// (exist?) /sys/kernel/config/usb_gadget/g0/configs/c.1/mass_storage.disk0
 	int8_t  host_pwr_state = -1;	// cat /sys/class/gpio/gpio504/value
-	int16_t hdmi_width = -1;		// cat /kvmapp/kvm/width
-	int16_t hdmi_height = -1;		// cat /kvmapp/kvm/height
+	int16_t hdmi_width = -1;		// cat /tmp/kvm/width
+	int16_t hdmi_height = -1;		// cat /tmp/kvm/height
 	int8_t type = -1;				// cat /kvmapp/kvm/type
-	int8_t now_fps = -1;			// cat /kvmapp/kvm/now_fps
+	int8_t now_fps = -1;			// cat /tmp/kvm/now_fps
 	int16_t qlty = -1;				// cat /kvmapp/kvm/qlty
     uint16_t oled_sleep_param = 0;
     uint8_t oled_sleep_state = 0;	// 0:wakeup; 1:sleep;

--- a/support/sg2002/kvm_system/main/lib/hdmi/hdmi.cpp
+++ b/support/sg2002/kvm_system/main/lib/hdmi/hdmi.cpp
@@ -226,9 +226,9 @@ uint8_t lt6911_get_csi_res()
 	// setenv("KVM_CSI_HEIGHT", to_string(Hactive).c_str(), 1);
 	// setenv("KVM_CSI_WIDTH",  to_string(Vactive).c_str(), 1);
 
-	sprintf(Cmd, "echo %d > /kvmapp/kvm/width", Hactive);
+	sprintf(Cmd, "echo %d > /tmp/kvm/width", Hactive);
 	system(Cmd);
-	sprintf(Cmd, "echo %d > /kvmapp/kvm/height", Vactive);
+	sprintf(Cmd, "echo %d > /tmp/kvm/height", Vactive);
 	system(Cmd);
 
 	delete dat0;

--- a/support/sg2002/kvm_system/main/lib/system_init/system_init.cpp
+++ b/support/sg2002/kvm_system/main/lib/system_init/system_init.cpp
@@ -85,14 +85,15 @@ void new_app_init(void)
 	system("rm -f /etc/init.d/S99*");
 	
 	// Add necessary configuration files for program execution
-	system("mkdir /kvmapp/kvm");
-	system("mkdir /etc/kvm");
-	system("echo 0 > /kvmapp/kvm/now_fps");
+	system("mkdir -p /kvmapp/kvm");
+	system("mkdir -p /tmp/kvm");
+	system("mkdir -p /etc/kvm");
+	system("echo 0 > /tmp/kvm/now_fps");
 	system("echo 30 > /kvmapp/kvm/fps");
 	system("echo 2000 > /kvmapp/kvm/qlty");
 	system("echo 720 > /kvmapp/kvm/res");
 	system("echo h264 > /kvmapp/kvm/type");
-	system("echo 0 > /kvmapp/kvm/state");
+	system("echo 0 > /tmp/kvm/state");
 	system("touch /etc/kvm/frame_detact");
 
 	// rm jpg_stream & kvm_stream

--- a/support/sg2002/kvm_system/main/lib/system_state/system_state.cpp
+++ b/support/sg2002/kvm_system/main/lib/system_state/system_state.cpp
@@ -265,7 +265,7 @@ void kvm_update_stream_fps(void)
 	uint8_t RW_Data[10];
 
 	// FPS
-	fp = fopen("/kvmapp/kvm/now_fps", "r");
+	fp = fopen("/tmp/kvm/now_fps", "r");
     fseek(fp, 0, SEEK_END);
     file_size = ftell(fp); 
     fseek(fp, 0, SEEK_SET);
@@ -330,16 +330,16 @@ void kvm_update_hdmi_res(void)
 	int file_size;
 	uint8_t RW_Data[10];
 	// HDMI width
-	fp = fopen("/kvmapp/kvm/width", "r");
+	fp = fopen("/tmp/kvm/width", "r");
 	fseek(fp, 0, SEEK_END);
-	file_size = ftell(fp); 
+	file_size = ftell(fp);
 	fseek(fp, 0, SEEK_SET);
 	fread(RW_Data, sizeof(char), file_size, fp);
 	fclose(fp);
 	RW_Data[file_size] = 0;
 	kvm_sys_state.hdmi_width = atoi((char*)RW_Data);
 	// HDMI height
-	fp = fopen("/kvmapp/kvm/height", "r");
+	fp = fopen("/tmp/kvm/height", "r");
 	fseek(fp, 0, SEEK_END);
 	file_size = ftell(fp); 
 	fseek(fp, 0, SEEK_SET);
@@ -406,7 +406,7 @@ void kvm_update_wifi_state(void)
 			// break;	// Start checking the connection directly.
 		case 0:
 		// WiFi is available but not connected.
-			system("echo 0 > /kvmapp/kvm/wifi_state");
+			system("echo 0 > /tmp/kvm/wifi_state");
 			if (get_ip_addr(WiFi_IP) && get_ip_addr(WiFi_ROUTE)){
 				// IP+Route has been acquired
 				if(kvm_sys_state.ping_allow){
@@ -422,7 +422,7 @@ void kvm_update_wifi_state(void)
 			break;
 		case 1:
 		// Connected to the network & continuously checking if it can ping successfully.
-			system("echo 1 > /kvmapp/kvm/wifi_state");
+			system("echo 1 > /tmp/kvm/wifi_state");
 			get_ip_addr(WiFi_IP);
 			if(kvm_sys_state.ping_allow){
 				if (kvm_sys_state.wifi_route[0] != 0){


### PR DESCRIPTION
## Summary

- Move frequently-written runtime state files (`now_fps`, `state`, `wifi_state`, `width`, `height`) from `/kvmapp/kvm/` to `/tmp/kvm/` (tmpfs) to minimize SD card writes and extend SD card lifespan
- `now_fps` alone causes ~86,400+ writes/day (written every 3 seconds), significantly contributing to SD card wear
- User settings (`fps`, `qlty`, `res`, `type`) remain on `/kvmapp/kvm/` as they need to persist across reboots

Related: #708, #701

## Changes

| File | Frequency | Change |
|------|-----------|--------|
| `now_fps` | Every 3 seconds | `/kvmapp/kvm/now_fps` → `/tmp/kvm/now_fps` |
| `state` | On camera state change | `/kvmapp/kvm/state` → `/tmp/kvm/state` |
| `wifi_state` | On WiFi state change | `/kvmapp/kvm/wifi_state` → `/tmp/kvm/wifi_state` |
| `width` / `height` | On HDMI resolution change | `/kvmapp/kvm/{width,height}` → `/tmp/kvm/{width,height}` |

### Files modified (8 files)

- `server/service/stream/frame_rate.go` — now_fps write path
- `server/service/network/wifi.go` — WiFiStateFile constant
- `support/sg2002/kvm_system/main/lib/system_init/system_init.cpp` — add `mkdir -p /tmp/kvm` + update init paths
- `support/sg2002/kvm_system/main/lib/system_state/system_state.cpp` — update read/write paths
- `support/sg2002/kvm_system/main/lib/hdmi/hdmi.cpp` — update width/height write paths
- `support/sg2002/additional/kvm/src/kvm_vision.cpp` — update defines + state write paths
- `support/sg2002/additional/sophgo-middleware/v2/sample/common/sample_common_sensor.c` — update width/height read paths
- `support/sg2002/kvm_system/main/include/config.h` — update comments

## Test plan

- [ ] Verify `/tmp/kvm/` directory and files are created on boot
- [ ] Verify FPS value updates correctly via `cat /tmp/kvm/now_fps`
- [ ] Verify `/tmp/kvm/width` and `/tmp/kvm/height` update on HDMI connect/disconnect
- [ ] Verify `/tmp/kvm/wifi_state` transitions on WiFi connect/disconnect
- [ ] Verify `/tmp/kvm/state` changes on camera stream start/stop
- [ ] Verify user settings (`fps`, `qlty`, `res`, `type`) persist after reboot
- [ ] Verify `/tmp` is mounted as tmpfs: `mount | grep tmpfs | grep /tmp`