### PR TITLE
fix: disable wakeup_on_write by default to prevent HID lockup on host reboot

### DIFF
--- a/kvmapp/system/init.d/S03usbdev
+++ b/kvmapp/system/init.d/S03usbdev
@@ -54,7 +54,7 @@ start_usb_dev(){
         then
             echo 1 > functions/hid.GS0/subclass
         fi
-        if [ ! -e /boot/usb.notwakeup ]
+        if [ -e /boot/usb.wakeup ]
         then
             echo 1 > functions/hid.GS0/wakeup_on_write
         fi
@@ -69,7 +69,7 @@ start_usb_dev(){
         then
             echo 1 > functions/hid.GS1/subclass
         fi
-        if [ ! -e /boot/usb.notwakeup ]
+        if [ -e /boot/usb.wakeup ]
         then
             echo 1 > functions/hid.GS1/wakeup_on_write
         fi
@@ -84,7 +84,7 @@ start_usb_dev(){
         then
             echo 1 > functions/hid.GS2/subclass
         fi
-        if [ ! -e /boot/usb.notwakeup ]
+        if [ -e /boot/usb.wakeup ]
         then
             echo 1 > functions/hid.GS2/wakeup_on_write
         fi

--- a/kvmapp/system/init.d/S03usbhid
+++ b/kvmapp/system/init.d/S03usbhid
@@ -39,7 +39,7 @@ start_usb_dev(){
     # keyboard
     mkdir functions/hid.GS0
     echo 1 > functions/hid.GS0/subclass
-    if [ ! -e /boot/usb.notwakeup ]
+    if [ -e /boot/usb.wakeup ]
     then
         echo 1 > functions/hid.GS0/wakeup_on_write
     fi
@@ -51,7 +51,7 @@ start_usb_dev(){
     # mouse
     mkdir functions/hid.GS1
     echo 1 > functions/hid.GS1/subclass
-    if [ ! -e /boot/usb.notwakeup ]
+    if [ -e /boot/usb.wakeup ]
     then
         echo 1 > functions/hid.GS1/wakeup_on_write
     fi
@@ -63,7 +63,7 @@ start_usb_dev(){
     # touchpad
     mkdir functions/hid.GS2
     echo 1 > functions/hid.GS2/subclass
-    if [ ! -e /boot/usb.notwakeup ]
+    if [ -e /boot/usb.wakeup ]
     then
         echo 1 > functions/hid.GS2/wakeup_on_write
     fi


### PR DESCRIPTION
## Summary

- **Disable `wakeup_on_write` by default** in both `S03usbdev` (regular mode) and `S03usbhid` (HID-only mode)
- Invert the opt-out flag (`/boot/usb.notwakeup`) to an opt-in flag (`/boot/usb.wakeup`) so the safe default requires no user action

## Problem

When `wakeup_on_write` is enabled (current default), every HID write (keyboard/mouse input) triggers a USB remote wakeup signal. When the host PC is restarting, in BIOS/UEFI, or has suspended USB:

1. The DWC2 controller spams wakeup signals that the host rejects:
   ```
   dwc2 4340000.usb: wakeup: signalling skipped: is not allowed by host
   configfs-gadget gadget: usb_gadget_wakeup
   ```
2. This causes USB endpoint transfer timeouts:
   ```
   dwc2 4340000.usb: dwc2_hsotg_ep_stop_xfr: timeout GINTSTS.GOUTNAKEFF
   dwc2 4340000.usb: dwc2_hsotg_ep_stop_xfr: timeout DOEPCTL.EPDisable
   ```
3. The USB gadget gets stuck — keyboard and mouse become permanently unresponsive
4. In severe cases (#220), this causes a **kernel NULL pointer dereference crash**

This is a widespread issue affecting NanoKVM Full, Lite, and PCIe variants across many host systems.

## Root Cause

The `wakeup_on_write` feature attempts USB remote wakeup signalling on every HID report write. Many host USB controllers do not allow remote wakeup (especially during boot/BIOS, restart, or on certain chipsets like Intel N100/N305). The failed wakeup attempts corrupt the DWC2 endpoint state machine, making recovery impossible without a full PHY restart.

## Fix

USB HID devices do not require remote wakeup to function — the host re-enumerates the gadget naturally after reboot. The fix simply inverts the default:

- **Before**: `wakeup_on_write=1` unless `/boot/usb.notwakeup` exists (unsafe default)
- **After**: `wakeup_on_write=0` unless `/boot/usb.wakeup` exists (safe default)

Users who specifically need USB remote wakeup can opt in by creating `/boot/usb.wakeup`.

## Testing

Tested on NanoKVM PCIe (firmware 2.3.1) connected to a desktop PC:
- Host reboot no longer causes HID lockup
- Keyboard and mouse remain functional through host restart cycle
- No more `wakeup: signalling skipped` or `ep_stop_xfr: timeout` errors in dmesg

## Related Issues

Fixes #220 — Rebooting PC causes USB errors (keyboard + mouse + drive) + kernel crash
Fixes #302 — HID stops working
Fixes #383 — USB HID stops working after 10-60s (mouse + keyboard)
Fixes #544 — HID not working in BIOS
Fixes #656 — Keyboard and mouse not working on PCIe KVM