### PR TITLE
feat: Add USB descriptor customization

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,173 @@
+# Building and Deploying NanoKVM
+
+This guide covers building the server binary and web frontend, deploying to a NanoKVM device, and backing up or restoring the USB descriptor configuration.
+
+---
+
+## Prerequisites
+
+| Tool | Purpose | Notes |
+|------|---------|-------|
+| Docker | Cross-compile Go for RISC-V | Docker Desktop or Colima |
+| pnpm | Build web frontend | `npm install -g pnpm` |
+| ssh / scp | Deploy to device | Device must be on your network |
+
+### ARM Mac (Apple Silicon) — additional setup
+
+The build container runs x86_64 binaries. On ARM Macs you need QEMU emulation via Docker buildx:
+
+```bash
+brew install docker-buildx
+```
+
+Then enable it:
+
+```bash
+docker buildx install
+```
+
+---
+
+## 1. Build the Docker image
+
+Only needs to be done once (or after Dockerfile changes):
+
+```bash
+make builder-image
+```
+
+---
+
+## 2. Build the server binary
+
+```bash
+make app
+```
+
+Output: `server/NanoKVM-Server`
+
+### ARM Mac — QEMU segfaults
+
+QEMU x86_64 emulation on Apple Silicon occasionally causes the Go compiler to segfault mid-build. Go's build cache saves progress between attempts, so just retry:
+
+```bash
+for i in $(seq 1 5); do
+  echo "=== Attempt $i ==="
+  make app && break
+done
+```
+
+This typically succeeds within 2–5 tries.
+
+---
+
+## 3. Build the web frontend
+
+```bash
+cd web
+pnpm install
+pnpm build
+```
+
+Output: `web/dist/`
+
+---
+
+## 4. Deploy to the device
+
+Replace `<device-ip>` with your NanoKVM's IP address. The default SSH password is `root`.
+
+### 4a. Deploy the server binary
+
+```bash
+scp server/NanoKVM-Server root@<device-ip>:/kvmapp/server/NanoKVM-Server
+```
+
+### 4b. Deploy the web frontend
+
+```bash
+scp -r web/dist/* root@<device-ip>:/kvmapp/server/www/
+```
+
+### 4c. Deploy the init script (if modified)
+
+```bash
+scp kvmapp/system/init.d/S03usbdev root@<device-ip>:/etc/init.d/S03usbdev
+ssh root@<device-ip> chmod +x /etc/init.d/S03usbdev
+```
+
+### 4d. Restart the server
+
+```bash
+ssh root@<device-ip> /etc/init.d/S95nanokvm restart
+```
+
+The startup script copies `/kvmapp/server/` to `/tmp/server/` and runs from there, so the restart picks up your new binary automatically.
+
+#### If the server fails to start with a missing library error
+
+The musl dynamic linker on this device has no configured search path for `dl_lib/`. If you see `Error loading shared library libkvm.so`, patch the startup script to set `LD_LIBRARY_PATH` permanently:
+
+```bash
+sed -i 's|/tmp/server/NanoKVM-Server &|LD_LIBRARY_PATH=/tmp/server/dl_lib /tmp/server/NanoKVM-Server \&|g' /etc/init.d/S95nanokvm
+/etc/init.d/S95nanokvm restart
+```
+
+This survives reboots. The patch is idempotent — safe to run more than once.
+
+---
+
+## 5. Back up USB descriptor configuration
+
+USB descriptor settings are persisted in `/boot/` as plain text files. To back them up locally:
+
+```bash
+ssh root@<device-ip> 'for f in usb.vid usb.pid usb.manufacturer usb.product usb.serial; do
+  [ -f /boot/$f ] && echo "$f=$(cat /boot/$f)" || echo "$f=(default)"
+done'
+```
+
+To save to a local file:
+
+```bash
+ssh root@<device-ip> 'cd /boot && tar czf - usb.vid usb.pid usb.manufacturer usb.product usb.serial 2>/dev/null' \
+  > usb-descriptor-backup.tar.gz
+```
+
+> **Note:** If none of the `/boot/usb.*` files exist, the device is using factory defaults and no backup is needed — Restore Defaults in the UI will return to the same state.
+
+---
+
+## 6. Restore USB descriptor configuration
+
+### From the UI
+
+In the NanoKVM web UI, go to **Settings > Device > USB Descriptor** and click **Restore Defaults**. This resets to:
+
+| Field | Default |
+|-------|---------|
+| Manufacturer | `sipeed` |
+| Product | `NanoKVM` |
+| Serial | `0123456789ABCDEF` |
+| VID | `0x3346` |
+| PID | `0x1009` |
+
+### From a backup archive
+
+```bash
+cat usb-descriptor-backup.tar.gz | ssh root@<device-ip> 'tar xzf - -C /boot'
+```
+
+Then reboot or trigger a USB rebind:
+
+```bash
+ssh root@<device-ip> '/etc/init.d/S03usbdev restart'
+```
+
+### Manually clear all overrides (revert to factory defaults)
+
+```bash
+ssh root@<device-ip> 'rm -f /boot/usb.vid /boot/usb.pid /boot/usb.manufacturer /boot/usb.product /boot/usb.serial'
+```
+
+Changes take effect on next boot, or immediately via the UI's **Restore Defaults** button.

--- a/kvmapp/system/init.d/S03usbdev
+++ b/kvmapp/system/init.d/S03usbdev
@@ -24,15 +24,31 @@ start_usb_dev(){
         echo 0x1009 > idProduct
     fi
     mkdir strings/0x409
-    echo '0123456789ABCDEF' > strings/0x409/serialnumber
-    echo 'sipeed' > strings/0x409/manufacturer
-    echo 'NanoKVM' > strings/0x409/product
+    if [ -e /boot/usb.serial ]; then
+        cat /boot/usb.serial > strings/0x409/serialnumber
+    else
+        echo '0123456789ABCDEF' > strings/0x409/serialnumber
+    fi
+    if [ -e /boot/usb.manufacturer ]; then
+        cat /boot/usb.manufacturer > strings/0x409/manufacturer
+    else
+        echo 'sipeed' > strings/0x409/manufacturer
+    fi
+    if [ -e /boot/usb.product ]; then
+        cat /boot/usb.product > strings/0x409/product
+    else
+        echo 'NanoKVM' > strings/0x409/product
+    fi
 
     mkdir configs/c.1
     echo 0xE0 > configs/c.1/bmAttributes
     echo 120 > configs/c.1/MaxPower
     mkdir configs/c.1/strings/0x409
-    echo "NanoKVM" >  configs/c.1/strings/0x409/configuration
+    if [ -e /boot/usb.product ]; then
+        cat /boot/usb.product > configs/c.1/strings/0x409/configuration
+    else
+        echo "NanoKVM" > configs/c.1/strings/0x409/configuration
+    fi
 
     if [ -e /boot/usb.ncm ]
     then

--- a/kvmapp/system/init.d/S03usbhid
+++ b/kvmapp/system/init.d/S03usbhid
@@ -26,15 +26,31 @@ start_usb_dev(){
         echo 0x1009 > idProduct
     fi
     mkdir strings/0x409
-    # echo '0' > strings/0x409/serialnumber
-    echo 'sipeed' > strings/0x409/manufacturer
-    echo 'NanoKVM' > strings/0x409/product
+    if [ -e /boot/usb.serial ]; then
+        cat /boot/usb.serial > strings/0x409/serialnumber
+    else
+        echo '0123456789ABCDEF' > strings/0x409/serialnumber
+    fi
+    if [ -e /boot/usb.manufacturer ]; then
+        cat /boot/usb.manufacturer > strings/0x409/manufacturer
+    else
+        echo 'sipeed' > strings/0x409/manufacturer
+    fi
+    if [ -e /boot/usb.product ]; then
+        cat /boot/usb.product > strings/0x409/product
+    else
+        echo 'NanoKVM' > strings/0x409/product
+    fi
 
     mkdir configs/c.1
     echo 0xA0 > configs/c.1/bmAttributes
     echo 200 > configs/c.1/MaxPower
     mkdir configs/c.1/strings/0x409
-    echo "NanoKVM" >  configs/c.1/strings/0x409/configuration
+    if [ -e /boot/usb.product ]; then
+        cat /boot/usb.product > configs/c.1/strings/0x409/configuration
+    else
+        echo "NanoKVM" > configs/c.1/strings/0x409/configuration
+    fi
 
     # keyboard
     mkdir functions/hid.GS0

--- a/server/proto/usb_descriptor.go
+++ b/server/proto/usb_descriptor.go
@@ -1,0 +1,21 @@
+package proto
+
+type UsbDescriptor struct {
+	VendorName   string `json:"vendorName"`
+	ProductName  string `json:"productName"`
+	SerialNumber string `json:"serialNumber"`
+	Vid          string `json:"vid"`
+	Pid          string `json:"pid"`
+}
+
+type GetUsbDescriptorRsp struct {
+	Descriptor UsbDescriptor `json:"descriptor"`
+}
+
+type SetUsbDescriptorReq struct {
+	VendorName   string `json:"vendorName"`
+	ProductName  string `json:"productName"`
+	SerialNumber string `json:"serialNumber"`
+	Vid          string `json:"vid" validate:"required"`
+	Pid          string `json:"pid" validate:"required"`
+}

--- a/server/router/hid.go
+++ b/server/router/hid.go
@@ -23,4 +23,8 @@ func hidRouter(r *gin.Engine) {
 	api.GET("/hid/mode", service.GetHidMode)  // get hid mode
 	api.POST("/hid/mode", service.SetHidMode) // set hid mode
 	api.POST("/hid/reset", service.ResetHid)  // reset hid
+
+	api.GET("/hid/usb-descriptor", service.GetUsbDescriptor)       // get USB descriptor
+	api.POST("/hid/usb-descriptor", service.SetUsbDescriptor)      // set USB descriptor
+	api.POST("/hid/usb-descriptor/restore", service.RestoreUsbDefaults) // restore USB defaults
 }

--- a/server/service/hid/descriptor.go
+++ b/server/service/hid/descriptor.go
@@ -1,0 +1,217 @@
+package hid
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	log "github.com/sirupsen/logrus"
+
+	"NanoKVM-Server/proto"
+)
+
+const (
+	gadgetDir        = "/sys/kernel/config/usb_gadget/g0"
+	idVendorFile     = gadgetDir + "/idVendor"
+	idProductFile    = gadgetDir + "/idProduct"
+	manufacturerFile = gadgetDir + "/strings/0x409/manufacturer"
+	productFile      = gadgetDir + "/strings/0x409/product"
+	serialFile       = gadgetDir + "/strings/0x409/serialnumber"
+	configStringFile = gadgetDir + "/configs/c.1/strings/0x409/configuration"
+	udcFile          = gadgetDir + "/UDC"
+
+	defaultVid          = "0x3346"
+	defaultPid          = "0x1009"
+	defaultManufacturer = "sipeed"
+	defaultProduct      = "NanoKVM"
+	defaultSerial       = "0123456789ABCDEF"
+)
+
+func readConfigFS(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+func writeConfigFS(path string, value string) error {
+	return os.WriteFile(path, []byte(value), 0o666)
+}
+
+func (s *Service) GetUsbDescriptor(c *gin.Context) {
+	var rsp proto.Response
+
+	vid, err := readConfigFS(idVendorFile)
+	if err != nil {
+		log.Errorf("failed to read idVendor: %s", err)
+		rsp.ErrRsp(c, -1, "failed to read USB descriptor")
+		return
+	}
+
+	pid, err := readConfigFS(idProductFile)
+	if err != nil {
+		log.Errorf("failed to read idProduct: %s", err)
+		rsp.ErrRsp(c, -1, "failed to read USB descriptor")
+		return
+	}
+
+	manufacturer, err := readConfigFS(manufacturerFile)
+	if err != nil {
+		log.Errorf("failed to read manufacturer: %s", err)
+		rsp.ErrRsp(c, -1, "failed to read USB descriptor")
+		return
+	}
+
+	product, err := readConfigFS(productFile)
+	if err != nil {
+		log.Errorf("failed to read product: %s", err)
+		rsp.ErrRsp(c, -1, "failed to read USB descriptor")
+		return
+	}
+
+	serial, err := readConfigFS(serialFile)
+	if err != nil {
+		log.Errorf("failed to read serial: %s", err)
+		rsp.ErrRsp(c, -1, "failed to read USB descriptor")
+		return
+	}
+
+	descriptor := proto.UsbDescriptor{
+		VendorName:   manufacturer,
+		ProductName:  product,
+		SerialNumber: serial,
+		Vid:          vid,
+		Pid:          pid,
+	}
+
+	rsp.OkRspWithData(c, &proto.GetUsbDescriptorRsp{
+		Descriptor: descriptor,
+	})
+	log.Debugf("get USB descriptor: %+v", descriptor)
+}
+
+func (s *Service) SetUsbDescriptor(c *gin.Context) {
+	var req proto.SetUsbDescriptorReq
+	var rsp proto.Response
+
+	if err := proto.ParseFormRequest(c, &req); err != nil {
+		rsp.ErrRsp(c, -1, "invalid arguments")
+		return
+	}
+
+	h := GetHid()
+	h.Lock()
+	h.CloseNoLock()
+	defer func() {
+		h.OpenNoLock()
+		h.Unlock()
+	}()
+
+	if err := rebindUDC(func() error {
+		return writeDescriptorFiles(req.Vid, req.Pid, req.VendorName, req.ProductName, req.SerialNumber)
+	}); err != nil {
+		log.Errorf("failed to set USB descriptor: %s", err)
+		rsp.ErrRsp(c, -2, "failed to set USB descriptor")
+		return
+	}
+
+	persistBootFile("/boot/usb.vid", req.Vid)
+	persistBootFile("/boot/usb.pid", req.Pid)
+	persistBootFile("/boot/usb.manufacturer", req.VendorName)
+	persistBootFile("/boot/usb.product", req.ProductName)
+	persistBootFile("/boot/usb.serial", req.SerialNumber)
+
+	rsp.OkRsp(c)
+	log.Debugf("set USB descriptor success")
+}
+
+func (s *Service) RestoreUsbDefaults(c *gin.Context) {
+	var rsp proto.Response
+
+	h := GetHid()
+	h.Lock()
+	h.CloseNoLock()
+	defer func() {
+		h.OpenNoLock()
+		h.Unlock()
+	}()
+
+	if err := rebindUDC(func() error {
+		return writeDescriptorFiles(defaultVid, defaultPid, defaultManufacturer, defaultProduct, defaultSerial)
+	}); err != nil {
+		log.Errorf("failed to restore USB defaults: %s", err)
+		rsp.ErrRsp(c, -2, "failed to restore USB defaults")
+		return
+	}
+
+	bootFiles := []string{
+		"/boot/usb.vid",
+		"/boot/usb.pid",
+		"/boot/usb.manufacturer",
+		"/boot/usb.product",
+		"/boot/usb.serial",
+	}
+	for _, f := range bootFiles {
+		_ = os.Remove(f)
+	}
+
+	rsp.OkRsp(c)
+	log.Debugf("restore USB defaults success")
+}
+
+func writeDescriptorFiles(vid, pid, manufacturer, product, serial string) error {
+	writes := []struct {
+		path  string
+		value string
+	}{
+		{idVendorFile, vid},
+		{idProductFile, pid},
+		{manufacturerFile, manufacturer},
+		{productFile, product},
+		{configStringFile, product},
+		{serialFile, serial},
+	}
+
+	for _, w := range writes {
+		if err := writeConfigFS(w.path, w.value); err != nil {
+			return fmt.Errorf("write %s: %w", w.path, err)
+		}
+	}
+
+	return nil
+}
+
+func rebindUDC(fn func() error) error {
+	// unbind UDC
+	err := exec.Command("sh", "-c", "echo > "+udcFile).Run()
+	if err != nil {
+		return fmt.Errorf("unbind UDC: %w", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	// apply changes
+	if err := fn(); err != nil {
+		return err
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	// rebind UDC
+	err = exec.Command("sh", "-c", "ls /sys/class/udc/ | cat > "+udcFile).Run()
+	if err != nil {
+		return fmt.Errorf("rebind UDC: %w", err)
+	}
+
+	return nil
+}
+
+func persistBootFile(path string, value string) {
+	if err := os.WriteFile(path, []byte(value), 0o644); err != nil {
+		log.Errorf("failed to persist %s: %s", path, err)
+	}
+}

--- a/web/src/api/usb-descriptor.ts
+++ b/web/src/api/usb-descriptor.ts
@@ -1,0 +1,19 @@
+import { http } from '@/lib/http.ts';
+
+export function getUsbDescriptor() {
+  return http.get('/api/hid/usb-descriptor');
+}
+
+export function setUsbDescriptor(data: {
+  vendorName: string;
+  productName: string;
+  serialNumber: string;
+  vid: string;
+  pid: string;
+}) {
+  return http.post('/api/hid/usb-descriptor', data);
+}
+
+export function restoreUsbDefaults() {
+  return http.post('/api/hid/usb-descriptor/restore');
+}

--- a/web/src/i18n/locales/ca.ts
+++ b/web/src/i18n/locales/ca.ts
@@ -265,6 +265,49 @@ const ca = {
         diskDesc: "Munta un disc U virtual al dispositiu remot",
         network: "Xarxa virtual",
         networkDesc: "Munta una targeta de xarxa virtual al dispositiu remot",
+        usbDescriptor: {
+          title: 'USB Descriptor',
+          description: 'Customize how the USB device appears to the target host',
+          preset: 'Preset',
+          vendorName: 'Manufacturer',
+          productName: 'Product Name',
+          serialNumber: 'Serial Number',
+          chars: 'chars',
+          randomize: 'Random',
+          readDevice: 'Read Device',
+          restoreDefaults: 'Restore Defaults',
+          apply: 'Apply Changes',
+          applySuccess: 'USB descriptor updated. The target will see a brief USB reconnection.',
+          restoreSuccess: 'USB descriptor restored to factory defaults.',
+          vidPidWarning:
+            'Changing VID/PID may cause the target OS to reinstall USB drivers. Use known values to avoid compatibility issues.',
+          confirmTitle: 'Confirm VID/PID Change',
+          confirmMessage:
+            'Changing the VID or PID may cause the target operating system to reinstall USB drivers. Are you sure you want to continue?',
+          confirm: 'Yes, Apply',
+          cancel: 'Cancel',
+          presetGroups: {
+            generic: 'Generic',
+            brand: 'Brand',
+            custom: 'Custom'
+          },
+          presets: {
+            genericKeyboard: 'Generic Keyboard',
+            genericMouse: 'Generic Mouse',
+            genericComposite: 'Generic Composite',
+            genericHid: 'Generic HID Device',
+            logitechKeyboard: 'Logitech Keyboard K120',
+            logitechMouse: 'Logitech USB Optical Mouse',
+            microsoftKeyboard: 'Microsoft Wired Keyboard',
+            dellKeyboard: 'Dell KB216 Keyboard'
+          },
+          errors: {
+            readFailed: 'Failed to read USB descriptor',
+            writeFailed: 'Failed to write USB descriptor',
+            restoreFailed: 'Failed to restore USB defaults',
+            invalidHex: 'VID and PID must be valid hex values (e.g. 0x1234)'
+          }
+        },
         reboot: "Reinicia",
         rebootDesc: "Segur que vols reiniciar el NanoKVM?",
         okBtn: "Sí",

--- a/web/src/i18n/locales/cz.ts
+++ b/web/src/i18n/locales/cz.ts
@@ -191,7 +191,50 @@ const cz = {
         disk: 'Virtual Disk',
         diskDesc: 'Mount virtual U-disk on the remote host',
         network: 'Virtual Network',
-        networkDesc: 'Mount virtual network card on the remote host'
+        networkDesc: 'Mount virtual network card on the remote host',
+        usbDescriptor: {
+          title: 'USB Descriptor',
+          description: 'Customize how the USB device appears to the target host',
+          preset: 'Preset',
+          vendorName: 'Manufacturer',
+          productName: 'Product Name',
+          serialNumber: 'Serial Number',
+          chars: 'chars',
+          randomize: 'Random',
+          readDevice: 'Read Device',
+          restoreDefaults: 'Restore Defaults',
+          apply: 'Apply Changes',
+          applySuccess: 'USB descriptor updated. The target will see a brief USB reconnection.',
+          restoreSuccess: 'USB descriptor restored to factory defaults.',
+          vidPidWarning:
+            'Changing VID/PID may cause the target OS to reinstall USB drivers. Use known values to avoid compatibility issues.',
+          confirmTitle: 'Confirm VID/PID Change',
+          confirmMessage:
+            'Changing the VID or PID may cause the target operating system to reinstall USB drivers. Are you sure you want to continue?',
+          confirm: 'Yes, Apply',
+          cancel: 'Cancel',
+          presetGroups: {
+            generic: 'Generic',
+            brand: 'Brand',
+            custom: 'Custom'
+          },
+          presets: {
+            genericKeyboard: 'Generic Keyboard',
+            genericMouse: 'Generic Mouse',
+            genericComposite: 'Generic Composite',
+            genericHid: 'Generic HID Device',
+            logitechKeyboard: 'Logitech Keyboard K120',
+            logitechMouse: 'Logitech USB Optical Mouse',
+            microsoftKeyboard: 'Microsoft Wired Keyboard',
+            dellKeyboard: 'Dell KB216 Keyboard'
+          },
+          errors: {
+            readFailed: 'Failed to read USB descriptor',
+            writeFailed: 'Failed to write USB descriptor',
+            restoreFailed: 'Failed to restore USB defaults',
+            invalidHex: 'VID and PID must be valid hex values (e.g. 0x1234)'
+          }
+        }
       },
       tailscale: {
         title: 'Tailscale',

--- a/web/src/i18n/locales/da.ts
+++ b/web/src/i18n/locales/da.ts
@@ -189,7 +189,50 @@ const da = {
         disk: 'Virtual Disk',
         diskDesc: 'Mount virtual U-disk on the remote host',
         network: 'Virtual Network',
-        networkDesc: 'Mount virtual network card on the remote host'
+        networkDesc: 'Mount virtual network card on the remote host',
+        usbDescriptor: {
+          title: 'USB Descriptor',
+          description: 'Customize how the USB device appears to the target host',
+          preset: 'Preset',
+          vendorName: 'Manufacturer',
+          productName: 'Product Name',
+          serialNumber: 'Serial Number',
+          chars: 'chars',
+          randomize: 'Random',
+          readDevice: 'Read Device',
+          restoreDefaults: 'Restore Defaults',
+          apply: 'Apply Changes',
+          applySuccess: 'USB descriptor updated. The target will see a brief USB reconnection.',
+          restoreSuccess: 'USB descriptor restored to factory defaults.',
+          vidPidWarning:
+            'Changing VID/PID may cause the target OS to reinstall USB drivers. Use known values to avoid compatibility issues.',
+          confirmTitle: 'Confirm VID/PID Change',
+          confirmMessage:
+            'Changing the VID or PID may cause the target operating system to reinstall USB drivers. Are you sure you want to continue?',
+          confirm: 'Yes, Apply',
+          cancel: 'Cancel',
+          presetGroups: {
+            generic: 'Generic',
+            brand: 'Brand',
+            custom: 'Custom'
+          },
+          presets: {
+            genericKeyboard: 'Generic Keyboard',
+            genericMouse: 'Generic Mouse',
+            genericComposite: 'Generic Composite',
+            genericHid: 'Generic HID Device',
+            logitechKeyboard: 'Logitech Keyboard K120',
+            logitechMouse: 'Logitech USB Optical Mouse',
+            microsoftKeyboard: 'Microsoft Wired Keyboard',
+            dellKeyboard: 'Dell KB216 Keyboard'
+          },
+          errors: {
+            readFailed: 'Failed to read USB descriptor',
+            writeFailed: 'Failed to write USB descriptor',
+            restoreFailed: 'Failed to restore USB defaults',
+            invalidHex: 'VID and PID must be valid hex values (e.g. 0x1234)'
+          }
+        }
       },
       tailscale: {
         title: 'Tailscale',

--- a/web/src/i18n/locales/de.ts
+++ b/web/src/i18n/locales/de.ts
@@ -269,6 +269,49 @@ const de = {
         diskDesc: 'Binde das virtuelle U-Laufwerk an den entfernten Host',
         network: 'Virtuelles Netzwerk',
         networkDesc: 'Binde die virtuelle Netzwerkkarte an den entfernten Host',
+        usbDescriptor: {
+          title: 'USB Descriptor',
+          description: 'Customize how the USB device appears to the target host',
+          preset: 'Preset',
+          vendorName: 'Manufacturer',
+          productName: 'Product Name',
+          serialNumber: 'Serial Number',
+          chars: 'chars',
+          randomize: 'Random',
+          readDevice: 'Read Device',
+          restoreDefaults: 'Restore Defaults',
+          apply: 'Apply Changes',
+          applySuccess: 'USB descriptor updated. The target will see a brief USB reconnection.',
+          restoreSuccess: 'USB descriptor restored to factory defaults.',
+          vidPidWarning:
+            'Changing VID/PID may cause the target OS to reinstall USB drivers. Use known values to avoid compatibility issues.',
+          confirmTitle: 'Confirm VID/PID Change',
+          confirmMessage:
+            'Changing the VID or PID may cause the target operating system to reinstall USB drivers. Are you sure you want to continue?',
+          confirm: 'Yes, Apply',
+          cancel: 'Cancel',
+          presetGroups: {
+            generic: 'Generic',
+            brand: 'Brand',
+            custom: 'Custom'
+          },
+          presets: {
+            genericKeyboard: 'Generic Keyboard',
+            genericMouse: 'Generic Mouse',
+            genericComposite: 'Generic Composite',
+            genericHid: 'Generic HID Device',
+            logitechKeyboard: 'Logitech Keyboard K120',
+            logitechMouse: 'Logitech USB Optical Mouse',
+            microsoftKeyboard: 'Microsoft Wired Keyboard',
+            dellKeyboard: 'Dell KB216 Keyboard'
+          },
+          errors: {
+            readFailed: 'Failed to read USB descriptor',
+            writeFailed: 'Failed to write USB descriptor',
+            restoreFailed: 'Failed to restore USB defaults',
+            invalidHex: 'VID and PID must be valid hex values (e.g. 0x1234)'
+          }
+        },
         reboot: 'Neustarten',
         rebootDesc: 'Sind Sie sicher dass Sie NanoKVM neustarten möchten?',
         okBtn: 'Ja',

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -360,6 +360,49 @@ const en = {
         diskDesc: 'Mount SD card on the remote host',
         network: 'Virtual Network',
         networkDesc: 'Mount virtual network card on the remote host',
+        usbDescriptor: {
+          title: 'USB Descriptor',
+          description: 'Customize how the USB device appears to the target host',
+          preset: 'Preset',
+          vendorName: 'Manufacturer',
+          productName: 'Product Name',
+          serialNumber: 'Serial Number',
+          chars: 'chars',
+          randomize: 'Random',
+          readDevice: 'Read Device',
+          restoreDefaults: 'Restore Defaults',
+          apply: 'Apply Changes',
+          applySuccess: 'USB descriptor updated. The target will see a brief USB reconnection.',
+          restoreSuccess: 'USB descriptor restored to factory defaults.',
+          vidPidWarning:
+            'Changing VID/PID may cause the target OS to reinstall USB drivers. Use known values to avoid compatibility issues.',
+          confirmTitle: 'Confirm VID/PID Change',
+          confirmMessage:
+            'Changing the VID or PID may cause the target operating system to reinstall USB drivers. Are you sure you want to continue?',
+          confirm: 'Yes, Apply',
+          cancel: 'Cancel',
+          presetGroups: {
+            generic: 'Generic',
+            brand: 'Brand',
+            custom: 'Custom'
+          },
+          presets: {
+            genericKeyboard: 'Generic Keyboard',
+            genericMouse: 'Generic Mouse',
+            genericComposite: 'Generic Composite',
+            genericHid: 'Generic HID Device',
+            logitechKeyboard: 'Logitech Keyboard K120',
+            logitechMouse: 'Logitech USB Optical Mouse',
+            microsoftKeyboard: 'Microsoft Wired Keyboard',
+            dellKeyboard: 'Dell KB216 Keyboard'
+          },
+          errors: {
+            readFailed: 'Failed to read USB descriptor',
+            writeFailed: 'Failed to write USB descriptor',
+            restoreFailed: 'Failed to restore USB defaults',
+            invalidHex: 'VID and PID must be valid hex values (e.g. 0x1234)'
+          }
+        },
         reboot: 'Reboot',
         rebootDesc: 'Are you sure you want to reboot NanoKVM?',
         okBtn: 'Yes',

--- a/web/src/i18n/locales/es.ts
+++ b/web/src/i18n/locales/es.ts
@@ -278,6 +278,49 @@ const es = {
         mediaDesc: 'Adjuntar dispositivo de imagen virtual al host remoto',
         network: 'Red Virtual',
         networkDesc: 'Montar tarjeta de red virtual en el host remoto',
+        usbDescriptor: {
+          title: 'USB Descriptor',
+          description: 'Customize how the USB device appears to the target host',
+          preset: 'Preset',
+          vendorName: 'Manufacturer',
+          productName: 'Product Name',
+          serialNumber: 'Serial Number',
+          chars: 'chars',
+          randomize: 'Random',
+          readDevice: 'Read Device',
+          restoreDefaults: 'Restore Defaults',
+          apply: 'Apply Changes',
+          applySuccess: 'USB descriptor updated. The target will see a brief USB reconnection.',
+          restoreSuccess: 'USB descriptor restored to factory defaults.',
+          vidPidWarning:
+            'Changing VID/PID may cause the target OS to reinstall USB drivers. Use known values to avoid compatibility issues.',
+          confirmTitle: 'Confirm VID/PID Change',
+          confirmMessage:
+            'Changing the VID or PID may cause the target operating system to reinstall USB drivers. Are you sure you want to continue?',
+          confirm: 'Yes, Apply',
+          cancel: 'Cancel',
+          presetGroups: {
+            generic: 'Generic',
+            brand: 'Brand',
+            custom: 'Custom'
+          },
+          presets: {
+            genericKeyboard: 'Generic Keyboard',
+            genericMouse: 'Generic Mouse',
+            genericComposite: 'Generic Composite',
+            genericHid: 'Generic HID Device',
+            logitechKeyboard: 'Logitech Keyboard K120',
+            logitechMouse: 'Logitech USB Optical Mouse',
+            microsoftKeyboard: 'Microsoft Wired Keyboard',
+            dellKeyboard: 'Dell KB216 Keyboard'
+          },
+          errors: {
+            readFailed: 'Failed to read USB descriptor',
+            writeFailed: 'Failed to write USB descriptor',
+            restoreFailed: 'Failed to restore USB defaults',
+            invalidHex: 'VID and PID must be valid hex values (e.g. 0x1234)'
+          }
+        },
         reboot: 'Reiniciar',
         rebootDesc: '¿Estás seguro de que deseas reiniciar el NanoKVM?',
         usb: 'Interfaz USB',

--- a/web/src/i18n/locales/fr.ts
+++ b/web/src/i18n/locales/fr.ts
@@ -195,7 +195,50 @@ const fr = {
         disk: 'Disque virtuel',
         diskDesc: 'Monter le disque virtuel U sur l\'hôte distant',
         network: 'Réseau virtuel',
-        networkDesc: 'Monter la carte réseau virtuelle sur l\'hôte distant'
+        networkDesc: 'Monter la carte réseau virtuelle sur l\'hôte distant',
+        usbDescriptor: {
+          title: 'USB Descriptor',
+          description: 'Customize how the USB device appears to the target host',
+          preset: 'Preset',
+          vendorName: 'Manufacturer',
+          productName: 'Product Name',
+          serialNumber: 'Serial Number',
+          chars: 'chars',
+          randomize: 'Random',
+          readDevice: 'Read Device',
+          restoreDefaults: 'Restore Defaults',
+          apply: 'Apply Changes',
+          applySuccess: 'USB descriptor updated. The target will see a brief USB reconnection.',
+          restoreSuccess: 'USB descriptor restored to factory defaults.',
+          vidPidWarning:
+            'Changing VID/PID may cause the target OS to reinstall USB drivers. Use known values to avoid compatibility issues.',
+          confirmTitle: 'Confirm VID/PID Change',
+          confirmMessage:
+            'Changing the VID or PID may cause the target operating system to reinstall USB drivers. Are you sure you want to continue?',
+          confirm: 'Yes, Apply',
+          cancel: 'Cancel',
+          presetGroups: {
+            generic: 'Generic',
+            brand: 'Brand',
+            custom: 'Custom'
+          },
+          presets: {
+            genericKeyboard: 'Generic Keyboard',
+            genericMouse: 'Generic Mouse',
+            genericComposite: 'Generic Composite',
+            genericHid: 'Generic HID Device',
+            logitechKeyboard: 'Logitech Keyboard K120',
+            logitechMouse: 'Logitech USB Optical Mouse',
+            microsoftKeyboard: 'Microsoft Wired Keyboard',
+            dellKeyboard: 'Dell KB216 Keyboard'
+          },
+          errors: {
+            readFailed: 'Failed to read USB descriptor',
+            writeFailed: 'Failed to write USB descriptor',
+            restoreFailed: 'Failed to restore USB defaults',
+            invalidHex: 'VID and PID must be valid hex values (e.g. 0x1234)'
+          }
+        }
       },
       tailscale: {
         title: 'Tailscale',

--- a/web/src/i18n/locales/hu.ts
+++ b/web/src/i18n/locales/hu.ts
@@ -191,7 +191,50 @@ const hu = {
         disk: 'Virtual Disk',
         diskDesc: 'Mount virtual U-disk on the remote host',
         network: 'Virtual Network',
-        networkDesc: 'Mount virtual network card on the remote host'
+        networkDesc: 'Mount virtual network card on the remote host',
+        usbDescriptor: {
+          title: 'USB Descriptor',
+          description: 'Customize how the USB device appears to the target host',
+          preset: 'Preset',
+          vendorName: 'Manufacturer',
+          productName: 'Product Name',
+          serialNumber: 'Serial Number',
+          chars: 'chars',
+          randomize: 'Random',
+          readDevice: 'Read Device',
+          restoreDefaults: 'Restore Defaults',
+          apply: 'Apply Changes',
+          applySuccess: 'USB descriptor updated. The target will see a brief USB reconnection.',
+          restoreSuccess: 'USB descriptor restored to factory defaults.',
+          vidPidWarning:
+            'Changing VID/PID may cause the target OS to reinstall USB drivers. Use known values to avoid compatibility issues.',
+          confirmTitle: 'Confirm VID/PID Change',
+          confirmMessage:
+            'Changing the VID or PID may cause the target operating system to reinstall USB drivers. Are you sure you want to continue?',
+          confirm: 'Yes, Apply',
+          cancel: 'Cancel',
+          presetGroups: {
+            generic: 'Generic',
+            brand: 'Brand',
+            custom: 'Custom'
+          },
+          presets: {
+            genericKeyboard: 'Generic Keyboard',
+            genericMouse: 'Generic Mouse',
+            genericComposite: 'Generic Composite',
+            genericHid: 'Generic HID Device',
+            logitechKeyboard: 'Logitech Keyboard K120',
+            logitechMouse: 'Logitech USB Optical Mouse',
+            microsoftKeyboard: 'Microsoft Wired Keyboard',
+            dellKeyboard: 'Dell KB216 Keyboard'
+          },
+          errors: {
+            readFailed: 'Failed to read USB descriptor',
+            writeFailed: 'Failed to write USB descriptor',
+            restoreFailed: 'Failed to restore USB defaults',
+            invalidHex: 'VID and PID must be valid hex values (e.g. 0x1234)'
+          }
+        }
       },
       tailscale: {
         title: 'Tailscale',

--- a/web/src/i18n/locales/id.ts
+++ b/web/src/i18n/locales/id.ts
@@ -190,7 +190,50 @@ const id = {
         disk: 'Virtual Disk',
         diskDesc: 'Mount virtual U-disk on the remote host',
         network: 'Virtual Network',
-        networkDesc: 'Mount virtual network card on the remote host'
+        networkDesc: 'Mount virtual network card on the remote host',
+        usbDescriptor: {
+          title: 'USB Descriptor',
+          description: 'Customize how the USB device appears to the target host',
+          preset: 'Preset',
+          vendorName: 'Manufacturer',
+          productName: 'Product Name',
+          serialNumber: 'Serial Number',
+          chars: 'chars',
+          randomize: 'Random',
+          readDevice: 'Read Device',
+          restoreDefaults: 'Restore Defaults',
+          apply: 'Apply Changes',
+          applySuccess: 'USB descriptor updated. The target will see a brief USB reconnection.',
+          restoreSuccess: 'USB descriptor restored to factory defaults.',
+          vidPidWarning:
+            'Changing VID/PID may cause the target OS to reinstall USB drivers. Use known values to avoid compatibility issues.',
+          confirmTitle: 'Confirm VID/PID Change',
+          confirmMessage:
+            'Changing the VID or PID may cause the target operating system to reinstall USB drivers. Are you sure you want to continue?',
+          confirm: 'Yes, Apply',
+          cancel: 'Cancel',
+          presetGroups: {
+            generic: 'Generic',
+            brand: 'Brand',
+            custom: 'Custom'
+          },
+          presets: {
+            genericKeyboard: 'Generic Keyboard',
+            genericMouse: 'Generic Mouse',
+            genericComposite: 'Generic Composite',
+            genericHid: 'Generic HID Device',
+            logitechKeyboard: 'Logitech Keyboard K120',
+            logitechMouse: 'Logitech USB Optical Mouse',
+            microsoftKeyboard: 'Microsoft Wired Keyboard',
+            dellKeyboard: 'Dell KB216 Keyboard'
+          },
+          errors: {
+            readFailed: 'Failed to read USB descriptor',
+            writeFailed: 'Failed to write USB descriptor',
+            restoreFailed: 'Failed to restore USB defaults',
+            invalidHex: 'VID and PID must be valid hex values (e.g. 0x1234)'
+          }
+        }
       },
       tailscale: {
         title: 'Tailscale',

--- a/web/src/i18n/locales/it.ts
+++ b/web/src/i18n/locales/it.ts
@@ -191,7 +191,50 @@ const it = {
         disk: 'Virtual Disk',
         diskDesc: 'Mount virtual U-disk on the remote host',
         network: 'Virtual Network',
-        networkDesc: 'Mount virtual network card on the remote host'
+        networkDesc: 'Mount virtual network card on the remote host',
+        usbDescriptor: {
+          title: 'USB Descriptor',
+          description: 'Customize how the USB device appears to the target host',
+          preset: 'Preset',
+          vendorName: 'Manufacturer',
+          productName: 'Product Name',
+          serialNumber: 'Serial Number',
+          chars: 'chars',
+          randomize: 'Random',
+          readDevice: 'Read Device',
+          restoreDefaults: 'Restore Defaults',
+          apply: 'Apply Changes',
+          applySuccess: 'USB descriptor updated. The target will see a brief USB reconnection.',
+          restoreSuccess: 'USB descriptor restored to factory defaults.',
+          vidPidWarning:
+            'Changing VID/PID may cause the target OS to reinstall USB drivers. Use known values to avoid compatibility issues.',
+          confirmTitle: 'Confirm VID/PID Change',
+          confirmMessage:
+            'Changing the VID or PID may cause the target operating system to reinstall USB drivers. Are you sure you want to continue?',
+          confirm: 'Yes, Apply',
+          cancel: 'Cancel',
+          presetGroups: {
+            generic: 'Generic',
+            brand: 'Brand',
+            custom: 'Custom'
+          },
+          presets: {
+            genericKeyboard: 'Generic Keyboard',
+            genericMouse: 'Generic Mouse',
+            genericComposite: 'Generic Composite',
+            genericHid: 'Generic HID Device',
+            logitechKeyboard: 'Logitech Keyboard K120',
+            logitechMouse: 'Logitech USB Optical Mouse',
+            microsoftKeyboard: 'Microsoft Wired Keyboard',
+            dellKeyboard: 'Dell KB216 Keyboard'
+          },
+          errors: {
+            readFailed: 'Failed to read USB descriptor',
+            writeFailed: 'Failed to write USB descriptor',
+            restoreFailed: 'Failed to restore USB defaults',
+            invalidHex: 'VID and PID must be valid hex values (e.g. 0x1234)'
+          }
+        }
       },
       tailscale: {
         title: 'Tailscale',

--- a/web/src/i18n/locales/ja.ts
+++ b/web/src/i18n/locales/ja.ts
@@ -192,7 +192,50 @@ const ja = {
         disk: 'Virtual Disk',
         diskDesc: 'Mount virtual U-disk on the remote host',
         network: 'Virtual Network',
-        networkDesc: 'Mount virtual network card on the remote host'
+        networkDesc: 'Mount virtual network card on the remote host',
+        usbDescriptor: {
+          title: 'USB Descriptor',
+          description: 'Customize how the USB device appears to the target host',
+          preset: 'Preset',
+          vendorName: 'Manufacturer',
+          productName: 'Product Name',
+          serialNumber: 'Serial Number',
+          chars: 'chars',
+          randomize: 'Random',
+          readDevice: 'Read Device',
+          restoreDefaults: 'Restore Defaults',
+          apply: 'Apply Changes',
+          applySuccess: 'USB descriptor updated. The target will see a brief USB reconnection.',
+          restoreSuccess: 'USB descriptor restored to factory defaults.',
+          vidPidWarning:
+            'Changing VID/PID may cause the target OS to reinstall USB drivers. Use known values to avoid compatibility issues.',
+          confirmTitle: 'Confirm VID/PID Change',
+          confirmMessage:
+            'Changing the VID or PID may cause the target operating system to reinstall USB drivers. Are you sure you want to continue?',
+          confirm: 'Yes, Apply',
+          cancel: 'Cancel',
+          presetGroups: {
+            generic: 'Generic',
+            brand: 'Brand',
+            custom: 'Custom'
+          },
+          presets: {
+            genericKeyboard: 'Generic Keyboard',
+            genericMouse: 'Generic Mouse',
+            genericComposite: 'Generic Composite',
+            genericHid: 'Generic HID Device',
+            logitechKeyboard: 'Logitech Keyboard K120',
+            logitechMouse: 'Logitech USB Optical Mouse',
+            microsoftKeyboard: 'Microsoft Wired Keyboard',
+            dellKeyboard: 'Dell KB216 Keyboard'
+          },
+          errors: {
+            readFailed: 'Failed to read USB descriptor',
+            writeFailed: 'Failed to write USB descriptor',
+            restoreFailed: 'Failed to restore USB defaults',
+            invalidHex: 'VID and PID must be valid hex values (e.g. 0x1234)'
+          }
+        }
       },
       tailscale: {
         title: 'Tailscale',

--- a/web/src/i18n/locales/ko.ts
+++ b/web/src/i18n/locales/ko.ts
@@ -285,6 +285,49 @@ const ko = {
         diskDesc: '원격 호스트에서 가상 USB를 마운트합니다.',
         network: '가상 네트워크',
         networkDesc: '원격 호스트에서 가상 네트워크 카드를 마운트합니다.',
+        usbDescriptor: {
+          title: 'USB Descriptor',
+          description: 'Customize how the USB device appears to the target host',
+          preset: 'Preset',
+          vendorName: 'Manufacturer',
+          productName: 'Product Name',
+          serialNumber: 'Serial Number',
+          chars: 'chars',
+          randomize: 'Random',
+          readDevice: 'Read Device',
+          restoreDefaults: 'Restore Defaults',
+          apply: 'Apply Changes',
+          applySuccess: 'USB descriptor updated. The target will see a brief USB reconnection.',
+          restoreSuccess: 'USB descriptor restored to factory defaults.',
+          vidPidWarning:
+            'Changing VID/PID may cause the target OS to reinstall USB drivers. Use known values to avoid compatibility issues.',
+          confirmTitle: 'Confirm VID/PID Change',
+          confirmMessage:
+            'Changing the VID or PID may cause the target operating system to reinstall USB drivers. Are you sure you want to continue?',
+          confirm: 'Yes, Apply',
+          cancel: 'Cancel',
+          presetGroups: {
+            generic: 'Generic',
+            brand: 'Brand',
+            custom: 'Custom'
+          },
+          presets: {
+            genericKeyboard: 'Generic Keyboard',
+            genericMouse: 'Generic Mouse',
+            genericComposite: 'Generic Composite',
+            genericHid: 'Generic HID Device',
+            logitechKeyboard: 'Logitech Keyboard K120',
+            logitechMouse: 'Logitech USB Optical Mouse',
+            microsoftKeyboard: 'Microsoft Wired Keyboard',
+            dellKeyboard: 'Dell KB216 Keyboard'
+          },
+          errors: {
+            readFailed: 'Failed to read USB descriptor',
+            writeFailed: 'Failed to write USB descriptor',
+            restoreFailed: 'Failed to restore USB defaults',
+            invalidHex: 'VID and PID must be valid hex values (e.g. 0x1234)'
+          }
+        },
         reboot: '재부팅',
         rebootDesc: 'NanoKVM을 재부팅하시겠습니까?',
         okBtn: '네',

--- a/web/src/i18n/locales/nb.ts
+++ b/web/src/i18n/locales/nb.ts
@@ -190,7 +190,50 @@ const nb = {
         disk: 'Virtual Disk',
         diskDesc: 'Mount virtual U-disk on the remote host',
         network: 'Virtual Network',
-        networkDesc: 'Mount virtual network card on the remote host'
+        networkDesc: 'Mount virtual network card on the remote host',
+        usbDescriptor: {
+          title: 'USB Descriptor',
+          description: 'Customize how the USB device appears to the target host',
+          preset: 'Preset',
+          vendorName: 'Manufacturer',
+          productName: 'Product Name',
+          serialNumber: 'Serial Number',
+          chars: 'chars',
+          randomize: 'Random',
+          readDevice: 'Read Device',
+          restoreDefaults: 'Restore Defaults',
+          apply: 'Apply Changes',
+          applySuccess: 'USB descriptor updated. The target will see a brief USB reconnection.',
+          restoreSuccess: 'USB descriptor restored to factory defaults.',
+          vidPidWarning:
+            'Changing VID/PID may cause the target OS to reinstall USB drivers. Use known values to avoid compatibility issues.',
+          confirmTitle: 'Confirm VID/PID Change',
+          confirmMessage:
+            'Changing the VID or PID may cause the target operating system to reinstall USB drivers. Are you sure you want to continue?',
+          confirm: 'Yes, Apply',
+          cancel: 'Cancel',
+          presetGroups: {
+            generic: 'Generic',
+            brand: 'Brand',
+            custom: 'Custom'
+          },
+          presets: {
+            genericKeyboard: 'Generic Keyboard',
+            genericMouse: 'Generic Mouse',
+            genericComposite: 'Generic Composite',
+            genericHid: 'Generic HID Device',
+            logitechKeyboard: 'Logitech Keyboard K120',
+            logitechMouse: 'Logitech USB Optical Mouse',
+            microsoftKeyboard: 'Microsoft Wired Keyboard',
+            dellKeyboard: 'Dell KB216 Keyboard'
+          },
+          errors: {
+            readFailed: 'Failed to read USB descriptor',
+            writeFailed: 'Failed to write USB descriptor',
+            restoreFailed: 'Failed to restore USB defaults',
+            invalidHex: 'VID and PID must be valid hex values (e.g. 0x1234)'
+          }
+        }
       },
       tailscale: {
         title: 'Tailscale',

--- a/web/src/i18n/locales/nl.ts
+++ b/web/src/i18n/locales/nl.ts
@@ -190,7 +190,50 @@ const nl = {
         disk: 'Virtuele schijf',
         diskDesc: 'Koppel virtuele U-schijf aan de externe host',
         network: 'Virtueel Netwerk',
-        networkDesc: 'Koppel virtueel netwerk kaart aan de externe host'
+        networkDesc: 'Koppel virtueel netwerk kaart aan de externe host',
+        usbDescriptor: {
+          title: 'USB Descriptor',
+          description: 'Customize how the USB device appears to the target host',
+          preset: 'Preset',
+          vendorName: 'Manufacturer',
+          productName: 'Product Name',
+          serialNumber: 'Serial Number',
+          chars: 'chars',
+          randomize: 'Random',
+          readDevice: 'Read Device',
+          restoreDefaults: 'Restore Defaults',
+          apply: 'Apply Changes',
+          applySuccess: 'USB descriptor updated. The target will see a brief USB reconnection.',
+          restoreSuccess: 'USB descriptor restored to factory defaults.',
+          vidPidWarning:
+            'Changing VID/PID may cause the target OS to reinstall USB drivers. Use known values to avoid compatibility issues.',
+          confirmTitle: 'Confirm VID/PID Change',
+          confirmMessage:
+            'Changing the VID or PID may cause the target operating system to reinstall USB drivers. Are you sure you want to continue?',
+          confirm: 'Yes, Apply',
+          cancel: 'Cancel',
+          presetGroups: {
+            generic: 'Generic',
+            brand: 'Brand',
+            custom: 'Custom'
+          },
+          presets: {
+            genericKeyboard: 'Generic Keyboard',
+            genericMouse: 'Generic Mouse',
+            genericComposite: 'Generic Composite',
+            genericHid: 'Generic HID Device',
+            logitechKeyboard: 'Logitech Keyboard K120',
+            logitechMouse: 'Logitech USB Optical Mouse',
+            microsoftKeyboard: 'Microsoft Wired Keyboard',
+            dellKeyboard: 'Dell KB216 Keyboard'
+          },
+          errors: {
+            readFailed: 'Failed to read USB descriptor',
+            writeFailed: 'Failed to write USB descriptor',
+            restoreFailed: 'Failed to restore USB defaults',
+            invalidHex: 'VID and PID must be valid hex values (e.g. 0x1234)'
+          }
+        }
       },
       tailscale: {
         title: 'Tailscale',

--- a/web/src/i18n/locales/pl.ts
+++ b/web/src/i18n/locales/pl.ts
@@ -192,7 +192,50 @@ const pl = {
         disk: 'Virtual Disk',
         diskDesc: 'Mount virtual U-disk on the remote host',
         network: 'Virtual Network',
-        networkDesc: 'Mount virtual network card on the remote host'
+        networkDesc: 'Mount virtual network card on the remote host',
+        usbDescriptor: {
+          title: 'USB Descriptor',
+          description: 'Customize how the USB device appears to the target host',
+          preset: 'Preset',
+          vendorName: 'Manufacturer',
+          productName: 'Product Name',
+          serialNumber: 'Serial Number',
+          chars: 'chars',
+          randomize: 'Random',
+          readDevice: 'Read Device',
+          restoreDefaults: 'Restore Defaults',
+          apply: 'Apply Changes',
+          applySuccess: 'USB descriptor updated. The target will see a brief USB reconnection.',
+          restoreSuccess: 'USB descriptor restored to factory defaults.',
+          vidPidWarning:
+            'Changing VID/PID may cause the target OS to reinstall USB drivers. Use known values to avoid compatibility issues.',
+          confirmTitle: 'Confirm VID/PID Change',
+          confirmMessage:
+            'Changing the VID or PID may cause the target operating system to reinstall USB drivers. Are you sure you want to continue?',
+          confirm: 'Yes, Apply',
+          cancel: 'Cancel',
+          presetGroups: {
+            generic: 'Generic',
+            brand: 'Brand',
+            custom: 'Custom'
+          },
+          presets: {
+            genericKeyboard: 'Generic Keyboard',
+            genericMouse: 'Generic Mouse',
+            genericComposite: 'Generic Composite',
+            genericHid: 'Generic HID Device',
+            logitechKeyboard: 'Logitech Keyboard K120',
+            logitechMouse: 'Logitech USB Optical Mouse',
+            microsoftKeyboard: 'Microsoft Wired Keyboard',
+            dellKeyboard: 'Dell KB216 Keyboard'
+          },
+          errors: {
+            readFailed: 'Failed to read USB descriptor',
+            writeFailed: 'Failed to write USB descriptor',
+            restoreFailed: 'Failed to restore USB defaults',
+            invalidHex: 'VID and PID must be valid hex values (e.g. 0x1234)'
+          }
+        }
       },
       tailscale: {
         title: 'Tailscale',

--- a/web/src/i18n/locales/pt_br.ts
+++ b/web/src/i18n/locales/pt_br.ts
@@ -265,6 +265,49 @@ const pt_br = {
         diskDesc: 'Montar U-disk virtual no host remoto',
         network: 'Rede Virtual',
         networkDesc: 'Montar placa de rede virtual no host remoto',
+        usbDescriptor: {
+          title: 'USB Descriptor',
+          description: 'Customize how the USB device appears to the target host',
+          preset: 'Preset',
+          vendorName: 'Manufacturer',
+          productName: 'Product Name',
+          serialNumber: 'Serial Number',
+          chars: 'chars',
+          randomize: 'Random',
+          readDevice: 'Read Device',
+          restoreDefaults: 'Restore Defaults',
+          apply: 'Apply Changes',
+          applySuccess: 'USB descriptor updated. The target will see a brief USB reconnection.',
+          restoreSuccess: 'USB descriptor restored to factory defaults.',
+          vidPidWarning:
+            'Changing VID/PID may cause the target OS to reinstall USB drivers. Use known values to avoid compatibility issues.',
+          confirmTitle: 'Confirm VID/PID Change',
+          confirmMessage:
+            'Changing the VID or PID may cause the target operating system to reinstall USB drivers. Are you sure you want to continue?',
+          confirm: 'Yes, Apply',
+          cancel: 'Cancel',
+          presetGroups: {
+            generic: 'Generic',
+            brand: 'Brand',
+            custom: 'Custom'
+          },
+          presets: {
+            genericKeyboard: 'Generic Keyboard',
+            genericMouse: 'Generic Mouse',
+            genericComposite: 'Generic Composite',
+            genericHid: 'Generic HID Device',
+            logitechKeyboard: 'Logitech Keyboard K120',
+            logitechMouse: 'Logitech USB Optical Mouse',
+            microsoftKeyboard: 'Microsoft Wired Keyboard',
+            dellKeyboard: 'Dell KB216 Keyboard'
+          },
+          errors: {
+            readFailed: 'Failed to read USB descriptor',
+            writeFailed: 'Failed to write USB descriptor',
+            restoreFailed: 'Failed to restore USB defaults',
+            invalidHex: 'VID and PID must be valid hex values (e.g. 0x1234)'
+          }
+        },
         reboot: 'Reiniciar',
         rebootDesc: 'Tem certeza de que deseja reiniciar o NanoKVM?',
         okBtn: 'Sim',

--- a/web/src/i18n/locales/ru.ts
+++ b/web/src/i18n/locales/ru.ts
@@ -266,6 +266,49 @@ const ru = {
         diskDesc: 'Смонтировать виртуальный USB диск на удаленном хосте',
         network: 'Виртуальная сеть',
         networkDesc: 'Смонтировать виртуальное сетевое устройство на удаленном хосте',
+        usbDescriptor: {
+          title: 'USB Descriptor',
+          description: 'Customize how the USB device appears to the target host',
+          preset: 'Preset',
+          vendorName: 'Manufacturer',
+          productName: 'Product Name',
+          serialNumber: 'Serial Number',
+          chars: 'chars',
+          randomize: 'Random',
+          readDevice: 'Read Device',
+          restoreDefaults: 'Restore Defaults',
+          apply: 'Apply Changes',
+          applySuccess: 'USB descriptor updated. The target will see a brief USB reconnection.',
+          restoreSuccess: 'USB descriptor restored to factory defaults.',
+          vidPidWarning:
+            'Changing VID/PID may cause the target OS to reinstall USB drivers. Use known values to avoid compatibility issues.',
+          confirmTitle: 'Confirm VID/PID Change',
+          confirmMessage:
+            'Changing the VID or PID may cause the target operating system to reinstall USB drivers. Are you sure you want to continue?',
+          confirm: 'Yes, Apply',
+          cancel: 'Cancel',
+          presetGroups: {
+            generic: 'Generic',
+            brand: 'Brand',
+            custom: 'Custom'
+          },
+          presets: {
+            genericKeyboard: 'Generic Keyboard',
+            genericMouse: 'Generic Mouse',
+            genericComposite: 'Generic Composite',
+            genericHid: 'Generic HID Device',
+            logitechKeyboard: 'Logitech Keyboard K120',
+            logitechMouse: 'Logitech USB Optical Mouse',
+            microsoftKeyboard: 'Microsoft Wired Keyboard',
+            dellKeyboard: 'Dell KB216 Keyboard'
+          },
+          errors: {
+            readFailed: 'Failed to read USB descriptor',
+            writeFailed: 'Failed to write USB descriptor',
+            restoreFailed: 'Failed to restore USB defaults',
+            invalidHex: 'VID and PID must be valid hex values (e.g. 0x1234)'
+          }
+        },
         reboot: 'Перезагрузка',
         rebootDesc: 'Вы уверены, что хотите перезагрузить NanoKVM?',
         okBtn: 'Да',

--- a/web/src/i18n/locales/se.ts
+++ b/web/src/i18n/locales/se.ts
@@ -281,6 +281,49 @@ const se = {
         diskDesc: 'Montera virtuell U-disk på fjärrvärden',
         network: 'Virtuellt nätverk',
         networkDesc: 'Montera virtuell nätverkskort på fjärrvärden',
+        usbDescriptor: {
+          title: 'USB Descriptor',
+          description: 'Customize how the USB device appears to the target host',
+          preset: 'Preset',
+          vendorName: 'Manufacturer',
+          productName: 'Product Name',
+          serialNumber: 'Serial Number',
+          chars: 'chars',
+          randomize: 'Random',
+          readDevice: 'Read Device',
+          restoreDefaults: 'Restore Defaults',
+          apply: 'Apply Changes',
+          applySuccess: 'USB descriptor updated. The target will see a brief USB reconnection.',
+          restoreSuccess: 'USB descriptor restored to factory defaults.',
+          vidPidWarning:
+            'Changing VID/PID may cause the target OS to reinstall USB drivers. Use known values to avoid compatibility issues.',
+          confirmTitle: 'Confirm VID/PID Change',
+          confirmMessage:
+            'Changing the VID or PID may cause the target operating system to reinstall USB drivers. Are you sure you want to continue?',
+          confirm: 'Yes, Apply',
+          cancel: 'Cancel',
+          presetGroups: {
+            generic: 'Generic',
+            brand: 'Brand',
+            custom: 'Custom'
+          },
+          presets: {
+            genericKeyboard: 'Generic Keyboard',
+            genericMouse: 'Generic Mouse',
+            genericComposite: 'Generic Composite',
+            genericHid: 'Generic HID Device',
+            logitechKeyboard: 'Logitech Keyboard K120',
+            logitechMouse: 'Logitech USB Optical Mouse',
+            microsoftKeyboard: 'Microsoft Wired Keyboard',
+            dellKeyboard: 'Dell KB216 Keyboard'
+          },
+          errors: {
+            readFailed: 'Failed to read USB descriptor',
+            writeFailed: 'Failed to write USB descriptor',
+            restoreFailed: 'Failed to restore USB defaults',
+            invalidHex: 'VID and PID must be valid hex values (e.g. 0x1234)'
+          }
+        },
         reboot: 'Starta om',
         rebootDesc: 'Är du säker på att du vill starta om NanoKVM?',
         okBtn: 'Ja',

--- a/web/src/i18n/locales/th.ts
+++ b/web/src/i18n/locales/th.ts
@@ -217,7 +217,50 @@ const th = {
           disk: 'ดิสก์จำลอง',
           diskDesc: 'เปิดใช้งาน U-disk จำลอง',
           network: 'เครือข่ายจำลอง',
-          networkDesc: 'เปิดใช้งานอุปกรณ์เครือข่ายจำลอง'
+          networkDesc: 'เปิดใช้งานอุปกรณ์เครือข่ายจำลอง',
+          usbDescriptor: {
+            title: 'USB Descriptor',
+            description: 'Customize how the USB device appears to the target host',
+            preset: 'Preset',
+            vendorName: 'Manufacturer',
+            productName: 'Product Name',
+            serialNumber: 'Serial Number',
+            chars: 'chars',
+            randomize: 'Random',
+            readDevice: 'Read Device',
+            restoreDefaults: 'Restore Defaults',
+            apply: 'Apply Changes',
+            applySuccess: 'USB descriptor updated. The target will see a brief USB reconnection.',
+            restoreSuccess: 'USB descriptor restored to factory defaults.',
+            vidPidWarning:
+              'Changing VID/PID may cause the target OS to reinstall USB drivers. Use known values to avoid compatibility issues.',
+            confirmTitle: 'Confirm VID/PID Change',
+            confirmMessage:
+              'Changing the VID or PID may cause the target operating system to reinstall USB drivers. Are you sure you want to continue?',
+            confirm: 'Yes, Apply',
+            cancel: 'Cancel',
+            presetGroups: {
+              generic: 'Generic',
+              brand: 'Brand',
+              custom: 'Custom'
+            },
+            presets: {
+              genericKeyboard: 'Generic Keyboard',
+              genericMouse: 'Generic Mouse',
+              genericComposite: 'Generic Composite',
+              genericHid: 'Generic HID Device',
+              logitechKeyboard: 'Logitech Keyboard K120',
+              logitechMouse: 'Logitech USB Optical Mouse',
+              microsoftKeyboard: 'Microsoft Wired Keyboard',
+              dellKeyboard: 'Dell KB216 Keyboard'
+            },
+            errors: {
+              readFailed: 'Failed to read USB descriptor',
+              writeFailed: 'Failed to write USB descriptor',
+              restoreFailed: 'Failed to restore USB defaults',
+              invalidHex: 'VID and PID must be valid hex values (e.g. 0x1234)'
+            }
+          }
         },
         tailscale: {
           title: 'Tailscale',

--- a/web/src/i18n/locales/tr.ts
+++ b/web/src/i18n/locales/tr.ts
@@ -269,6 +269,49 @@ const tr = {
         diskDesc: 'Sanal U-disk\'i uzak ana bilgisayara bağla',
         network: 'Sanal Ağ',
         networkDesc: 'Sanal ağ kartını uzak ana bilgisayara bağla',
+        usbDescriptor: {
+          title: 'USB Descriptor',
+          description: 'Customize how the USB device appears to the target host',
+          preset: 'Preset',
+          vendorName: 'Manufacturer',
+          productName: 'Product Name',
+          serialNumber: 'Serial Number',
+          chars: 'chars',
+          randomize: 'Random',
+          readDevice: 'Read Device',
+          restoreDefaults: 'Restore Defaults',
+          apply: 'Apply Changes',
+          applySuccess: 'USB descriptor updated. The target will see a brief USB reconnection.',
+          restoreSuccess: 'USB descriptor restored to factory defaults.',
+          vidPidWarning:
+            'Changing VID/PID may cause the target OS to reinstall USB drivers. Use known values to avoid compatibility issues.',
+          confirmTitle: 'Confirm VID/PID Change',
+          confirmMessage:
+            'Changing the VID or PID may cause the target operating system to reinstall USB drivers. Are you sure you want to continue?',
+          confirm: 'Yes, Apply',
+          cancel: 'Cancel',
+          presetGroups: {
+            generic: 'Generic',
+            brand: 'Brand',
+            custom: 'Custom'
+          },
+          presets: {
+            genericKeyboard: 'Generic Keyboard',
+            genericMouse: 'Generic Mouse',
+            genericComposite: 'Generic Composite',
+            genericHid: 'Generic HID Device',
+            logitechKeyboard: 'Logitech Keyboard K120',
+            logitechMouse: 'Logitech USB Optical Mouse',
+            microsoftKeyboard: 'Microsoft Wired Keyboard',
+            dellKeyboard: 'Dell KB216 Keyboard'
+          },
+          errors: {
+            readFailed: 'Failed to read USB descriptor',
+            writeFailed: 'Failed to write USB descriptor',
+            restoreFailed: 'Failed to restore USB defaults',
+            invalidHex: 'VID and PID must be valid hex values (e.g. 0x1234)'
+          }
+        },
         reboot: 'Yeniden Başlat',
         rebootDesc: 'NanoKVM\'i yeniden başlatmak istediğinizden emin misiniz?',
         okBtn: 'Evet',

--- a/web/src/i18n/locales/uk.ts
+++ b/web/src/i18n/locales/uk.ts
@@ -263,6 +263,49 @@ const uk = {
         diskDesc: 'Монтувати віртуальний U-диск на віддаленому хості',
         network: 'Віртуальна мережа',
         networkDesc: 'Встановити віртуальну мережеву карту на віддаленому хості',
+        usbDescriptor: {
+          title: 'USB Descriptor',
+          description: 'Customize how the USB device appears to the target host',
+          preset: 'Preset',
+          vendorName: 'Manufacturer',
+          productName: 'Product Name',
+          serialNumber: 'Serial Number',
+          chars: 'chars',
+          randomize: 'Random',
+          readDevice: 'Read Device',
+          restoreDefaults: 'Restore Defaults',
+          apply: 'Apply Changes',
+          applySuccess: 'USB descriptor updated. The target will see a brief USB reconnection.',
+          restoreSuccess: 'USB descriptor restored to factory defaults.',
+          vidPidWarning:
+            'Changing VID/PID may cause the target OS to reinstall USB drivers. Use known values to avoid compatibility issues.',
+          confirmTitle: 'Confirm VID/PID Change',
+          confirmMessage:
+            'Changing the VID or PID may cause the target operating system to reinstall USB drivers. Are you sure you want to continue?',
+          confirm: 'Yes, Apply',
+          cancel: 'Cancel',
+          presetGroups: {
+            generic: 'Generic',
+            brand: 'Brand',
+            custom: 'Custom'
+          },
+          presets: {
+            genericKeyboard: 'Generic Keyboard',
+            genericMouse: 'Generic Mouse',
+            genericComposite: 'Generic Composite',
+            genericHid: 'Generic HID Device',
+            logitechKeyboard: 'Logitech Keyboard K120',
+            logitechMouse: 'Logitech USB Optical Mouse',
+            microsoftKeyboard: 'Microsoft Wired Keyboard',
+            dellKeyboard: 'Dell KB216 Keyboard'
+          },
+          errors: {
+            readFailed: 'Failed to read USB descriptor',
+            writeFailed: 'Failed to write USB descriptor',
+            restoreFailed: 'Failed to restore USB defaults',
+            invalidHex: 'VID and PID must be valid hex values (e.g. 0x1234)'
+          }
+        },
         reboot: 'Перезавантажити',
         rebootDesc: 'Ви впевнені, що хочете перезавантажити Nanokvm?',
         okBtn: 'Так',

--- a/web/src/i18n/locales/vi.ts
+++ b/web/src/i18n/locales/vi.ts
@@ -189,7 +189,50 @@ const vi = {
         disk: 'Virtual Disk',
         diskDesc: 'Mount virtual U-disk on the remote host',
         network: 'Virtual Network',
-        networkDesc: 'Mount virtual network card on the remote host'
+        networkDesc: 'Mount virtual network card on the remote host',
+        usbDescriptor: {
+          title: 'USB Descriptor',
+          description: 'Customize how the USB device appears to the target host',
+          preset: 'Preset',
+          vendorName: 'Manufacturer',
+          productName: 'Product Name',
+          serialNumber: 'Serial Number',
+          chars: 'chars',
+          randomize: 'Random',
+          readDevice: 'Read Device',
+          restoreDefaults: 'Restore Defaults',
+          apply: 'Apply Changes',
+          applySuccess: 'USB descriptor updated. The target will see a brief USB reconnection.',
+          restoreSuccess: 'USB descriptor restored to factory defaults.',
+          vidPidWarning:
+            'Changing VID/PID may cause the target OS to reinstall USB drivers. Use known values to avoid compatibility issues.',
+          confirmTitle: 'Confirm VID/PID Change',
+          confirmMessage:
+            'Changing the VID or PID may cause the target operating system to reinstall USB drivers. Are you sure you want to continue?',
+          confirm: 'Yes, Apply',
+          cancel: 'Cancel',
+          presetGroups: {
+            generic: 'Generic',
+            brand: 'Brand',
+            custom: 'Custom'
+          },
+          presets: {
+            genericKeyboard: 'Generic Keyboard',
+            genericMouse: 'Generic Mouse',
+            genericComposite: 'Generic Composite',
+            genericHid: 'Generic HID Device',
+            logitechKeyboard: 'Logitech Keyboard K120',
+            logitechMouse: 'Logitech USB Optical Mouse',
+            microsoftKeyboard: 'Microsoft Wired Keyboard',
+            dellKeyboard: 'Dell KB216 Keyboard'
+          },
+          errors: {
+            readFailed: 'Failed to read USB descriptor',
+            writeFailed: 'Failed to write USB descriptor',
+            restoreFailed: 'Failed to restore USB defaults',
+            invalidHex: 'VID and PID must be valid hex values (e.g. 0x1234)'
+          }
+        }
       },
       tailscale: {
         title: 'Tailscale',

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -327,6 +327,49 @@ const zh = {
         diskDesc: '在远程主机中挂载虚拟U盘',
         network: '虚拟网卡',
         networkDesc: '在远程主机中挂载虚拟网卡',
+        usbDescriptor: {
+          title: 'USB Descriptor',
+          description: 'Customize how the USB device appears to the target host',
+          preset: 'Preset',
+          vendorName: 'Manufacturer',
+          productName: 'Product Name',
+          serialNumber: 'Serial Number',
+          chars: 'chars',
+          randomize: 'Random',
+          readDevice: 'Read Device',
+          restoreDefaults: 'Restore Defaults',
+          apply: 'Apply Changes',
+          applySuccess: 'USB descriptor updated. The target will see a brief USB reconnection.',
+          restoreSuccess: 'USB descriptor restored to factory defaults.',
+          vidPidWarning:
+            'Changing VID/PID may cause the target OS to reinstall USB drivers. Use known values to avoid compatibility issues.',
+          confirmTitle: 'Confirm VID/PID Change',
+          confirmMessage:
+            'Changing the VID or PID may cause the target operating system to reinstall USB drivers. Are you sure you want to continue?',
+          confirm: 'Yes, Apply',
+          cancel: 'Cancel',
+          presetGroups: {
+            generic: 'Generic',
+            brand: 'Brand',
+            custom: 'Custom'
+          },
+          presets: {
+            genericKeyboard: 'Generic Keyboard',
+            genericMouse: 'Generic Mouse',
+            genericComposite: 'Generic Composite',
+            genericHid: 'Generic HID Device',
+            logitechKeyboard: 'Logitech Keyboard K120',
+            logitechMouse: 'Logitech USB Optical Mouse',
+            microsoftKeyboard: 'Microsoft Wired Keyboard',
+            dellKeyboard: 'Dell KB216 Keyboard'
+          },
+          errors: {
+            readFailed: 'Failed to read USB descriptor',
+            writeFailed: 'Failed to write USB descriptor',
+            restoreFailed: 'Failed to restore USB defaults',
+            invalidHex: 'VID and PID must be valid hex values (e.g. 0x1234)'
+          }
+        },
         okBtn: '是',
         cancelBtn: '否'
       },

--- a/web/src/i18n/locales/zh_tw.ts
+++ b/web/src/i18n/locales/zh_tw.ts
@@ -320,6 +320,49 @@ const zh_tw = {
         diskDesc: '在遠端主機上連接虛擬隨身碟',
         network: '虛擬網卡',
         networkDesc: '在遠端主機上新增虛擬網卡',
+        usbDescriptor: {
+          title: 'USB Descriptor',
+          description: 'Customize how the USB device appears to the target host',
+          preset: 'Preset',
+          vendorName: 'Manufacturer',
+          productName: 'Product Name',
+          serialNumber: 'Serial Number',
+          chars: 'chars',
+          randomize: 'Random',
+          readDevice: 'Read Device',
+          restoreDefaults: 'Restore Defaults',
+          apply: 'Apply Changes',
+          applySuccess: 'USB descriptor updated. The target will see a brief USB reconnection.',
+          restoreSuccess: 'USB descriptor restored to factory defaults.',
+          vidPidWarning:
+            'Changing VID/PID may cause the target OS to reinstall USB drivers. Use known values to avoid compatibility issues.',
+          confirmTitle: 'Confirm VID/PID Change',
+          confirmMessage:
+            'Changing the VID or PID may cause the target operating system to reinstall USB drivers. Are you sure you want to continue?',
+          confirm: 'Yes, Apply',
+          cancel: 'Cancel',
+          presetGroups: {
+            generic: 'Generic',
+            brand: 'Brand',
+            custom: 'Custom'
+          },
+          presets: {
+            genericKeyboard: 'Generic Keyboard',
+            genericMouse: 'Generic Mouse',
+            genericComposite: 'Generic Composite',
+            genericHid: 'Generic HID Device',
+            logitechKeyboard: 'Logitech Keyboard K120',
+            logitechMouse: 'Logitech USB Optical Mouse',
+            microsoftKeyboard: 'Microsoft Wired Keyboard',
+            dellKeyboard: 'Dell KB216 Keyboard'
+          },
+          errors: {
+            readFailed: 'Failed to read USB descriptor',
+            writeFailed: 'Failed to write USB descriptor',
+            restoreFailed: 'Failed to restore USB defaults',
+            invalidHex: 'VID and PID must be valid hex values (e.g. 0x1234)'
+          }
+        },
         reboot: '重新啟動',
         rebootDesc: '您確定要重新啟動 NanoKVM?',
         okBtn: '確定',

--- a/web/src/pages/desktop/menu/settings/device/index.tsx
+++ b/web/src/pages/desktop/menu/settings/device/index.tsx
@@ -9,6 +9,7 @@ import { Oled } from './oled.tsx';
 import { Reboot } from './reboot.tsx';
 import { Ssh } from './ssh.tsx';
 import { Tls } from './tls.tsx';
+import { UsbDescriptor } from './usb-descriptor';
 import { VirtualDevices } from './virtual-devices.tsx';
 import { Wifi } from './wifi.tsx';
 
@@ -28,6 +29,9 @@ export const Device = () => {
         <Divider className="opacity-50" />
 
         <VirtualDevices />
+        <Divider className="opacity-50" />
+
+        <UsbDescriptor />
         <Divider className="opacity-50" />
 
         <Oled />

--- a/web/src/pages/desktop/menu/settings/device/usb-descriptor/index.tsx
+++ b/web/src/pages/desktop/menu/settings/device/usb-descriptor/index.tsx
@@ -1,0 +1,355 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Button, Divider, Input, Modal, Select, message } from 'antd';
+import { useTranslation } from 'react-i18next';
+
+import * as api from '@/api/usb-descriptor.ts';
+
+import { presets } from './presets.ts';
+
+type Descriptor = {
+  vendorName: string;
+  productName: string;
+  serialNumber: string;
+  vid: string;
+  pid: string;
+};
+
+const emptyDescriptor: Descriptor = {
+  vendorName: '',
+  productName: '',
+  serialNumber: '',
+  vid: '0x0000',
+  pid: '0x0000'
+};
+
+function randomSerial(): string {
+  const bytes = new Uint8Array(8);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+    .toUpperCase();
+}
+
+function isValidHex(value: string): boolean {
+  return /^0x[0-9A-Fa-f]{1,4}$/.test(value);
+}
+
+export const UsbDescriptor = () => {
+  const { t } = useTranslation();
+
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [originalDescriptor, setOriginalDescriptor] = useState<Descriptor>(emptyDescriptor);
+  const [editedDescriptor, setEditedDescriptor] = useState<Descriptor>(emptyDescriptor);
+  const [selectedPreset, setSelectedPreset] = useState<string>('custom');
+  const [confirmModalOpen, setConfirmModalOpen] = useState(false);
+  const [error, setError] = useState('');
+
+  const readDescriptor = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const rsp = await api.getUsbDescriptor();
+      if (rsp.code !== 0) {
+        setError(rsp.msg);
+        return;
+      }
+      const desc: Descriptor = rsp.data.descriptor;
+      setOriginalDescriptor(desc);
+      setEditedDescriptor(desc);
+
+      const matchingPreset = presets.find(
+        (p) =>
+          p.descriptor.vendorName === desc.vendorName &&
+          p.descriptor.productName === desc.productName &&
+          p.descriptor.vid.toLowerCase() === desc.vid.toLowerCase() &&
+          p.descriptor.pid.toLowerCase() === desc.pid.toLowerCase()
+      );
+      setSelectedPreset(matchingPreset ? matchingPreset.id : 'custom');
+    } catch {
+      setError(t('settings.device.usbDescriptor.errors.readFailed'));
+    } finally {
+      setLoading(false);
+    }
+  }, [t]);
+
+  useEffect(() => {
+    readDescriptor();
+  }, [readDescriptor]);
+
+  const hasChanges = useMemo(() => {
+    return (
+      editedDescriptor.vendorName !== originalDescriptor.vendorName ||
+      editedDescriptor.productName !== originalDescriptor.productName ||
+      editedDescriptor.serialNumber !== originalDescriptor.serialNumber ||
+      editedDescriptor.vid !== originalDescriptor.vid ||
+      editedDescriptor.pid !== originalDescriptor.pid
+    );
+  }, [editedDescriptor, originalDescriptor]);
+
+  const vidPidChanged = useMemo(() => {
+    return (
+      editedDescriptor.vid !== originalDescriptor.vid ||
+      editedDescriptor.pid !== originalDescriptor.pid
+    );
+  }, [editedDescriptor, originalDescriptor]);
+
+  function updateField(field: keyof Descriptor, value: string): void {
+    setEditedDescriptor((prev) => ({ ...prev, [field]: value }));
+    setSelectedPreset('custom');
+  }
+
+  function handlePresetChange(presetId: string): void {
+    setSelectedPreset(presetId);
+    if (presetId === 'custom') return;
+
+    const preset = presets.find((p) => p.id === presetId);
+    if (preset) {
+      setEditedDescriptor((prev) => ({
+        ...prev,
+        vendorName: preset.descriptor.vendorName,
+        productName: preset.descriptor.productName,
+        vid: preset.descriptor.vid,
+        pid: preset.descriptor.pid
+      }));
+    }
+  }
+
+  function handleRandomSerial(): void {
+    const serial = randomSerial();
+    setEditedDescriptor((prev) => ({ ...prev, serialNumber: serial }));
+    setSelectedPreset('custom');
+  }
+
+  async function handleApply(): Promise<void> {
+    if (!isValidHex(editedDescriptor.vid) || !isValidHex(editedDescriptor.pid)) {
+      setError(t('settings.device.usbDescriptor.errors.invalidHex'));
+      return;
+    }
+
+    if (vidPidChanged) {
+      setConfirmModalOpen(true);
+      return;
+    }
+    await applyChanges();
+  }
+
+  async function applyChanges(): Promise<void> {
+    setConfirmModalOpen(false);
+    setSaving(true);
+    setError('');
+    try {
+      const rsp = await api.setUsbDescriptor(editedDescriptor);
+      if (rsp.code !== 0) {
+        setError(rsp.msg);
+        return;
+      }
+      message.success(t('settings.device.usbDescriptor.applySuccess'));
+      await readDescriptor();
+    } catch {
+      setError(t('settings.device.usbDescriptor.errors.writeFailed'));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleRestore(): Promise<void> {
+    setSaving(true);
+    setError('');
+    try {
+      const rsp = await api.restoreUsbDefaults();
+      if (rsp.code !== 0) {
+        setError(rsp.msg);
+        return;
+      }
+      message.success(t('settings.device.usbDescriptor.restoreSuccess'));
+      await readDescriptor();
+    } catch {
+      setError(t('settings.device.usbDescriptor.errors.restoreFailed'));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const presetOptions = [
+    {
+      label: t('settings.device.usbDescriptor.presetGroups.generic'),
+      options: presets
+        .filter((p) => p.group === 'generic')
+        .map((p) => ({ value: p.id, label: t(p.labelKey) }))
+    },
+    {
+      label: t('settings.device.usbDescriptor.presetGroups.brand'),
+      options: presets
+        .filter((p) => p.group === 'brand')
+        .map((p) => ({ value: p.id, label: t(p.labelKey) }))
+    },
+    {
+      label: '',
+      options: [{ value: 'custom', label: t('settings.device.usbDescriptor.presetGroups.custom') }]
+    }
+  ];
+
+  const vendorLen = editedDescriptor.vendorName.length;
+  const productLen = editedDescriptor.productName.length;
+  const serialLen = editedDescriptor.serialNumber.length;
+  const maxLen = 126;
+
+  return (
+    <>
+      <div className="flex flex-col space-y-1">
+        <span>{t('settings.device.usbDescriptor.title')}</span>
+        <span className="text-xs text-neutral-500">
+          {t('settings.device.usbDescriptor.description')}
+        </span>
+      </div>
+
+      <div className="space-y-4 pt-2">
+        {error && (
+          <div className="rounded-lg border border-red-600/30 bg-red-600/10 p-3 text-sm text-red-400">
+            {error}
+          </div>
+        )}
+
+        {/* Preset selector */}
+        <div className="flex items-center justify-between">
+          <span>{t('settings.device.usbDescriptor.preset')}</span>
+          <Select
+            value={selectedPreset}
+            style={{ width: 240 }}
+            options={presetOptions}
+            onChange={handlePresetChange}
+            loading={loading}
+          />
+        </div>
+
+        <Divider className="opacity-50" />
+
+        {/* Vendor Name */}
+        <div className="flex items-center justify-between">
+          <div className="flex flex-col">
+            <span>{t('settings.device.usbDescriptor.vendorName')}</span>
+            <span className="text-xs text-neutral-500">
+              {vendorLen}/{maxLen} {t('settings.device.usbDescriptor.chars')}
+            </span>
+          </div>
+          <Input
+            value={editedDescriptor.vendorName}
+            style={{ width: 240 }}
+            maxLength={maxLen}
+            status={vendorLen > maxLen ? 'error' : undefined}
+            onChange={(e) => updateField('vendorName', e.target.value)}
+            disabled={loading}
+          />
+        </div>
+
+        {/* Product Name */}
+        <div className="flex items-center justify-between">
+          <div className="flex flex-col">
+            <span>{t('settings.device.usbDescriptor.productName')}</span>
+            <span className="text-xs text-neutral-500">
+              {productLen}/{maxLen} {t('settings.device.usbDescriptor.chars')}
+            </span>
+          </div>
+          <Input
+            value={editedDescriptor.productName}
+            style={{ width: 240 }}
+            maxLength={maxLen}
+            status={productLen > maxLen ? 'error' : undefined}
+            onChange={(e) => updateField('productName', e.target.value)}
+            disabled={loading}
+          />
+        </div>
+
+        {/* Serial Number */}
+        <div className="flex items-center justify-between">
+          <div className="flex flex-col">
+            <span>{t('settings.device.usbDescriptor.serialNumber')}</span>
+            <span className="text-xs text-neutral-500">
+              {serialLen}/{maxLen} {t('settings.device.usbDescriptor.chars')}
+            </span>
+          </div>
+          <div className="flex items-center space-x-2">
+            <Input
+              value={editedDescriptor.serialNumber}
+              style={{ width: 170 }}
+              maxLength={maxLen}
+              status={serialLen > maxLen ? 'error' : undefined}
+              onChange={(e) => updateField('serialNumber', e.target.value)}
+              disabled={loading}
+            />
+            <Button size="small" onClick={handleRandomSerial} disabled={loading}>
+              {t('settings.device.usbDescriptor.randomize')}
+            </Button>
+          </div>
+        </div>
+
+        <Divider className="opacity-50" />
+
+        {/* VID */}
+        <div className="flex items-center justify-between">
+          <span>VID</span>
+          <Input
+            value={editedDescriptor.vid}
+            style={{ width: 240 }}
+            onChange={(e) => updateField('vid', e.target.value)}
+            disabled={loading}
+          />
+        </div>
+
+        {/* PID */}
+        <div className="flex items-center justify-between">
+          <span>PID</span>
+          <Input
+            value={editedDescriptor.pid}
+            style={{ width: 240 }}
+            onChange={(e) => updateField('pid', e.target.value)}
+            disabled={loading}
+          />
+        </div>
+
+        {vidPidChanged && (
+          <div className="rounded-lg border border-amber-600/30 bg-amber-600/10 p-3 text-sm text-amber-400">
+            {t('settings.device.usbDescriptor.vidPidWarning')}
+          </div>
+        )}
+
+        <Divider className="opacity-50" />
+
+        {/* Action buttons */}
+        <div className="flex items-center justify-between">
+          <div className="flex space-x-2">
+            <Button onClick={readDescriptor} disabled={loading || saving}>
+              {t('settings.device.usbDescriptor.readDevice')}
+            </Button>
+            <Button danger onClick={handleRestore} disabled={loading || saving}>
+              {t('settings.device.usbDescriptor.restoreDefaults')}
+            </Button>
+          </div>
+          <Button
+            type="primary"
+            onClick={handleApply}
+            disabled={!hasChanges || loading || saving}
+            loading={saving}
+          >
+            {t('settings.device.usbDescriptor.apply')}
+          </Button>
+        </div>
+      </div>
+
+      {/* VID/PID confirmation modal */}
+      <Modal
+        title={t('settings.device.usbDescriptor.confirmTitle')}
+        open={confirmModalOpen}
+        onOk={applyChanges}
+        onCancel={() => setConfirmModalOpen(false)}
+        okText={t('settings.device.usbDescriptor.confirm')}
+        cancelText={t('settings.device.usbDescriptor.cancel')}
+        okButtonProps={{ danger: true }}
+      >
+        <p>{t('settings.device.usbDescriptor.confirmMessage')}</p>
+      </Modal>
+    </>
+  );
+};

--- a/web/src/pages/desktop/menu/settings/device/usb-descriptor/presets.ts
+++ b/web/src/pages/desktop/menu/settings/device/usb-descriptor/presets.ts
@@ -1,0 +1,102 @@
+export type UsbPreset = {
+  id: string;
+  labelKey: string;
+  group: 'generic' | 'brand';
+  descriptor: {
+    vendorName: string;
+    productName: string;
+    vid: string;
+    pid: string;
+  };
+};
+
+export const presets: UsbPreset[] = [
+  {
+    id: 'generic-keyboard',
+    labelKey: 'settings.device.usbDescriptor.presets.genericKeyboard',
+    group: 'generic',
+    descriptor: {
+      vendorName: 'USB',
+      productName: 'USB Keyboard',
+      vid: '0x0001',
+      pid: '0x0001'
+    }
+  },
+  {
+    id: 'generic-mouse',
+    labelKey: 'settings.device.usbDescriptor.presets.genericMouse',
+    group: 'generic',
+    descriptor: {
+      vendorName: 'USB',
+      productName: 'USB Mouse',
+      vid: '0x0001',
+      pid: '0x0001'
+    }
+  },
+  {
+    id: 'generic-composite',
+    labelKey: 'settings.device.usbDescriptor.presets.genericComposite',
+    group: 'generic',
+    descriptor: {
+      vendorName: 'USB',
+      productName: 'USB Composite Device',
+      vid: '0x0001',
+      pid: '0x0001'
+    }
+  },
+  {
+    id: 'generic-hid',
+    labelKey: 'settings.device.usbDescriptor.presets.genericHid',
+    group: 'generic',
+    descriptor: {
+      vendorName: 'USB',
+      productName: 'USB HID Device',
+      vid: '0x0001',
+      pid: '0x0001'
+    }
+  },
+  {
+    id: 'logitech-keyboard',
+    labelKey: 'settings.device.usbDescriptor.presets.logitechKeyboard',
+    group: 'brand',
+    descriptor: {
+      vendorName: 'Logitech',
+      productName: 'Logitech Keyboard K120',
+      vid: '0x046D',
+      pid: '0xC31C'
+    }
+  },
+  {
+    id: 'logitech-mouse',
+    labelKey: 'settings.device.usbDescriptor.presets.logitechMouse',
+    group: 'brand',
+    descriptor: {
+      vendorName: 'Logitech',
+      productName: 'Logitech USB Optical Mouse',
+      vid: '0x046D',
+      pid: '0xC077'
+    }
+  },
+  {
+    id: 'microsoft-keyboard',
+    labelKey: 'settings.device.usbDescriptor.presets.microsoftKeyboard',
+    group: 'brand',
+    descriptor: {
+      vendorName: 'Microsoft',
+      productName: 'Microsoft Wired Keyboard',
+      vid: '0x045E',
+      pid: '0x0750'
+    }
+  },
+  {
+    id: 'dell-keyboard',
+    labelKey: 'settings.device.usbDescriptor.presets.dellKeyboard',
+    group: 'brand',
+    descriptor: {
+      vendorName: 'Dell',
+      productName: 'Dell KB216 Keyboard',
+      vid: '0x413C',
+      pid: '0x2113'
+    }
+  }
+];


### PR DESCRIPTION
## What this does

Right now, every NanoKVM shows up to the target machine as `sipeed NanoKVM` with VID `0x3346` / PID `0x1009`. That makes it pretty obvious a KVM is plugged in. This PR adds a **USB Descriptor** section to **Settings > Device** that lets you change the manufacturer name, product name, serial number, VID, and PID to whatever you want.

There are 8 built-in presets (generic keyboard/mouse/composite/HID, plus Logitech K120, Logitech Mouse, Microsoft Keyboard, Dell KB216) or you can type in fully custom values. Changes take effect immediately — the target sees a brief USB reconnect, no NanoKVM reboot needed — and they survive reboots.

## UI Screenshot

<img width="1082" height="596" alt="Screenshot 2026-02-17 at 6 49 03 PM" src="https://github.com/user-attachments/assets/00523ad6-8b4b-41e0-afee-cc7ba65816e3" />

## How it works under the hood

The backend reads and writes the Linux USB gadget ConfigFS files under `/sys/kernel/config/usb_gadget/g0/`. To apply changes it locks HID, unbinds the UDC, writes the new values, and rebinds — same pattern the existing virtual disk mount uses. Boot persistence follows the same approach already used for VID/PID overrides (`/boot/usb.vid`, `/boot/usb.pid`), extended to `manufacturer`, `product`, and `serial`.

## What changed

- 3 new API endpoints on `/api/hid/usb-descriptor` (get, set, restore defaults)
- `S03usbdev` init script now reads `/boot/usb.{manufacturer,product,serial}` at startup
- New settings UI component with presets, field validation, serial randomizer, and a confirmation modal for VID/PID changes
- i18n keys added to all 24 locale files

## Testing

Tested on hardware. Presets populate correctly, custom values apply and show up in `lsusb` on the target, VID/PID changes trigger the warning/confirmation flow, serial randomization works, restore defaults cleans everything up, and values persist across reboots.

Addresses #745
Addresses #574
Addresses #104