### PR TITLE
Fix `/data` partition type and label during first-boot provisioning

### DIFF
--- a/kvmapp/system/init.d/S01fs
+++ b/kvmapp/system/init.d/S01fs
@@ -24,10 +24,11 @@ then
                 then
                         touch /etc/kvm.disk0
                         # use all sdcard free space for data
-                        parted -s /dev/mmcblk0 "mkpart primary 8193MB 100%"
+                        # Create as NTFS type so MBR ID is 0x07 (Microsoft basic data, used by exFAT).
+                        parted -s /dev/mmcblk0 "mkpart primary ntfs 8193MB 100%"
                         sleep 1
-                        # resize data filesystem
-                        (mkfs.exfat /dev/mmcblk0p3) &
+                        # format data filesystem and set volume label
+                        mkfs.exfat -L data /dev/mmcblk0p3
                         sleep 1
                 fi
         fi


### PR DESCRIPTION
- Use parted NTFS type when creating `mmcblk0p3` so MBR ID is `0x07` ([Microsoft basic data partition, NTFS/exFAT]) instead of Linux `0x83`.
- Format the partition with a label.

Fixes: #763

[Microsoft basic data partition, NTFS/exFAT]: https://en.wikipedia.org/wiki/Microsoft_basic_data_partition