### PR TITLE
Enable support for 640x480 resolution

### DIFF
--- a/support/sg2002/additional/kvm/src/kvm_vision.cpp
+++ b/support/sg2002/additional/kvm/src/kvm_vision.cpp
@@ -164,6 +164,7 @@ uint16_t hdmi_res_list[][2] = {
     {1152, 864},
     {1024, 768},
     {800, 600},
+	{640, 480},
 };
 
 uint16_t hdmi_unsupported_res_list[][2] = {


### PR DESCRIPTION
For release v1.4.0 (app version 2.2.0), there was inherent support for almost all types of displays (including 640x480), 
but in app release 2.2.2, some resolutions were hardcoded, disabling support for 640x480. This commits aims to change that 