### PR TITLE
Fix wrong message during support build

### DIFF
--- a/support/sg2002/build
+++ b/support/sg2002/build
@@ -162,7 +162,13 @@ then
       if [ -e $SOURCE_PATH ]
       then
         cp -rf $SOURCE_PATH $TARGET_PATH
-        echo -e "\e[36m[build] \e[32mkvm_system has been moved to kvmapp.\e[0m"
+        if [ "$Project_Name" = "kvm_system" ]
+        then
+          echo -e "\e[36m[build] \e[32mkvm_system has been moved to kvmapp.\e[0m"
+        else
+          echo -e "\e[36m[build] \e[32mkvm_vision has been moved to kvmapp.\e[0m"
+        fi
+        
       else
         echo -e "\e[36m[build] \e[31mThe source file does not exist. Please compile using \e[34m./build kvm_system \e[31mfirst.\e[0m"
       fi

--- a/support/sg2002/build
+++ b/support/sg2002/build
@@ -58,7 +58,7 @@ case "$1" in
   kvm_vision)
     Project_Name="kvm_vision"
     Project_PATH="$NanoKVM_PATH/support/sg2002/kvm_vision_test"
-    echo -e "\e[36m[build] \e[32mProject: kvm_system \e[0m"
+    echo -e "\e[36m[build] \e[32mProject: kvm_vision \e[0m"
   ;;
   *)
     echo -e "\e[36m[build] \e[31mInvalid project name \e[0m"


### PR DESCRIPTION
## Setup:
```
cd support/sg2002
./build kvm_vision add_to_kvmapp
```

## Result:
[build] Project: kvm_system 
[build] kvm_system has been moved to kvmapp.

## Expected Result
[build] Project: kvm_vision
[build] kvm_vision has been moved to kvmapp.

## Result after fix
[build] Project: kvm_vision
[build] kvm_vision has been moved to kvmapp.