### PR TITLE
feat(web): improve login persistence and screen interactfeat(web): 优化登录持久化与桌面交互体验 / Improve login persistence and desktop interactionsions

### DIFF
--- a/web/src/assets/styles/index.css
+++ b/web/src/assets/styles/index.css
@@ -7,6 +7,7 @@ body {
   padding: 0;
   margin: 0;
   background: #000;
+  overflow: hidden;
 }
 
 ::-webkit-scrollbar {

--- a/web/src/hooks/useMenuBounds.ts
+++ b/web/src/hooks/useMenuBounds.ts
@@ -15,11 +15,10 @@ export function useMenuBounds(
   isMenuExpanded: boolean
 ): MenuBounds {
   const menuDisabledItems = useAtomValue(menuDisabledItemsAtom);
-  const [menuBounds, setMenuBounds] = useState<MenuBounds>({
-    left: 0,
-    right: 0,
-    top: 0,
-    bottom: 0
+  const [menuBounds, setMenuBounds] = useState<MenuBounds>(() => {
+    const hw = window.innerWidth / 2;
+    const hh = window.innerHeight;
+    return { left: -hw, right: hw, top: -100, bottom: hh };
   });
 
   const handleResize = useCallback(() => {

--- a/web/src/hooks/useMenuSnap.ts
+++ b/web/src/hooks/useMenuSnap.ts
@@ -1,0 +1,113 @@
+import { RefObject, useCallback, useEffect, useRef, useState } from 'react';
+
+import {
+  getMenuSnapEdge,
+  getMenuSnapOffset,
+  setMenuSnapEdge,
+  setMenuSnapOffset,
+  type SnapEdge
+} from '@/lib/localstorage.ts';
+
+/** Distance from each edge (px) that triggers snap */
+const SNAP_THRESHOLD = 80;
+/** How many px of the panel remain visible when snapped (the "indicator strip") */
+export const SNAP_PEEK = 6;
+/** Hover zone width (px) on the indicator strip to trigger pop-out */
+export const SNAP_HOVER_ZONE = 28;
+
+export interface SnapState {
+  edge: SnapEdge;
+  /** normalised position along the perpendicular axis [0,1] */
+  offset: number;
+}
+
+export interface UseMenuSnapReturn {
+  snapState: SnapState;
+  isSnapHovered: boolean;
+  /** Call at drag-stop with node rect + final absolute position */
+  onDragStop: (nodeRef: RefObject<HTMLElement | null>) => void;
+  /** Update hover state when mouse enters/leaves indicator */
+  setSnapHovered: (v: boolean) => void;
+  /** Un-snap (release from edge) */
+  clearSnap: () => void;
+}
+
+export function useMenuSnap(): UseMenuSnapReturn {
+  const [snapState, setSnapState] = useState<SnapState>(() => ({
+    edge: getMenuSnapEdge(),
+    offset: getMenuSnapOffset()
+  }));
+  const [isSnapHovered, setIsSnapHoveredRaw] = useState(false);
+  const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Persist whenever snap changes
+  useEffect(() => {
+    setMenuSnapEdge(snapState.edge);
+    setMenuSnapOffset(snapState.offset);
+  }, [snapState]);
+
+  const onDragStop = useCallback((nodeRef: RefObject<HTMLElement | null>) => {
+    const el = nodeRef.current;
+    if (!el) return;
+
+    const rect = el.getBoundingClientRect();
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+
+    // Distances from each edge
+    const dTop = rect.top;
+    const dBottom = vh - rect.bottom;
+    const dLeft = rect.left;
+    const dRight = vw - rect.right;
+
+    const min = Math.min(dTop, dBottom, dLeft, dRight);
+
+    if (min > SNAP_THRESHOLD) {
+      // Not close enough to any edge — clear snap
+      setSnapState({ edge: null, offset: 0.5 });
+      return;
+    }
+
+    let edge: SnapEdge = null;
+    let offset = 0.5;
+
+    if (min === dTop) {
+      edge = 'top';
+      offset = (rect.left + rect.width / 2) / vw;
+    } else if (min === dBottom) {
+      edge = 'bottom';
+      offset = (rect.left + rect.width / 2) / vw;
+    } else if (min === dLeft) {
+      edge = 'left';
+      offset = (rect.top + rect.height / 2) / vh;
+    } else {
+      edge = 'right';
+      offset = (rect.top + rect.height / 2) / vh;
+    }
+
+    offset = Math.max(0.05, Math.min(0.95, offset));
+    setSnapState({ edge, offset });
+  }, []);
+
+  const setSnapHovered = useCallback((v: boolean) => {
+    if (hoverTimerRef.current) {
+      clearTimeout(hoverTimerRef.current);
+      hoverTimerRef.current = null;
+    }
+    if (v) {
+      setIsSnapHoveredRaw(true);
+    } else {
+      // Small delay before hiding so cursor can travel to the expanded panel
+      hoverTimerRef.current = setTimeout(() => {
+        setIsSnapHoveredRaw(false);
+      }, 300);
+    }
+  }, []);
+
+  const clearSnap = useCallback(() => {
+    setSnapState({ edge: null, offset: 0.5 });
+    setIsSnapHoveredRaw(false);
+  }, []);
+
+  return { snapState, isSnapHovered, onDragStop, setSnapHovered, clearSnap };
+}

--- a/web/src/hooks/useScreenFitScale.ts
+++ b/web/src/hooks/useScreenFitScale.ts
@@ -1,0 +1,63 @@
+import { useEffect, useRef, useState } from 'react';
+import { useAtomValue } from 'jotai';
+
+import { resolutionAtom } from '@/jotai/screen.ts';
+
+/**
+ * Computes a fit-scale so that the remote screen (native resolution) is
+ * always contained within the given container element without overflow.
+ *
+ * Returns 1 when the native resolution is unknown or smaller than the container.
+ * The caller should apply:  transform: scale(fitScale * userVideoScale)
+ *
+ * Mouse coordinate mapping in absolute.tsx remains correct because:
+ * - The element keeps its CSS size at native resolution (nativeW × nativeH)
+ * - transform: scale(S) makes getBoundingClientRect() return nativeW*S × nativeH*S
+ * - getMediaSize() returns the real native size (videoWidth/naturalWidth/canvas.width)
+ * - mediaRatio === elementRatio after uniform scale → getCorrectedCoords maps correctly
+ */
+export function useScreenFitScale(containerRef: React.RefObject<HTMLElement | null>): number {
+  const resolution = useAtomValue(resolutionAtom);
+  const [fitScale, setFitScale] = useState(1);
+  // Keep a stable ref to avoid re-creating the ResizeObserver on every render
+  const resolutionRef = useRef(resolution);
+  resolutionRef.current = resolution;
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    function compute() {
+      const res = resolutionRef.current;
+      if (!res?.width || !res?.height) {
+        setFitScale(1);
+        return;
+      }
+      const cw = el!.clientWidth;
+      const ch = el!.clientHeight;
+      if (cw === 0 || ch === 0) return;
+      setFitScale(Math.min(cw / res.width, ch / res.height));
+    }
+
+    compute();
+
+    const ro = new ResizeObserver(compute);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [containerRef]);
+
+  // Also recompute when resolution changes
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el || !resolution?.width || !resolution?.height) {
+      setFitScale(1);
+      return;
+    }
+    const cw = el.clientWidth;
+    const ch = el.clientHeight;
+    if (cw === 0 || ch === 0) return;
+    setFitScale(Math.min(cw / resolution.width, ch / resolution.height));
+  }, [containerRef, resolution]);
+
+  return fitScale;
+}

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -28,6 +28,8 @@ const en = {
       ok: 'Ok',
       cancel: 'Cancel',
       loginButtonText: 'Login',
+      rememberPassword: 'Remember Password',
+      autoLogin: 'Auto Login',
       tips: {
         reset1:
           'To reset the passwords, press and hold the BOOT button on the NanoKVM for 10 seconds.',

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -28,6 +28,8 @@ const zh = {
       ok: '确定',
       cancel: '取消',
       loginButtonText: '登录',
+      rememberPassword: '记住密码',
+      autoLogin: '自动登录',
       tips: {
         reset1: '长按 NanoKVM 上的 BOOT 按键 10 秒钟来重置帐号。',
         reset2: '详细操作步骤可参考此文档：',

--- a/web/src/lib/localstorage.ts
+++ b/web/src/lib/localstorage.ts
@@ -18,6 +18,8 @@ const KEYBOARD_LANGUAGE_KEY = 'nano-kvm-keyboard-language';
 const SKIP_MODIFY_PASSWORD_KEY = 'nano-kvm-skip-modify-password';
 const MENU_DISABLED_ITEMS_KEY = 'nano-kvm-menu-disabled-items';
 const MENU_AUTO_HIDE_KEY = 'nano-kvm-menu-auto-hide';
+const MENU_SNAP_EDGE_KEY = 'nano-kvm-menu-snap-edge';
+const MENU_SNAP_OFFSET_KEY = 'nano-kvm-menu-snap-offset';
 const POWER_CONFIRM_KEY = 'nano-kvm-power-confirm';
 
 type ItemWithExpiry = {
@@ -229,4 +231,31 @@ export function getPowerConfirm() {
 
 export function setPowerConfirm(enabled: boolean) {
   localStorage.setItem(POWER_CONFIRM_KEY, String(enabled));
+}
+
+export type SnapEdge = 'top' | 'bottom' | 'left' | 'right' | null;
+
+export function getMenuSnapEdge(): SnapEdge {
+  const v = localStorage.getItem(MENU_SNAP_EDGE_KEY);
+  if (v === 'top' || v === 'bottom' || v === 'left' || v === 'right') return v;
+  return null;
+}
+
+export function setMenuSnapEdge(edge: SnapEdge) {
+  if (edge === null) {
+    localStorage.removeItem(MENU_SNAP_EDGE_KEY);
+  } else {
+    localStorage.setItem(MENU_SNAP_EDGE_KEY, edge);
+  }
+}
+
+// Perpendicular axis normalized position [0,1] when snapped (e.g. left/right edge => vertical %)
+export function getMenuSnapOffset(): number {
+  const v = localStorage.getItem(MENU_SNAP_OFFSET_KEY);
+  const n = parseFloat(v ?? '');
+  return isNaN(n) ? 0.5 : Math.max(0, Math.min(1, n));
+}
+
+export function setMenuSnapOffset(offset: number) {
+  localStorage.setItem(MENU_SNAP_OFFSET_KEY, String(offset));
 }

--- a/web/src/pages/auth/login/index.tsx
+++ b/web/src/pages/auth/login/index.tsx
@@ -1,6 +1,6 @@
 import { ReactElement, useEffect, useState } from 'react';
 import { LockOutlined, UserOutlined } from '@ant-design/icons';
-import { Button, Form, Input } from 'antd';
+import { Button, Checkbox, Form, Input } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
@@ -11,16 +11,46 @@ import { Head } from '@/components/head.tsx';
 
 import { Tips } from './tips.tsx';
 
+const REMEMBER_KEY = 'nano-kvm-remember';
+
+interface SavedCredentials {
+  username: string;
+  password: string;
+  autoLogin: boolean;
+}
+
 export const Login = (): ReactElement => {
   const navigate = useNavigate();
   const { t } = useTranslation();
+  const [form] = Form.useForm();
 
   const [isLoading, setIsloading] = useState(false);
   const [msg, setMsg] = useState('');
+  const [rememberChecked, setRememberChecked] = useState(false);
 
   useEffect(() => {
     if (existToken()) {
       navigate('/', { replace: true });
+      return;
+    }
+
+    try {
+      const saved = localStorage.getItem(REMEMBER_KEY);
+      if (saved) {
+        const creds: SavedCredentials = JSON.parse(saved);
+        form.setFieldsValue({
+          username: creds.username,
+          password: creds.password,
+          remember: true,
+          autoLogin: creds.autoLogin
+        });
+        setRememberChecked(true);
+        if (creds.autoLogin) {
+          doLogin({ username: creds.username, password: creds.password, remember: true, autoLogin: true });
+        }
+      }
+    } catch {
+      localStorage.removeItem(REMEMBER_KEY);
     }
   }, []);
 
@@ -30,7 +60,7 @@ export const Login = (): ReactElement => {
     }
   }, [msg]);
 
-  function login(values: any) {
+  function doLogin(values: any) {
     if (isLoading) return;
     setIsloading(true);
 
@@ -48,6 +78,19 @@ export const Login = (): ReactElement => {
 
           setMsg(errorMsg);
           return;
+        }
+
+        if (values.remember) {
+          localStorage.setItem(
+            REMEMBER_KEY,
+            JSON.stringify({
+              username: values.username,
+              password: values.password,
+              autoLogin: values.autoLogin || false
+            } as SavedCredentials)
+          );
+        } else {
+          localStorage.removeItem(REMEMBER_KEY);
         }
 
         setMsg('');
@@ -70,9 +113,10 @@ export const Login = (): ReactElement => {
 
       <div className="flex h-screen w-screen flex-col items-center justify-center">
         <Form
+          form={form}
           style={{ minWidth: 300, maxWidth: 500 }}
-          initialValues={{ remember: true }}
-          onFinish={login}
+          initialValues={{ remember: false, autoLogin: false }}
+          onFinish={doLogin}
         >
           <div className="flex flex-col items-center justify-center pb-4">
             <img
@@ -105,6 +149,24 @@ export const Login = (): ReactElement => {
               placeholder={t('auth.placeholderPassword')}
             />
           </Form.Item>
+
+          <div className="flex items-center justify-between pb-3">
+            <Form.Item name="remember" valuePropName="checked" noStyle>
+              <Checkbox
+                onChange={(e) => {
+                  setRememberChecked(e.target.checked);
+                  if (!e.target.checked) {
+                    form.setFieldValue('autoLogin', false);
+                  }
+                }}
+              >
+                {t('auth.rememberPassword')}
+              </Checkbox>
+            </Form.Item>
+            <Form.Item name="autoLogin" valuePropName="checked" noStyle>
+              <Checkbox disabled={!rememberChecked}>{t('auth.autoLogin')}</Checkbox>
+            </Form.Item>
+          </div>
 
           <div className="pb-1 text-red-500">{msg}</div>
 

--- a/web/src/pages/desktop/menu/index.tsx
+++ b/web/src/pages/desktop/menu/index.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Divider } from 'antd';
 import clsx from 'clsx';
 import { useAtomValue } from 'jotai';
@@ -8,6 +8,7 @@ import Draggable, { DraggableData, DraggableEvent } from 'react-draggable';
 import { menuDisabledItemsAtom } from '@/jotai/settings.ts';
 import { useMenuBounds } from '@/hooks/useMenuBounds.ts';
 import { useMenuVisibility } from '@/hooks/useMenuVisibility.ts';
+import { useMenuSnap, SNAP_PEEK, SNAP_HOVER_ZONE } from '@/hooks/useMenuSnap.ts';
 
 import { DownloadImage } from './download.tsx';
 import { Fullscreen } from './fullscreen';
@@ -26,6 +27,11 @@ import { Wol } from './wol';
 export const Menu = () => {
   const nodeRef = useRef<HTMLDivElement | null>(null);
 
+  // Track the last drag position so we can restore it after unsnapping
+  const savedPosRef = useRef({ x: 0, y: 0 });
+  // Incrementing this key forces the Draggable to re-mount at savedPosRef
+  const [unSnapKey, setUnSnapKey] = useState(0);
+
   const menuDisabledItems = useAtomValue(menuDisabledItemsAtom);
 
   const {
@@ -38,23 +44,279 @@ export const Menu = () => {
   } = useMenuVisibility();
 
   const menuBounds = useMenuBounds(nodeRef, isMenuExpanded);
+  const { snapState, isSnapHovered, onDragStop, setSnapHovered, clearSnap } = useMenuSnap();
 
-  function onDragStop(_e: DraggableEvent, data: DraggableData) {
+  const isSnapped = snapState.edge !== null;
+  const edge = snapState.edge;
+
+  // Ref to measure the popped-out panel's actual rendered size
+  const snapPanelRef = useRef<HTMLDivElement>(null);
+  // Clamped normalised offset so the panel never goes off-screen
+  const [clampedOffset, setClampedOffset] = useState(snapState.offset);
+
+  useEffect(() => {
+    if (!isSnapped) return;
+    const el = snapPanelRef.current;
+    if (!el) return;
+
+    const isHorizontal = edge === 'top' || edge === 'bottom';
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+
+    if (isHorizontal) {
+      const halfW = el.offsetWidth / 2;
+      const raw = snapState.offset * vw;
+      const clamped = Math.max(halfW + 4, Math.min(vw - halfW - 4, raw));
+      setClampedOffset(clamped / vw);
+    } else {
+      const halfH = el.offsetHeight / 2;
+      const raw = snapState.offset * vh;
+      const clamped = Math.max(halfH + 4, Math.min(vh - halfH - 4, raw));
+      setClampedOffset(clamped / vh);
+    }
+  }, [isSnapped, edge, snapState.offset, isSnapHovered]);
+
+  function handleDragStop(_e: DraggableEvent, data: DraggableData) {
+    // Always save position so we can restore it on unsnap
+    savedPosRef.current = { x: data.x, y: data.y };
     if (data.x === 0 && data.y === 0) return;
+    onDragStop(nodeRef);
     handleMoved();
+  }
+
+  // Clear snap and re-mount Draggable at the last known position (near the snap edge)
+  function handleClearSnap() {
+    clearSnap();
+    setUnSnapKey((k) => k + 1);
+  }
+
+  // Handles both click and drag on the grip while snapped.
+  // Moving >= 25px = drag to release; mouseup without movement = click to release.
+  function startGripDrag(e: React.MouseEvent) {
+    e.stopPropagation();
+    e.preventDefault();
+    const startX = e.clientX;
+    const startY = e.clientY;
+    let unsnapped = false;
+
+    function onMove(ev: MouseEvent) {
+      if (unsnapped) return;
+      const dx = ev.clientX - startX;
+      const dy = ev.clientY - startY;
+      if (Math.sqrt(dx * dx + dy * dy) > 25) {
+        unsnapped = true;
+        cleanup();
+        handleClearSnap();
+      }
+    }
+
+    function onUp() {
+      cleanup();
+      if (!unsnapped) {
+        handleClearSnap();
+      }
+    }
+
+    function cleanup() {
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+    }
+
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
   }
 
   function isEnabled(item: string) {
     return !menuDisabledItems.includes(item);
   }
 
+  // Shared menu items renderer
+  function renderMenuItems(isHorizontal: boolean) {
+    const divider = (
+      <Divider
+        type={isHorizontal ? 'vertical' : 'horizontal'}
+        style={{ margin: isHorizontal ? '0' : '4px 0' }}
+      />
+    );
+    return (
+      <>
+        <Screen />
+        <Keyboard />
+        <Mouse />
+        {divider}
+
+        {isEnabled('image') && <Image />}
+        {isEnabled('download') && <DownloadImage />}
+        {isEnabled('script') && <Script />}
+        {isEnabled('terminal') && <Terminal />}
+        {isEnabled('wol') && <Wol />}
+
+        {['image', 'download', 'script', 'terminal', 'wol'].some(isEnabled) && divider}
+
+        {isEnabled('picoclaw') && (
+          <>
+            <Picoclaw />
+            {divider}
+          </>
+        )}
+
+        {isEnabled('power') && (
+          <>
+            <Power />
+            {divider}
+          </>
+        )}
+
+        <Settings />
+        {isEnabled('fullscreen') && <Fullscreen />}
+        {isEnabled('collapse') && <Collapse toggleMenu={setIsMenuExpanded} />}
+      </>
+    );
+  }
+
+  // ---- Snapped mode ----
+  if (isSnapped) {
+    const isHorizontal = edge === 'top' || edge === 'bottom';
+    // Use clamped offset so panel stays within viewport
+    const offsetPct = `${clampedOffset * 100}%`;
+
+    // Full-edge hover trigger strip.
+    // pointerEvents is disabled when panel is visible so the panel (zIndex 1002) can receive clicks.
+    const stripStyle: React.CSSProperties = isHorizontal
+      ? {
+          position: 'fixed',
+          [edge!]: 0,
+          left: 0,
+          right: 0,
+          height: SNAP_HOVER_ZONE,
+          zIndex: 1001,
+          pointerEvents: isSnapHovered ? 'none' : 'auto',
+          cursor: 'pointer'
+        }
+      : {
+          position: 'fixed',
+          [edge!]: 0,
+          top: 0,
+          bottom: 0,
+          width: SNAP_HOVER_ZONE,
+          zIndex: 1001,
+          pointerEvents: isSnapHovered ? 'none' : 'auto',
+          cursor: 'pointer'
+        };
+
+    // Visible indicator pill
+    const pillStyle: React.CSSProperties = isHorizontal
+      ? {
+          position: 'absolute',
+          [edge!]: 0,
+          left: `calc(${offsetPct} - 40px)`,
+          width: 80,
+          height: SNAP_PEEK,
+          borderRadius: edge === 'top' ? '0 0 4px 4px' : '4px 4px 0 0',
+          background: 'rgba(200,200,200,0.55)',
+          transition: 'opacity 0.2s',
+          opacity: isSnapHovered ? 0.9 : 0.5,
+          pointerEvents: 'none'
+        }
+      : {
+          position: 'absolute',
+          [edge!]: 0,
+          top: `calc(${offsetPct} - 20px)`,
+          height: 40,
+          width: SNAP_PEEK,
+          borderRadius: edge === 'left' ? '0 4px 4px 0' : '4px 0 0 4px',
+          background: 'rgba(200,200,200,0.55)',
+          transition: 'opacity 0.2s',
+          opacity: isSnapHovered ? 0.9 : 0.5,
+          pointerEvents: 'none'
+        };
+
+    // Panel sits above strip (zIndex 1002).
+    // Hidden state uses opacity+visibility ONLY — no off-screen translate,
+    // which would push the element beyond the viewport and trigger scrollbars.
+    const panelHidden: React.CSSProperties = {
+      opacity: 0,
+      visibility: 'hidden' as const,
+      pointerEvents: 'none' as const
+    };
+    const panelVisible: React.CSSProperties = {
+      opacity: 1,
+      visibility: 'visible' as const
+    };
+
+    const menuPanelStyle: React.CSSProperties = isHorizontal
+      ? {
+          position: 'fixed',
+          [edge!]: 0,
+          left: offsetPct,
+          transform: 'translateX(-50%)',
+          zIndex: 1002,
+          transition: 'opacity 0.2s ease, visibility 0.2s ease',
+          ...(isSnapHovered ? panelVisible : panelHidden)
+        }
+      : {
+          position: 'fixed',
+          [edge!]: 0,
+          top: offsetPct,
+          transform: 'translateY(-50%)',
+          zIndex: 1002,
+          maxHeight: 'calc(100dvh - 8px)',
+          overflowY: 'hidden' as const,
+          transition: 'opacity 0.2s ease, visibility 0.2s ease',
+          ...(isSnapHovered ? panelVisible : panelHidden)
+        };
+
+    return (
+      <>
+        {/* Hover trigger strip */}
+        <div style={stripStyle} onMouseEnter={() => setSnapHovered(true)}>
+          <div style={pillStyle} />
+        </div>
+
+        {/* Pop-out menu panel */}
+        <div
+          ref={snapPanelRef}
+          style={menuPanelStyle}
+          onMouseEnter={() => setSnapHovered(true)}
+          onMouseLeave={() => setSnapHovered(false)}
+        >
+          <div
+            className={clsx(
+              'flex items-center rounded bg-neutral-800/80 transition-all',
+              isHorizontal ? 'h-[36px] flex-row pl-1 pr-2' : 'w-[36px] flex-col py-1 px-0'
+            )}
+          >
+            {/* Grip — click or drag to unsnap, menu re-appears near the snap edge */}
+            <div
+              className="flex cursor-move select-none items-center justify-center px-1 text-neutral-500 hover:text-white"
+              title="拖动或点击可解除吸附"
+              onMouseDown={startGripDrag}
+            >
+              <GripVerticalIcon size={18} />
+            </div>
+
+            <Divider
+              type={isHorizontal ? 'vertical' : 'horizontal'}
+              style={{ margin: isHorizontal ? '0' : '4px 0' }}
+            />
+
+            {renderMenuItems(isHorizontal)}
+          </div>
+        </div>
+      </>
+    );
+  }
+
+  // ---- Normal floating mode ----
   return (
     <Draggable
+      key={unSnapKey}
       nodeRef={nodeRef}
       bounds={menuBounds}
       handle="strong"
       positionOffset={{ x: '-50%', y: '0%' }}
-      onStop={onDragStop}
+      defaultPosition={savedPosRef.current}
+      onStop={handleDragStop}
     >
       <div
         ref={nodeRef}
@@ -87,38 +349,7 @@ export const Menu = () => {
             </strong>
             <Divider type="vertical" />
 
-            <Screen />
-            <Keyboard />
-            <Mouse />
-            <Divider type="vertical" />
-
-            {isEnabled('image') && <Image />}
-            {isEnabled('download') && <DownloadImage />}
-            {isEnabled('script') && <Script />}
-            {isEnabled('terminal') && <Terminal />}
-            {isEnabled('wol') && <Wol />}
-
-            {['image', 'download', 'script', 'terminal', 'wol'].some(isEnabled) && (
-              <Divider type="vertical" />
-            )}
-
-            {isEnabled('picoclaw') && (
-              <>
-                <Picoclaw />
-                <Divider type="vertical" />
-              </>
-            )}
-
-            {isEnabled('power') && (
-              <>
-                <Power />
-                <Divider type="vertical" />
-              </>
-            )}
-
-            <Settings />
-            {isEnabled('fullscreen') && <Fullscreen />}
-            {isEnabled('collapse') && <Collapse toggleMenu={setIsMenuExpanded} />}
+            {renderMenuItems(true)}
           </div>
         </div>
 

--- a/web/src/pages/desktop/screen/h264-direct.tsx
+++ b/web/src/pages/desktop/screen/h264-direct.tsx
@@ -5,6 +5,7 @@ import { w3cwebsocket as W3cWebSocket } from 'websocket';
 
 import * as storage from '@/lib/localstorage.ts';
 import { getBaseUrl } from '@/lib/service.ts';
+import { useScreenFitScale } from '@/hooks/useScreenFitScale.ts';
 import { mouseStyleAtom } from '@/jotai/mouse';
 import { resolutionAtom, videoScaleAtom } from '@/jotai/screen.ts';
 
@@ -16,7 +17,10 @@ export const H264Direct = () => {
   const [videoScale, setVideoScale] = useAtom(videoScaleAtom);
 
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const workerRef = useRef<Worker | null>(null);
+
+  const fitScale = useScreenFitScale(containerRef);
 
   useEffect(() => {
     const scale = storage.getVideoScale();
@@ -69,16 +73,19 @@ export const H264Direct = () => {
   }, []);
 
   return (
-    <div className="flex h-full min-h-0 w-full min-w-0 items-center justify-center overflow-hidden">
+    <div
+      ref={containerRef}
+      className="flex h-full min-h-0 w-full min-w-0 items-center justify-center overflow-hidden"
+    >
       <canvas
         id="screen"
         ref={canvasRef}
         className={clsx('block select-none', mouseStyle)}
         style={{
-          transform: `scale(${videoScale})`,
+          transform: `scale(${fitScale * videoScale})`,
           transformOrigin: 'center',
           ...(resolution?.width
-            ? { width: resolution.width, height: resolution.height, objectFit: 'cover' }
+            ? { width: resolution.width, height: resolution.height }
             : { maxWidth: '100%', maxHeight: '100%', objectFit: 'scale-down' })
         }}
       ></canvas>

--- a/web/src/pages/desktop/screen/h264-webrtc.tsx
+++ b/web/src/pages/desktop/screen/h264-webrtc.tsx
@@ -5,6 +5,7 @@ import { w3cwebsocket as W3cWebSocket } from 'websocket';
 
 import * as storage from '@/lib/localstorage.ts';
 import { getBaseUrl } from '@/lib/service.ts';
+import { useScreenFitScale } from '@/hooks/useScreenFitScale.ts';
 import { mouseStyleAtom } from '@/jotai/mouse.ts';
 import { resolutionAtom, videoScaleAtom } from '@/jotai/screen.ts';
 
@@ -15,8 +16,11 @@ export const H264Webrtc = () => {
   const [isLoading, setIsLoading] = useState(true);
 
   const videoRef = useRef<HTMLVideoElement | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const videoOfferSent = useRef(false);
   const videoIceCandidates = useRef<RTCIceCandidate[]>([]);
+
+  const fitScale = useScreenFitScale(containerRef);
 
   useEffect(() => {
     const url = `${getBaseUrl('ws')}/api/stream/h264`;
@@ -179,16 +183,19 @@ export const H264Webrtc = () => {
 
   return (
     <div className="relative h-full min-h-0 w-full min-w-0 overflow-hidden">
-      <div className="flex h-full min-h-0 w-full min-w-0 items-center justify-center overflow-hidden">
+      <div
+        ref={containerRef}
+        className="flex h-full min-h-0 w-full min-w-0 items-center justify-center overflow-hidden"
+      >
         <video
           id="screen"
           ref={videoRef}
           className={clsx('block select-none', mouseStyle)}
           style={{
-            transform: `scale(${videoScale})`,
+            transform: `scale(${fitScale * videoScale})`,
             transformOrigin: 'center',
             ...(resolution?.width
-              ? { width: resolution.width, height: resolution.height, objectFit: 'cover' }
+              ? { width: resolution.width, height: resolution.height }
               : { maxWidth: '100%', maxHeight: '100%', objectFit: 'scale-down' })
           }}
           muted

--- a/web/src/pages/desktop/screen/mjpeg.tsx
+++ b/web/src/pages/desktop/screen/mjpeg.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
 import { useAtom, useAtomValue } from 'jotai';
 
@@ -6,6 +6,7 @@ import { stopFrameDetect } from '@/api/stream.ts';
 import { getFrameDetect } from '@/lib/localstorage.ts';
 import * as storage from '@/lib/localstorage.ts';
 import { getBaseUrl } from '@/lib/service.ts';
+import { useScreenFitScale } from '@/hooks/useScreenFitScale.ts';
 import { mouseStyleAtom } from '@/jotai/mouse.ts';
 import { resolutionAtom, videoScaleAtom } from '@/jotai/screen.ts';
 
@@ -17,6 +18,9 @@ export const Mjpeg = () => {
   const [streamNonce, setStreamNonce] = useState(0);
   const streamURL = `${getBaseUrl('http')}/api/stream/mjpeg`;
   const streamSrc = hasError ? undefined : `${streamURL}?v=${streamNonce}`;
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const fitScale = useScreenFitScale(containerRef);
 
   useEffect(() => {
     // stop frame detect for a while
@@ -36,15 +40,18 @@ export const Mjpeg = () => {
   }, [setVideoScale]);
 
   return (
-    <div className="flex h-full min-h-0 w-full min-w-0 items-center justify-center overflow-hidden bg-black">
+    <div
+      ref={containerRef}
+      className="flex h-full min-h-0 w-full min-w-0 items-center justify-center overflow-hidden bg-black"
+    >
       <img
         id="screen"
         className={clsx('block select-none', mouseStyle)}
         style={{
-          transform: `scale(${videoScale})`,
+          transform: `scale(${fitScale * videoScale})`,
           transformOrigin: 'center',
           ...(resolution?.width
-            ? { width: resolution.width, height: resolution.height, objectFit: 'cover' }
+            ? { width: resolution.width, height: resolution.height }
             : { maxHeight: '100%', objectFit: 'scale-down' }),
           visibility: hasError ? 'hidden' : 'visible'
         }}


### PR DESCRIPTION
变更内容 
本次更新主要优化了 Web 端的登录体验、桌面悬浮菜单交互，以及远程画面的自适应显示效果。

具体改动
登录页新增“记住密码”和“自动登录”选项
登录成功后将账号信息和自动登录状态保存到本地
页面初始化时自动恢复已保存的登录信息，并在开启自动登录时直接登录
为登录页新增中英文国际化文案
桌面悬浮菜单支持拖拽到屏幕边缘后自动吸附
吸附后的菜单支持悬停展开，并支持点击或拖动解除吸附
菜单吸附边和偏移位置会持久化保存
优化菜单边界和页面 overflow，避免吸附状态下出现滚动条
新增统一的屏幕自适应缩放逻辑
H264 Direct、H264 WebRTC 和 MJPEG 模式下的远程画面现在会根据容器尺寸自动缩放，减少溢出和裁切问题

Summary
This PR improves the Web UI in three areas: login persistence, floating desktop menu interactions, and adaptive remote screen rendering.

Changes
Added Remember Password and Auto Login options to the login page
Persisted saved credentials and auto-login preference in local storage
Restored saved login state on page load and triggered login automatically when enabled
Added new i18n strings for both Chinese and English
Added edge snapping behavior for the floating desktop menu
Added hover-to-expand behavior for snapped menus, with click or drag to release
Persisted snapped edge and offset position locally
Adjusted menu bounds and page overflow handling to avoid scrollbars in snapped mode
Added a shared fit-scale hook for remote screen rendering
Applied adaptive scaling to H264 Direct, H264 WebRTC, and MJPEG views to reduce overflow and cropping