### PR TITLE
fix: read pico gateway token from security.yml dynamically

### DIFF
--- a/server/config/picoclaw_internal.go
+++ b/server/config/picoclaw_internal.go
@@ -2,9 +2,12 @@ package config
 
 import (
 	"os"
+	"os/user"
 	"path/filepath"
 	"strings"
 	"sync"
+
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -21,10 +24,18 @@ func GetPicoclawInternalToken() (string, error) {
 	picoclawInternalToken.mu.Lock()
 	defer picoclawInternalToken.mu.Unlock()
 
+	// Always try to read the live pico token from security.yml first
+	if token := readPicoclawSecurityToken(); token != "" {
+		picoclawInternalToken.value = token
+		return token, nil
+	}
+
+	// Fall back to cached value
 	if picoclawInternalToken.value != "" {
 		return picoclawInternalToken.value, nil
 	}
 
+	// Fall back to the legacy token file
 	if token, err := readPicoclawInternalToken(); err == nil {
 		if token != "" {
 			picoclawInternalToken.value = token
@@ -58,4 +69,45 @@ func readPicoclawInternalToken() (string, error) {
 	}
 
 	return strings.TrimSpace(string(data)), nil
+}
+
+type picoclawSecurityYAML struct {
+	ChannelList map[string]struct {
+		Token    string `yaml:"token,omitempty"`
+		Settings *struct {
+			Token string `yaml:"token,omitempty"`
+		} `yaml:"settings,omitempty"`
+	} `yaml:"channel_list,omitempty"`
+}
+
+func readPicoclawSecurityToken() string {
+	home := os.Getenv("PICOCLAW_HOME")
+	if home == "" {
+		u, err := user.Current()
+		if err != nil {
+			return ""
+		}
+		home = filepath.Join(u.HomeDir, ".picoclaw")
+	}
+
+	data, err := os.ReadFile(filepath.Join(home, ".security.yml"))
+	if err != nil {
+		return ""
+	}
+
+	var sec picoclawSecurityYAML
+	if err := yaml.Unmarshal(data, &sec); err != nil {
+		return ""
+	}
+
+	entry, ok := sec.ChannelList["pico"]
+	if !ok {
+		return ""
+	}
+	if entry.Settings != nil {
+		if t := strings.TrimSpace(entry.Settings.Token); t != "" {
+			return t
+		}
+	}
+	return strings.TrimSpace(entry.Token)
 }


### PR DESCRIPTION
## Summary

Fix token desync between NanoKVM-Server and PicoClaw gateway after PicoClaw restarts.

## Problem

When PicoClaw restarts, it regenerates the pico channel token. NanoKVM-Server was caching the old token, causing authentication failures on the gateway endpoint.

## Solution

`GetPicoclawInternalToken()` now reads the token directly from `~/.picoclaw/.security.yml` on every call instead of using a cached value.

Fallback chain: security.yml → cached → legacy token file → generate new

## Files changed

- `server/config/picoclaw_internal.go` (new file)