### PR TITLE
fix(storage): gate default data disk until filesystem is ready

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,22 @@ VISION_BUILD_CMD := . ./home/build/MaixCDK/bin/activate && cd /home/build/NanoKV
 RELEASE_BUILD_CMD := /home/build/NanoKVM/scripts/build-in-container.sh
 
 .PHONY: help check-root builder-image rebuild-image check-image shell app support vision \
-        web release-build package release all clean
+        web release-build package release all test test-s01fs-data-disk \
+        test-go-storage test-go-vm clean
 
 # Default target
 all: app support
+
+test: test-s01fs-data-disk test-go-storage test-go-vm
+
+test-s01fs-data-disk:
+	@bash tools/test-s01fs-data-disk.sh
+
+test-go-storage:
+	@cd server && go test ./service/storage
+
+test-go-vm:
+	@cd server && go test ./service/vm/virtualdisk
 
 # Help target
 help:
@@ -47,6 +59,7 @@ help:
 	@echo "  release-build - Build every riscv64 release artifact in one pass"
 	@echo "  package       - Assemble nanokvm_<VERSION>.tar.gz + latest.json"
 	@echo "  release       - release-build + web + package (needs VERSION=x.y.z)"
+	@echo "  test          - Run repository tests"
 	@echo "  clean         - Clean build artifacts"
 	@echo ""
 	@echo "Prerequisites:"

--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,12 @@ RELEASE_BUILD_CMD := /home/build/NanoKVM/scripts/build-in-container.sh
 
 .PHONY: help check-root builder-image rebuild-image check-image shell app support vision \
         web release-build package release all test test-s01fs-data-disk \
-        test-go-storage test-go-vm clean
+        test-go-storage test-go-vm test-go-utils test-go-download clean
 
 # Default target
 all: app support
 
-test: test-s01fs-data-disk test-go-storage test-go-vm
+test: test-s01fs-data-disk test-go-storage test-go-vm test-go-utils test-go-download
 
 test-s01fs-data-disk:
 	@bash tools/test-s01fs-data-disk.sh
@@ -40,6 +40,12 @@ test-go-storage:
 
 test-go-vm:
 	@cd server && go test ./service/vm/virtualdisk
+
+test-go-utils:
+	@cd server && go test ./utils
+
+test-go-download:
+	@cd server && go test ./service/download
 
 # Help target
 help:

--- a/kvmapp/system/init.d/S01fs
+++ b/kvmapp/system/init.d/S01fs
@@ -1,41 +1,142 @@
 #!/bin/sh
 
+: "${NANOKVM_DISK:=/dev/mmcblk0}"
+: "${NANOKVM_BOOT_PART:=/dev/mmcblk0p1}"
+: "${NANOKVM_ROOT_PART:=/dev/mmcblk0p2}"
+: "${NANOKVM_DATA_PART:=/dev/mmcblk0p3}"
+: "${NANOKVM_BOOT_DIR:=/boot}"
+: "${NANOKVM_DATA_DIR:=/data}"
+: "${NANOKVM_DISK0_MARKER:=/etc/kvm.disk0}"
+: "${NANOKVM_DATA_FORMAT_PENDING:=/etc/kvm.disk0.formatting}"
+: "${NANOKVM_PROFILE:=/etc/profile}"
+
+is_empty_partition() (
+        tmp="$(mktemp "${TMPDIR:-/tmp}/s01fs-data-head.XXXXXX")" || return 1
+        trap 'rm -f "$tmp"' EXIT
+
+        # Conservative recovery for devices stranded by older boots that marked
+        # disk0 complete before formatting finished.
+        if ! dd if="$1" of="$tmp" bs=1M count=4 2>/dev/null
+        then
+                return 1
+        fi
+
+        if [ "$(wc -c < "$tmp")" = "0" ]
+        then
+                return 0
+        fi
+
+        if ! od -An -tx1 "$tmp" | grep -q '[1-9a-fA-F]'
+        then
+                return 0
+        fi
+
+        return 1
+)
+
+format_and_mount_data_partition() {
+        if mkfs.exfat "$NANOKVM_DATA_PART"
+        then
+                rm -f "$NANOKVM_DATA_FORMAT_PENDING"
+                mkdir -p "$NANOKVM_DATA_DIR"
+                if mount "$NANOKVM_DATA_PART" "$NANOKVM_DATA_DIR"
+                then
+                        touch "$NANOKVM_DISK0_MARKER"
+                else
+                        rm -f "$NANOKVM_DISK0_MARKER"
+                fi
+        else
+                rm -f "$NANOKVM_DISK0_MARKER"
+        fi
+}
+
+normalize_disk_file() {
+        printf '%s' "$1" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
+}
+
 if [ "$1" = "start" ]
 then
+        data_mount_handled=0
+        data_marker_after_mount=0
+
                 # use all sdcard free space for data
-                parted -s /dev/mmcblk0 "resizepart 2 -0"
+                parted -s "$NANOKVM_DISK" "resizepart 2 -0"
                 echo "yes
                 8192MB
-                " | parted ---pretend-input-tty /dev/mmcblk0 "resizepart 2 8192MB"
+                " | parted ---pretend-input-tty "$NANOKVM_DISK" "resizepart 2 8192MB"
                 # resize data filesystem
-                (resize2fs /dev/mmcblk0p2) &
+                (resize2fs "$NANOKVM_ROOT_PART") &
 
 
-        . /etc/profile
+        if [ -r "$NANOKVM_PROFILE" ]
+        then
+                # shellcheck disable=SC1090
+                . "$NANOKVM_PROFILE"
+        fi
         printf "mounting filesystem : "
-        mkdir -p /boot
-        mount -t vfat /dev/mmcblk0p1 /boot
+        mkdir -p "$NANOKVM_BOOT_DIR"
+        mount -t vfat "$NANOKVM_BOOT_PART" "$NANOKVM_BOOT_DIR"
         mount -t configfs configfs /sys/kernel/config
         mount -t debugfs debugfs /sys/kernel/debug
 
-        if [ -e /boot/usb.disk0 ]
+        disk0_file=""
+        if [ -e "$NANOKVM_BOOT_DIR/usb.disk0" ]
         then
-                if [ ! -e /etc/kvm.disk0 ]
+                disk0_file="$(normalize_disk_file "$(cat "$NANOKVM_BOOT_DIR/usb.disk0")")"
+        fi
+
+        if [ -e "$NANOKVM_BOOT_DIR/usb.disk0" ] && { [ -z "$disk0_file" ] || [ "$disk0_file" = "$NANOKVM_DATA_PART" ]; }
+        then
+                if [ ! -e "$NANOKVM_DATA_PART" ]
                 then
-                        touch /etc/kvm.disk0
                         # use all sdcard free space for data
-                        parted -s /dev/mmcblk0 "mkpart primary 8193MB 100%"
+                        if parted -s "$NANOKVM_DISK" "mkpart primary 8193MB 100%"
+                        then
+                                touch "$NANOKVM_DATA_FORMAT_PENDING"
+                        fi
                         sleep 1
-                        # resize data filesystem
-                        (mkfs.exfat /dev/mmcblk0p3) &
-                        sleep 1
+                fi
+
+        fi
+
+        if [ -e "$NANOKVM_DATA_PART" ] && [ -e "$NANOKVM_DATA_FORMAT_PENDING" ] && [ "$data_mount_handled" = "0" ]
+        then
+                format_and_mount_data_partition
+                data_mount_handled=1
+        fi
+
+        if [ -e "$NANOKVM_DATA_PART" ] && [ "$data_mount_handled" = "0" ]
+        then
+                if [ -n "$(blkid "$NANOKVM_DATA_PART" 2>/dev/null)" ]
+                then
+                        data_marker_after_mount=1
+                elif [ -e "$NANOKVM_DISK0_MARKER" ] && is_empty_partition "$NANOKVM_DATA_PART"
+                then
+                        touch "$NANOKVM_DATA_FORMAT_PENDING"
+                        format_and_mount_data_partition
+                        data_mount_handled=1
+                else
+                        # Existing unrecognized partitions may contain data. Only
+                        # format partitions this script created, marked pending, or
+                        # legacy-marked as complete while still empty.
+                        rm -f "$NANOKVM_DISK0_MARKER"
+                        data_mount_handled=1
                 fi
         fi
 
-        if [ -e /dev/mmcblk0p3 ]
+        if [ -e "$NANOKVM_DATA_PART" ] && [ "$data_mount_handled" = "0" ]
         then
-                mkdir -p /data
-                mount /dev/mmcblk0p3 /data
+                mkdir -p "$NANOKVM_DATA_DIR"
+                if mount "$NANOKVM_DATA_PART" "$NANOKVM_DATA_DIR"
+                then
+                        if [ "$data_marker_after_mount" = "1" ]
+                        then
+                                touch "$NANOKVM_DISK0_MARKER"
+                        fi
+                elif [ "$data_marker_after_mount" = "1" ]
+                then
+                        rm -f "$NANOKVM_DISK0_MARKER"
+                fi
         fi
 
         echo "OK"

--- a/kvmapp/system/init.d/S01fs
+++ b/kvmapp/system/init.d/S01fs
@@ -1,41 +1,146 @@
 #!/bin/sh
 
+: "${NANOKVM_DISK:=/dev/mmcblk0}"
+: "${NANOKVM_BOOT_PART:=/dev/mmcblk0p1}"
+: "${NANOKVM_ROOT_PART:=/dev/mmcblk0p2}"
+: "${NANOKVM_DATA_PART:=/dev/mmcblk0p3}"
+: "${NANOKVM_BOOT_DIR:=/boot}"
+: "${NANOKVM_DATA_DIR:=/data}"
+: "${NANOKVM_DISK0_MARKER:=/etc/kvm.disk0}"
+: "${NANOKVM_DATA_FORMAT_PENDING:=/etc/kvm.disk0.formatting}"
+: "${NANOKVM_PROFILE:=/etc/profile}"
+
+format_data_partition() {
+        if mkfs.exfat "$NANOKVM_DATA_PART"
+        then
+                rm -f "$NANOKVM_DATA_FORMAT_PENDING"
+                touch "$NANOKVM_DISK0_MARKER"
+                return 0
+        fi
+        rm -f "$NANOKVM_DISK0_MARKER"
+        return 1
+}
+
+format_and_mount_data_partition() {
+        if format_data_partition
+        then
+                mkdir -p "$NANOKVM_DATA_DIR"
+                if mount "$NANOKVM_DATA_PART" "$NANOKVM_DATA_DIR"
+                then
+                        return 0
+                else
+                        rm -f "$NANOKVM_DISK0_MARKER"
+                fi
+        fi
+        return 1
+}
+
+normalize_disk_file() {
+        printf '%s' "$1" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
+}
+
 if [ "$1" = "start" ]
 then
+        data_mount_handled=0
+        data_marker_after_mount=0
+
                 # use all sdcard free space for data
-                parted -s /dev/mmcblk0 "resizepart 2 -0"
+                parted -s "$NANOKVM_DISK" "resizepart 2 -0"
                 echo "yes
                 8192MB
-                " | parted ---pretend-input-tty /dev/mmcblk0 "resizepart 2 8192MB"
+                " | parted ---pretend-input-tty "$NANOKVM_DISK" "resizepart 2 8192MB"
                 # resize data filesystem
-                (resize2fs /dev/mmcblk0p2) &
+                (resize2fs "$NANOKVM_ROOT_PART") &
 
 
-        . /etc/profile
+        if [ -r "$NANOKVM_PROFILE" ]
+        then
+                # shellcheck disable=SC1090
+                . "$NANOKVM_PROFILE"
+        fi
         printf "mounting filesystem : "
-        mkdir -p /boot
-        mount -t vfat /dev/mmcblk0p1 /boot
+        mkdir -p "$NANOKVM_BOOT_DIR"
+        mount -t vfat "$NANOKVM_BOOT_PART" "$NANOKVM_BOOT_DIR"
         mount -t configfs configfs /sys/kernel/config
         mount -t debugfs debugfs /sys/kernel/debug
 
-        if [ -e /boot/usb.disk0 ]
+        disk0_file=""
+        if [ -e "$NANOKVM_BOOT_DIR/usb.disk0" ]
         then
-                if [ ! -e /etc/kvm.disk0 ]
+                disk0_file="$(normalize_disk_file "$(cat "$NANOKVM_BOOT_DIR/usb.disk0")")"
+        fi
+
+        default_disk_configured=0
+        if [ -e "$NANOKVM_BOOT_DIR/usb.disk0" ] \
+                && { [ -z "$disk0_file" ] || [ "$disk0_file" = "$NANOKVM_DATA_PART" ] \
+                || { [ -e "$disk0_file" ] && [ -e "$NANOKVM_DATA_PART" ] \
+                        && [ "$(readlink -f "$disk0_file" 2>/dev/null)" = "$(readlink -f "$NANOKVM_DATA_PART" 2>/dev/null)" ]; }; }
+        then
+                default_disk_configured=1
+        fi
+
+        if [ -e "$NANOKVM_BOOT_DIR/usb.disk0" ] \
+                && [ "$default_disk_configured" = "1" ] \
+                && [ ! -e "$NANOKVM_DATA_FORMAT_PENDING" ] \
+                && [ -e "$NANOKVM_DATA_PART" ] \
+                && [ -n "$(blkid "$NANOKVM_DATA_PART" 2>/dev/null)" ]
+        then
+                # The virtual disk owns p3 until its toggle remounts /data.
+                touch "$NANOKVM_DISK0_MARKER"
+                data_mount_handled=1
+        fi
+
+        if [ -e "$NANOKVM_BOOT_DIR/usb.disk0" ] && [ "$default_disk_configured" = "1" ]
+        then
+                if [ ! -e "$NANOKVM_DATA_PART" ]
                 then
-                        touch /etc/kvm.disk0
                         # use all sdcard free space for data
-                        parted -s /dev/mmcblk0 "mkpart primary 8193MB 100%"
+                        if parted -s "$NANOKVM_DISK" "mkpart primary 8193MB 100%"
+                        then
+                                touch "$NANOKVM_DATA_FORMAT_PENDING"
+                        fi
                         sleep 1
-                        # resize data filesystem
-                        (mkfs.exfat /dev/mmcblk0p3) &
-                        sleep 1
+                fi
+
+        fi
+
+        if [ -e "$NANOKVM_DATA_PART" ] && [ -e "$NANOKVM_DATA_FORMAT_PENDING" ] && [ "$data_mount_handled" = "0" ]
+        then
+                if [ "$default_disk_configured" = "1" ]
+                then
+                        format_data_partition
+                else
+                        format_and_mount_data_partition
+                fi
+                data_mount_handled=1
+        fi
+
+        if [ -e "$NANOKVM_DATA_PART" ] && [ "$data_mount_handled" = "0" ]
+        then
+                if [ -n "$(blkid "$NANOKVM_DATA_PART" 2>/dev/null)" ]
+                then
+                        data_marker_after_mount=1
+                else
+                        # Existing unrecognized partitions may contain data. Only
+                        # format partitions this script explicitly marked pending.
+                        rm -f "$NANOKVM_DISK0_MARKER"
+                        data_mount_handled=1
                 fi
         fi
 
-        if [ -e /dev/mmcblk0p3 ]
+        if [ -e "$NANOKVM_DATA_PART" ] && [ "$data_mount_handled" = "0" ]
         then
-                mkdir -p /data
-                mount /dev/mmcblk0p3 /data
+                mkdir -p "$NANOKVM_DATA_DIR"
+                if mount "$NANOKVM_DATA_PART" "$NANOKVM_DATA_DIR"
+                then
+                        if [ "$data_marker_after_mount" = "1" ]
+                        then
+                                touch "$NANOKVM_DISK0_MARKER"
+                        fi
+                elif [ "$data_marker_after_mount" = "1" ]
+                then
+                        rm -f "$NANOKVM_DISK0_MARKER"
+                fi
         fi
 
         echo "OK"

--- a/kvmapp/system/init.d/S01fs
+++ b/kvmapp/system/init.d/S01fs
@@ -11,13 +11,22 @@
 : "${NANOKVM_PROFILE:=/etc/profile}"
 
 format_data_partition() {
+        if ! rm -f "$NANOKVM_DISK0_MARKER"
+        then
+                return 1
+        fi
         if mkfs.exfat "$NANOKVM_DATA_PART"
         then
-                rm -f "$NANOKVM_DATA_FORMAT_PENDING"
-                touch "$NANOKVM_DISK0_MARKER"
+                if ! rm -f "$NANOKVM_DATA_FORMAT_PENDING"
+                then
+                        return 1
+                fi
                 return 0
         fi
-        rm -f "$NANOKVM_DISK0_MARKER"
+        if ! rm -f "$NANOKVM_DISK0_MARKER"
+        then
+                return 1
+        fi
         return 1
 }
 
@@ -72,9 +81,7 @@ then
 
         default_disk_configured=0
         if [ -e "$NANOKVM_BOOT_DIR/usb.disk0" ] \
-                && { [ -z "$disk0_file" ] || [ "$disk0_file" = "$NANOKVM_DATA_PART" ] \
-                || { [ -e "$disk0_file" ] && [ -e "$NANOKVM_DATA_PART" ] \
-                        && [ "$(readlink -f "$disk0_file" 2>/dev/null)" = "$(readlink -f "$NANOKVM_DATA_PART" 2>/dev/null)" ]; }; }
+                && { [ -z "$disk0_file" ] || [ "$disk0_file" = "$NANOKVM_DATA_PART" ]; }
         then
                 default_disk_configured=1
         fi
@@ -86,8 +93,10 @@ then
                 && [ -n "$(blkid "$NANOKVM_DATA_PART" 2>/dev/null)" ]
         then
                 # The virtual disk owns p3 until its toggle remounts /data.
-                touch "$NANOKVM_DISK0_MARKER"
-                data_mount_handled=1
+                if touch "$NANOKVM_DISK0_MARKER"
+                then
+                        data_mount_handled=1
+                fi
         fi
 
         if [ -e "$NANOKVM_BOOT_DIR/usb.disk0" ] && [ "$default_disk_configured" = "1" ]
@@ -108,11 +117,24 @@ then
         then
                 if [ "$default_disk_configured" = "1" ]
                 then
-                        format_data_partition
+                        if format_data_partition
+                        then
+                                if touch "$NANOKVM_DISK0_MARKER"
+                                then
+                                        data_mount_handled=1
+                                fi
+                        else
+                                data_mount_handled=1
+                        fi
                 else
-                        format_and_mount_data_partition
+                        if format_and_mount_data_partition
+                        then
+                                data_mount_handled=1
+                                touch "$NANOKVM_DISK0_MARKER"
+                        else
+                                data_mount_handled=1
+                        fi
                 fi
-                data_mount_handled=1
         fi
 
         if [ -e "$NANOKVM_DATA_PART" ] && [ "$data_mount_handled" = "0" ]
@@ -135,7 +157,10 @@ then
                 then
                         if [ "$data_marker_after_mount" = "1" ]
                         then
-                                touch "$NANOKVM_DISK0_MARKER"
+                                if ! touch "$NANOKVM_DISK0_MARKER"
+                                then
+                                        data_mount_handled=1
+                                fi
                         fi
                 elif [ "$data_marker_after_mount" = "1" ]
                 then

--- a/kvmapp/system/init.d/S03usbdev
+++ b/kvmapp/system/init.d/S03usbdev
@@ -1,5 +1,61 @@
 #!/bin/sh
+# shellcheck disable=SC1091,SC2012,SC2164,SC3037
 # kvmhwd Rev2.2
+
+: "${NANOKVM_DISK0_MARKER:=/etc/kvm.disk0}"
+: "${NANOKVM_DATA_FORMAT_PENDING:=/etc/kvm.disk0.formatting}"
+: "${NANOKVM_DATA_PART:=/dev/mmcblk0p3}"
+: "${NANOKVM_BOOT_DIR:=/boot}"
+
+data_disk_ready(){
+    [ -e "$NANOKVM_DISK0_MARKER" ] && [ ! -e "$NANOKVM_DATA_FORMAT_PENDING" ] && [ -e "$NANOKVM_DATA_PART" ]
+}
+
+default_data_disk_file(){
+    if data_disk_ready
+    then
+            printf '%s\n' "$NANOKVM_DATA_PART"
+    fi
+}
+
+normalize_disk_file(){
+    printf '%s' "$1" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
+}
+
+resolve_disk_file(){
+    disk_file="$(normalize_disk_file "$1")"
+    if [ -z "$disk_file" ] || [ "$disk_file" = "$NANOKVM_DATA_PART" ]
+    then
+            default_data_disk_file
+    else
+            printf '%s\n' "$disk_file"
+    fi
+}
+
+configure_mass_storage(){
+    if [ ! -e "$NANOKVM_BOOT_DIR/usb.disk0" ]
+    then
+            return
+    fi
+
+    disk=$(cat "$NANOKVM_BOOT_DIR/usb.disk0")
+    data_file="$(resolve_disk_file "$disk")"
+    if [ -z "$data_file" ]
+    then
+            return
+    fi
+
+    mkdir functions/mass_storage.disk0
+    ln -s functions/mass_storage.disk0 configs/c.1/
+    echo 1 > functions/mass_storage.disk0/lun.0/removable
+    if [ -e "$NANOKVM_BOOT_DIR/usb.disk0.ro" ]
+    then
+            echo 1 > functions/mass_storage.disk0/lun.0/ro
+            echo 0 > functions/mass_storage.disk0/lun.0/cdrom
+    fi
+    echo "NanoKVM USB Mass Storage0520" > functions/mass_storage.disk0/lun.0/inquiry_string
+    printf '%s\n' "$data_file" > functions/mass_storage.disk0/lun.0/file
+}
 
 start_usb_dev(){
     . /etc/profile
@@ -129,30 +185,7 @@ start_usb_dev(){
         ln -s functions/hid.GS2 configs/c.1
     fi
 
-    if [ -e /boot/usb.disk0 ]
-    then
-            mkdir functions/mass_storage.disk0
-            ln -s functions/mass_storage.disk0 configs/c.1/
-            echo 1 > functions/mass_storage.disk0/lun.0/removable
-            if [ -e /boot/usb.disk0.ro ]
-            then
-                    echo 1 > functions/mass_storage.disk0/lun.0/ro
-                    echo 0 > functions/mass_storage.disk0/lun.0/cdrom
-            fi
-            echo "NanoKVM USB Mass Storage0520" > functions/mass_storage.disk0/lun.0/inquiry_string
-            disk=$(cat /boot/usb.disk0)
-            if [ -z "${disk}" ]
-            then
-                    # if [ ! -e /mnt/usbdisk.img ]
-                    # then
-                    #         fallocate -l 8G /mnt/usbdisk.img
-                    #         mkfs.vfat /mnt/usbdisk.img
-                    # fi
-                    echo /dev/mmcblk0p3 > functions/mass_storage.disk0/lun.0/file
-            else
-                    cat /boot/usb.disk0 > functions/mass_storage.disk0/lun.0/file
-            fi
-    fi
+    configure_mass_storage
 
     ls /sys/class/udc/ | cat > UDC
     echo device > /proc/cviusb/otg_role

--- a/kvmapp/system/init.d/S03usbdev
+++ b/kvmapp/system/init.d/S03usbdev
@@ -1,5 +1,68 @@
 #!/bin/sh
+# shellcheck disable=SC1091,SC2012,SC2164,SC3037
 # kvmhwd Rev2.2
+
+: "${NANOKVM_DISK0_MARKER:=/etc/kvm.disk0}"
+: "${NANOKVM_DATA_FORMAT_PENDING:=/etc/kvm.disk0.formatting}"
+: "${NANOKVM_DATA_PART:=/dev/mmcblk0p3}"
+: "${NANOKVM_BOOT_DIR:=/boot}"
+
+data_disk_ready(){
+    [ -e "$NANOKVM_DISK0_MARKER" ] && [ ! -e "$NANOKVM_DATA_FORMAT_PENDING" ] && [ -e "$NANOKVM_DATA_PART" ]
+}
+
+default_data_disk_file(){
+    if data_disk_ready
+    then
+            printf '%s\n' "$NANOKVM_DATA_PART"
+    fi
+}
+
+normalize_disk_file(){
+    printf '%s' "$1" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
+}
+
+is_default_data_partition(){
+    disk_file="$1"
+    [ "$disk_file" = "$NANOKVM_DATA_PART" ] && return 0
+    [ -e "$disk_file" ] && [ -e "$NANOKVM_DATA_PART" ] \
+        && [ "$(readlink -f "$disk_file" 2>/dev/null)" = "$(readlink -f "$NANOKVM_DATA_PART" 2>/dev/null)" ]
+}
+
+resolve_disk_file(){
+    disk_file="$(normalize_disk_file "$1")"
+    if [ -z "$disk_file" ] || is_default_data_partition "$disk_file"
+    then
+            default_data_disk_file
+    else
+            printf '%s\n' "$disk_file"
+    fi
+}
+
+configure_mass_storage(){
+    if [ ! -e "$NANOKVM_BOOT_DIR/usb.disk0" ]
+    then
+            return
+    fi
+
+    disk=$(normalize_disk_file "$(cat "$NANOKVM_BOOT_DIR/usb.disk0")")
+    data_file="$(resolve_disk_file "$disk")"
+    if [ -z "$data_file" ]
+    then
+            return
+    fi
+
+    mkdir functions/mass_storage.disk0
+    ln -s functions/mass_storage.disk0 configs/c.1/
+    echo 1 > functions/mass_storage.disk0/lun.0/removable
+    if [ -e "$NANOKVM_BOOT_DIR/usb.disk0.ro" ]
+    then
+            echo 1 > functions/mass_storage.disk0/lun.0/ro
+            echo 0 > functions/mass_storage.disk0/lun.0/cdrom
+    fi
+    echo "NanoKVM USB Mass Storage0520" > functions/mass_storage.disk0/lun.0/inquiry_string
+    printf '%s\n' "$data_file" > functions/mass_storage.disk0/lun.0/file
+}
 
 start_usb_dev(){
     . /etc/profile
@@ -129,30 +192,7 @@ start_usb_dev(){
         ln -s functions/hid.GS2 configs/c.1
     fi
 
-    if [ -e /boot/usb.disk0 ]
-    then
-            mkdir functions/mass_storage.disk0
-            ln -s functions/mass_storage.disk0 configs/c.1/
-            echo 1 > functions/mass_storage.disk0/lun.0/removable
-            if [ -e /boot/usb.disk0.ro ]
-            then
-                    echo 1 > functions/mass_storage.disk0/lun.0/ro
-                    echo 0 > functions/mass_storage.disk0/lun.0/cdrom
-            fi
-            echo "NanoKVM USB Mass Storage0520" > functions/mass_storage.disk0/lun.0/inquiry_string
-            disk=$(cat /boot/usb.disk0)
-            if [ -z "${disk}" ]
-            then
-                    # if [ ! -e /mnt/usbdisk.img ]
-                    # then
-                    #         fallocate -l 8G /mnt/usbdisk.img
-                    #         mkfs.vfat /mnt/usbdisk.img
-                    # fi
-                    echo /dev/mmcblk0p3 > functions/mass_storage.disk0/lun.0/file
-            else
-                    cat /boot/usb.disk0 > functions/mass_storage.disk0/lun.0/file
-            fi
-    fi
+    configure_mass_storage
 
     ls /sys/class/udc/ | cat > UDC
     echo device > /proc/cviusb/otg_role

--- a/kvmapp/system/init.d/S03usbdev
+++ b/kvmapp/system/init.d/S03usbdev
@@ -6,9 +6,13 @@
 : "${NANOKVM_DATA_FORMAT_PENDING:=/etc/kvm.disk0.formatting}"
 : "${NANOKVM_DATA_PART:=/dev/mmcblk0p3}"
 : "${NANOKVM_BOOT_DIR:=/boot}"
+: "${NANOKVM_MOUNTS_FILE:=/proc/mounts}"
 
 data_disk_ready(){
-    [ -e "$NANOKVM_DISK0_MARKER" ] && [ ! -e "$NANOKVM_DATA_FORMAT_PENDING" ] && [ -e "$NANOKVM_DATA_PART" ]
+    [ -e "$NANOKVM_DISK0_MARKER" ] \
+        && [ ! -e "$NANOKVM_DATA_FORMAT_PENDING" ] \
+        && [ -e "$NANOKVM_DATA_PART" ] \
+        && awk -v part="$NANOKVM_DATA_PART" '$1 == part { found = 1 } END { exit found }' "$NANOKVM_MOUNTS_FILE" 2>/dev/null
 }
 
 default_data_disk_file(){
@@ -31,17 +35,33 @@ is_default_data_partition(){
 
 resolve_disk_file(){
     disk_file="$(normalize_disk_file "$1")"
-    if [ -z "$disk_file" ] || is_default_data_partition "$disk_file"
+    if [ -z "$disk_file" ] || [ "$disk_file" = "$NANOKVM_DATA_PART" ]
     then
             default_data_disk_file
+    elif is_default_data_partition "$disk_file"
+    then
+            # A path alias can become visible only after /data is mounted.
+            # Refuse it instead of risking simultaneous local and USB access.
+            return
     else
             printf '%s\n' "$disk_file"
+    fi
+}
+
+clear_mass_storage_backing(){
+    if [ -e functions/mass_storage.disk0/lun.0/file ]
+    then
+            if ! printf '\n' > functions/mass_storage.disk0/lun.0/file
+            then
+                    return 1
+            fi
     fi
 }
 
 configure_mass_storage(){
     if [ ! -e "$NANOKVM_BOOT_DIR/usb.disk0" ]
     then
+            clear_mass_storage_backing
             return
     fi
 
@@ -49,6 +69,7 @@ configure_mass_storage(){
     data_file="$(resolve_disk_file "$disk")"
     if [ -z "$data_file" ]
     then
+            clear_mass_storage_backing
             return
     fi
 
@@ -192,7 +213,11 @@ start_usb_dev(){
         ln -s functions/hid.GS2 configs/c.1
     fi
 
-    configure_mass_storage
+    if ! configure_mass_storage
+    then
+        echo "failed to configure mass storage" >&2
+        return 1
+    fi
 
     ls /sys/class/udc/ | cat > UDC
     echo device > /proc/cviusb/otg_role

--- a/server/service/download/service.go
+++ b/server/service/download/service.go
@@ -39,6 +39,7 @@ var (
 	errDownloadInProgress = errors.New("download in progress")
 	errSHA256Mismatch     = errors.New("sha256 mismatch")
 	validISOFilename      = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+	dataDirectoryMounted  = utils.IsMountPoint
 )
 
 type Service struct {
@@ -151,6 +152,10 @@ func (s *Service) finishDownload(done chan struct{}, status downloadStatus) {
 
 func (s *Service) ImageEnabled(c *gin.Context) {
 	var rsp proto.Response
+	if !dataDirectoryMounted("/data") {
+		rsp.OkRspWithData(c, &proto.ImageEnabledRsp{Enabled: false})
+		return
+	}
 
 	testFile := "/data/.testfile"
 	file, err := os.Create(testFile)
@@ -202,6 +207,10 @@ func (s *Service) StatusImage(c *gin.Context) {
 
 func (s *Service) DownloadImageFile(c *gin.Context) {
 	var rsp proto.Response
+	if !dataDirectoryMounted("/data") {
+		rsp.ErrRsp(c, -1, "data disk is not mounted")
+		return
+	}
 
 	log.Debug("DownloadImageFile")
 	expectedSHA256, err := parseSHA256(c.GetHeader("X-SHA256-Sum"))
@@ -345,6 +354,10 @@ func (s *Service) DownloadImage(c *gin.Context) {
 	filename := filepath.Base(u.Path)
 	if filename == "." || filename == "/" || filename == "" {
 		rsp.ErrRsp(c, -1, "invalid url")
+		return
+	}
+	if !dataDirectoryMounted("/data") {
+		rsp.ErrRsp(c, -1, "data disk is not mounted")
 		return
 	}
 

--- a/server/service/download/service_test.go
+++ b/server/service/download/service_test.go
@@ -1,0 +1,48 @@
+package download
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestImageOperationsRefuseUnmountedDataDirectory(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	oldMounted := dataDirectoryMounted
+	dataDirectoryMounted = func(string) bool { return false }
+	t.Cleanup(func() { dataDirectoryMounted = oldMounted })
+
+	t.Run("enabled", func(t *testing.T) {
+		response := httptest.NewRecorder()
+		context, _ := gin.CreateTestContext(response)
+		NewService().ImageEnabled(context)
+
+		if !strings.Contains(response.Body.String(), `"enabled":false`) {
+			t.Fatalf("response = %s, want disabled", response.Body.String())
+		}
+	})
+
+	t.Run("upload", func(t *testing.T) {
+		response := httptest.NewRecorder()
+		context, _ := gin.CreateTestContext(response)
+		NewService().DownloadImageFile(context)
+
+		if !strings.Contains(response.Body.String(), "data disk is not mounted") {
+			t.Fatalf("response = %s, want data mount error", response.Body.String())
+		}
+	})
+
+	t.Run("remote download", func(t *testing.T) {
+		response := httptest.NewRecorder()
+		context, _ := gin.CreateTestContext(response)
+		context.Request = httptest.NewRequest("POST", "/download/image", strings.NewReader(`{"file":"https://example.com/test.iso"}`))
+		context.Request.Header.Set("Content-Type", "application/json")
+		NewService().DownloadImage(context)
+
+		if !strings.Contains(response.Body.String(), "data disk is not mounted") {
+			t.Fatalf("response = %s, want data mount error", response.Body.String())
+		}
+	})
+}

--- a/server/service/storage/image.go
+++ b/server/service/storage/image.go
@@ -18,12 +18,46 @@ import (
 
 const (
 	imageDirectory = "/data"
-	imageNone      = "/dev/mmcblk0p3"
-	cdromFlag      = "/sys/kernel/config/usb_gadget/g0/functions/mass_storage.disk0/lun.0/cdrom"
-	mountDevice    = "/sys/kernel/config/usb_gadget/g0/functions/mass_storage.disk0/lun.0/file"
-	inquiryString  = "/sys/kernel/config/usb_gadget/g0/functions/mass_storage.disk0/lun.0/inquiry_string"
-	roFlag         = "/sys/kernel/config/usb_gadget/g0/functions/mass_storage.disk0/lun.0/ro"
+	dataDiskMarker = "/etc/kvm.disk0"
+	formatPending  = "/etc/kvm.disk0.formatting"
+	dataPartition  = "/dev/mmcblk0p3"
 )
+
+var (
+	imageNone     = dataPartition
+	cdromFlag     = "/sys/kernel/config/usb_gadget/g0/functions/mass_storage.disk0/lun.0/cdrom"
+	mountDevice   = "/sys/kernel/config/usb_gadget/g0/functions/mass_storage.disk0/lun.0/file"
+	inquiryString = "/sys/kernel/config/usb_gadget/g0/functions/mass_storage.disk0/lun.0/inquiry_string"
+	roFlag        = "/sys/kernel/config/usb_gadget/g0/functions/mass_storage.disk0/lun.0/ro"
+
+	dataDiskMarkerPath = dataDiskMarker
+	formatPendingPath  = formatPending
+	dataPartitionPath  = dataPartition
+)
+
+func defaultDataDiskImage() string {
+	if _, err := os.Stat(dataDiskMarkerPath); err != nil {
+		return ""
+	}
+	if _, err := os.Stat(formatPendingPath); err == nil {
+		return ""
+	}
+	if _, err := os.Stat(dataPartitionPath); err != nil {
+		return ""
+	}
+	return dataPartitionPath
+}
+
+func mountImagePath(requested string) (string, bool) {
+	requested = strings.TrimSpace(requested)
+	if requested == "" {
+		return "", true
+	}
+	if requested == dataPartitionPath {
+		return requested, defaultDataDiskImage() != ""
+	}
+	return requested, true
+}
 
 func (s *Service) GetImages(c *gin.Context) {
 	var rsp proto.Response
@@ -60,6 +94,13 @@ func (s *Service) MountImage(c *gin.Context) {
 
 	if err := proto.ParseFormRequest(c, &req); err != nil {
 		rsp.ErrRsp(c, -1, "invalid arguments")
+		return
+	}
+
+	// mount
+	image, ok := mountImagePath(req.File)
+	if !ok {
+		rsp.ErrRsp(c, -2, "data disk is not ready")
 		return
 	}
 
@@ -106,12 +147,6 @@ func (s *Service) MountImage(c *gin.Context) {
 		log.Errorf("set inquiry %s failed: %s", inquiryData, err)
 		rsp.ErrRsp(c, -2, "set inquiry failed")
 		return
-	}
-
-	// mount
-	image := req.File
-	if image == "" {
-		image = imageNone
 	}
 
 	if err := os.WriteFile(mountDevice, []byte(image), 0o666); err != nil {

--- a/server/service/storage/image.go
+++ b/server/service/storage/image.go
@@ -14,6 +14,8 @@ import (
 
 	"NanoKVM-Server/proto"
 	"NanoKVM-Server/service/hid"
+	"NanoKVM-Server/service/vm/virtualdisk"
+	"NanoKVM-Server/utils"
 )
 
 const (
@@ -33,6 +35,11 @@ var (
 	dataDiskMarkerPath = dataDiskMarker
 	formatPendingPath  = formatPending
 	dataPartitionPath  = dataPartition
+	virtualDiskPath    = "/boot/usb.disk0"
+	dataDirectoryMount = utils.IsMountPoint
+	runShellCommand    = func(command string) error {
+		return exec.Command("sh", "-c", command).Run()
+	}
 )
 
 func mountImagePath(requested string) (string, bool) {
@@ -59,9 +66,27 @@ func isDataPartitionPath(path string) bool {
 	return err == nil && os.SameFile(requested, partition)
 }
 
+func defaultDataDiskOwned() bool {
+	return virtualdisk.IsDefaultConfigured(virtualdisk.Paths{
+		Config:    virtualDiskPath,
+		Marker:    dataDiskMarkerPath,
+		Pending:   formatPendingPath,
+		Partition: dataPartitionPath,
+	})
+}
+
+func isDataPath(path string) bool {
+	clean := filepath.Clean(path)
+	return clean == imageDirectory || strings.HasPrefix(clean, imageDirectory+string(os.PathSeparator))
+}
+
 func (s *Service) GetImages(c *gin.Context) {
 	var rsp proto.Response
 	var images []string
+	if !dataDirectoryMount(imageDirectory) {
+		rsp.ErrRsp(c, -2, "data disk is not mounted")
+		return
+	}
 
 	err := filepath.Walk(imageDirectory, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -103,6 +128,10 @@ func (s *Service) MountImage(c *gin.Context) {
 		rsp.ErrRsp(c, -2, "data disk is not ready")
 		return
 	}
+	if isDataPath(image) && !dataDirectoryMount(imageDirectory) {
+		rsp.ErrRsp(c, -2, "data disk is not mounted")
+		return
+	}
 
 	h := hid.GetHid()
 	h.Lock()
@@ -111,13 +140,17 @@ func (s *Service) MountImage(c *gin.Context) {
 		h.OpenNoLock()
 		h.Unlock()
 	}()
+	clearRequested := image == ""
+	if clearRequested && defaultDataDiskOwned() && !dataDirectoryMount(imageDirectory) {
+		image = dataPartitionPath
+	}
 
 	// cdrom and ro flag
 	// set to 0 when unmount image
 	// set to 1 when mount image and the CD-ROM is enabled
-	if req.File == "" || req.Cdrom {
+	if clearRequested || req.Cdrom {
 		flag := "0"
-		if req.File != "" && req.Cdrom {
+		if !clearRequested && req.Cdrom {
 			flag = "1"
 		}
 
@@ -170,7 +203,7 @@ func (s *Service) MountImage(c *gin.Context) {
 	}
 
 	for _, command := range commands {
-		err := exec.Command("sh", "-c", command).Run()
+		err := runShellCommand(command)
 		if err != nil {
 			rsp.ErrRsp(c, -2, "execute command failed")
 			return
@@ -245,6 +278,10 @@ func (s *Service) DeleteImage(c *gin.Context) {
 
 	if err := proto.ParseFormRequest(c, &req); err != nil {
 		rsp.ErrRsp(c, -1, "invalid arguments")
+		return
+	}
+	if !dataDirectoryMount(imageDirectory) {
+		rsp.ErrRsp(c, -2, "data disk is not mounted")
 		return
 	}
 

--- a/server/service/storage/image.go
+++ b/server/service/storage/image.go
@@ -18,12 +18,46 @@ import (
 
 const (
 	imageDirectory = "/data"
-	imageNone      = "/dev/mmcblk0p3"
-	cdromFlag      = "/sys/kernel/config/usb_gadget/g0/functions/mass_storage.disk0/lun.0/cdrom"
-	mountDevice    = "/sys/kernel/config/usb_gadget/g0/functions/mass_storage.disk0/lun.0/file"
-	inquiryString  = "/sys/kernel/config/usb_gadget/g0/functions/mass_storage.disk0/lun.0/inquiry_string"
-	roFlag         = "/sys/kernel/config/usb_gadget/g0/functions/mass_storage.disk0/lun.0/ro"
+	dataDiskMarker = "/etc/kvm.disk0"
+	formatPending  = "/etc/kvm.disk0.formatting"
+	dataPartition  = "/dev/mmcblk0p3"
 )
+
+var (
+	imageNone     = dataPartition
+	cdromFlag     = "/sys/kernel/config/usb_gadget/g0/functions/mass_storage.disk0/lun.0/cdrom"
+	mountDevice   = "/sys/kernel/config/usb_gadget/g0/functions/mass_storage.disk0/lun.0/file"
+	inquiryString = "/sys/kernel/config/usb_gadget/g0/functions/mass_storage.disk0/lun.0/inquiry_string"
+	roFlag        = "/sys/kernel/config/usb_gadget/g0/functions/mass_storage.disk0/lun.0/ro"
+
+	dataDiskMarkerPath = dataDiskMarker
+	formatPendingPath  = formatPending
+	dataPartitionPath  = dataPartition
+)
+
+func mountImagePath(requested string) (string, bool) {
+	requested = strings.TrimSpace(requested)
+	if requested == "" {
+		return "", true
+	}
+	if isDataPartitionPath(requested) {
+		return "", false
+	}
+	return requested, true
+}
+
+func isDataPartitionPath(path string) bool {
+	if path == dataPartitionPath {
+		return true
+	}
+
+	requested, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	partition, err := os.Stat(dataPartitionPath)
+	return err == nil && os.SameFile(requested, partition)
+}
 
 func (s *Service) GetImages(c *gin.Context) {
 	var rsp proto.Response
@@ -62,6 +96,21 @@ func (s *Service) MountImage(c *gin.Context) {
 		rsp.ErrRsp(c, -1, "invalid arguments")
 		return
 	}
+
+	// mount
+	image, ok := mountImagePath(req.File)
+	if !ok {
+		rsp.ErrRsp(c, -2, "data disk is not ready")
+		return
+	}
+
+	h := hid.GetHid()
+	h.Lock()
+	h.CloseNoLock()
+	defer func() {
+		h.OpenNoLock()
+		h.Unlock()
+	}()
 
 	// cdrom and ro flag
 	// set to 0 when unmount image
@@ -108,25 +157,11 @@ func (s *Service) MountImage(c *gin.Context) {
 		return
 	}
 
-	// mount
-	image := req.File
-	if image == "" {
-		image = imageNone
-	}
-
 	if err := os.WriteFile(mountDevice, []byte(image), 0o666); err != nil {
 		log.Errorf("mount file %s failed: %s", image, err)
 		rsp.ErrRsp(c, -2, "mount image failed")
 		return
 	}
-
-	h := hid.GetHid()
-	h.Lock()
-	h.CloseNoLock()
-	defer func() {
-		h.OpenNoLock()
-		h.Unlock()
-	}()
 
 	// reset usb
 	commands := []string{

--- a/server/service/storage/image_test.go
+++ b/server/service/storage/image_test.go
@@ -1,0 +1,301 @@
+package storage
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func withDataDiskPaths(t *testing.T) (marker string, pending string, part string) {
+	t.Helper()
+
+	oldMarker := dataDiskMarkerPath
+	oldPending := formatPendingPath
+	oldPart := dataPartitionPath
+	oldImageNone := imageNone
+
+	dir := t.TempDir()
+	marker = filepath.Join(dir, "kvm.disk0")
+	pending = filepath.Join(dir, "kvm.disk0.formatting")
+	part = filepath.Join(dir, "mmcblk0p3")
+
+	dataDiskMarkerPath = marker
+	formatPendingPath = pending
+	dataPartitionPath = part
+	imageNone = part
+
+	t.Cleanup(func() {
+		dataDiskMarkerPath = oldMarker
+		formatPendingPath = oldPending
+		dataPartitionPath = oldPart
+		imageNone = oldImageNone
+	})
+
+	return marker, pending, part
+}
+
+func touch(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatalf("touch %s: %v", path, err)
+	}
+}
+
+func TestMountImagePathDefaultDataDisk(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(t *testing.T, marker, pending, part string)
+		requested string
+		wantImage string
+		wantOK    bool
+	}{
+		{
+			name:      "empty request clears backing without data disk readiness",
+			wantImage: "",
+			wantOK:    true,
+		},
+		{
+			name: "explicit data partition allowed when ready",
+			setup: func(t *testing.T, marker, _pending, part string) {
+				touch(t, marker)
+				touch(t, part)
+			},
+			requested: "DATA_PART",
+			wantImage: "DATA_PART",
+			wantOK:    true,
+		},
+		{
+			name: "explicit data partition with whitespace allowed when ready",
+			setup: func(t *testing.T, marker, _pending, part string) {
+				touch(t, marker)
+				touch(t, part)
+			},
+			requested: " WHITESPACE_DATA_PART ",
+			wantImage: "DATA_PART",
+			wantOK:    true,
+		},
+		{
+			name: "explicit data partition blocked without ready marker",
+			setup: func(t *testing.T, _marker, _pending, part string) {
+				touch(t, part)
+			},
+			requested: "DATA_PART",
+			wantOK:    false,
+		},
+		{
+			name: "explicit data partition with whitespace blocked without ready marker",
+			setup: func(t *testing.T, _marker, _pending, part string) {
+				touch(t, part)
+			},
+			requested: " WHITESPACE_DATA_PART ",
+			wantOK:    false,
+		},
+		{
+			name: "explicit data partition blocked while format pending",
+			setup: func(t *testing.T, marker, pending, part string) {
+				touch(t, marker)
+				touch(t, pending)
+				touch(t, part)
+			},
+			requested: "DATA_PART",
+			wantOK:    false,
+		},
+		{
+			name: "explicit data partition with whitespace blocked while format pending",
+			setup: func(t *testing.T, marker, pending, part string) {
+				touch(t, marker)
+				touch(t, pending)
+				touch(t, part)
+			},
+			requested: " WHITESPACE_DATA_PART ",
+			wantOK:    false,
+		},
+		{
+			name: "explicit data partition blocked when partition missing",
+			setup: func(t *testing.T, marker, _pending, _part string) {
+				touch(t, marker)
+			},
+			requested: "DATA_PART",
+			wantOK:    false,
+		},
+		{
+			name:      "custom image allowed without data disk readiness",
+			requested: "/data/custom.iso",
+			wantImage: "/data/custom.iso",
+			wantOK:    true,
+		},
+		{
+			name:      "custom image path is trimmed",
+			requested: "  /data/custom.iso  ",
+			wantImage: "/data/custom.iso",
+			wantOK:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			marker, pending, part := withDataDiskPaths(t)
+			if tt.setup != nil {
+				tt.setup(t, marker, pending, part)
+			}
+
+			requested := tt.requested
+			if requested == "DATA_PART" {
+				requested = part
+			}
+			if requested == " WHITESPACE_DATA_PART " {
+				requested = "  " + part + "  "
+			}
+
+			got, ok := mountImagePath(requested)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+
+			want := tt.wantImage
+			if want == "DATA_PART" {
+				want = part
+			}
+			if got != want {
+				t.Fatalf("image = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestMountImageDefaultDataDiskNotReadyHasNoSideEffects(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	withDataDiskPaths(t)
+
+	oldMountDevice := mountDevice
+	oldRoFlag := roFlag
+	oldCdromFlag := cdromFlag
+	oldInquiryString := inquiryString
+
+	dir := t.TempDir()
+	mountDevice = filepath.Join(dir, "file")
+	roFlag = filepath.Join(dir, "ro")
+	cdromFlag = filepath.Join(dir, "cdrom")
+	inquiryString = filepath.Join(dir, "inquiry")
+
+	t.Cleanup(func() {
+		mountDevice = oldMountDevice
+		roFlag = oldRoFlag
+		cdromFlag = oldCdromFlag
+		inquiryString = oldInquiryString
+	})
+
+	writeFile := func(path, content string) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	readFile := func(path string) string {
+		t.Helper()
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		return string(content)
+	}
+
+	writeFile(mountDevice, "/data/current.iso")
+	writeFile(roFlag, "1")
+	writeFile(cdromFlag, "1")
+	writeFile(inquiryString, "old inquiry")
+
+	response := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(response)
+	context.Request = httptest.NewRequest("POST", "/storage/image/mount", strings.NewReader(fmt.Sprintf(`{"file":%q}`, dataPartitionPath)))
+	context.Request.Header.Set("Content-Type", "application/json")
+
+	NewService().MountImage(context)
+
+	if !strings.Contains(response.Body.String(), "data disk is not ready") {
+		t.Fatalf("response = %s, want data disk readiness error", response.Body.String())
+	}
+	if got := readFile(mountDevice); got != "/data/current.iso" {
+		t.Fatalf("mountDevice = %q, want unchanged current image", got)
+	}
+	if got := readFile(roFlag); got != "1" {
+		t.Fatalf("roFlag = %q, want unchanged", got)
+	}
+	if got := readFile(cdromFlag); got != "1" {
+		t.Fatalf("cdromFlag = %q, want unchanged", got)
+	}
+	if got := readFile(inquiryString); got != "old inquiry" {
+		t.Fatalf("inquiryString = %q, want unchanged", got)
+	}
+}
+
+func TestMountImageEmptyRequestClearsCurrentImageWhenDataDiskNotReady(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	withDataDiskPaths(t)
+
+	oldMountDevice := mountDevice
+	oldRoFlag := roFlag
+	oldCdromFlag := cdromFlag
+	oldInquiryString := inquiryString
+
+	dir := t.TempDir()
+	mountDevice = filepath.Join(dir, "file")
+	roFlag = filepath.Join(dir, "ro")
+	cdromFlag = filepath.Join(dir, "cdrom")
+	inquiryString = filepath.Join(dir, "inquiry")
+
+	t.Cleanup(func() {
+		mountDevice = oldMountDevice
+		roFlag = oldRoFlag
+		cdromFlag = oldCdromFlag
+		inquiryString = oldInquiryString
+	})
+
+	writeFile := func(path, content string) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	readFile := func(path string) string {
+		t.Helper()
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		return string(content)
+	}
+
+	writeFile(mountDevice, "/data/current.iso")
+	writeFile(roFlag, "1")
+	writeFile(cdromFlag, "1")
+	writeFile(inquiryString, "old inquiry")
+
+	response := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(response)
+	context.Request = httptest.NewRequest("POST", "/storage/image/mount", strings.NewReader(`{"file":""}`))
+	context.Request.Header.Set("Content-Type", "application/json")
+
+	NewService().MountImage(context)
+
+	if strings.Contains(response.Body.String(), "data disk is not ready") {
+		t.Fatalf("response = %s, should allow empty unmount request", response.Body.String())
+	}
+	if got := readFile(mountDevice); got != "" {
+		t.Fatalf("mountDevice = %q, want cleared backing file", got)
+	}
+	if got := readFile(roFlag); got != "0" {
+		t.Fatalf("roFlag = %q, want reset", got)
+	}
+	if got := readFile(cdromFlag); got != "0" {
+		t.Fatalf("cdromFlag = %q, want reset", got)
+	}
+}

--- a/server/service/storage/image_test.go
+++ b/server/service/storage/image_test.go
@@ -1,0 +1,310 @@
+package storage
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func withDataDiskPaths(t *testing.T) (marker string, pending string, part string) {
+	t.Helper()
+
+	oldMarker := dataDiskMarkerPath
+	oldPending := formatPendingPath
+	oldPart := dataPartitionPath
+
+	dir := t.TempDir()
+	marker = filepath.Join(dir, "kvm.disk0")
+	pending = filepath.Join(dir, "kvm.disk0.formatting")
+	part = filepath.Join(dir, "mmcblk0p3")
+
+	dataDiskMarkerPath = marker
+	formatPendingPath = pending
+	dataPartitionPath = part
+
+	t.Cleanup(func() {
+		dataDiskMarkerPath = oldMarker
+		formatPendingPath = oldPending
+		dataPartitionPath = oldPart
+	})
+
+	return marker, pending, part
+}
+
+func touch(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatalf("touch %s: %v", path, err)
+	}
+}
+
+func TestMountImagePathDefaultDataDisk(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(t *testing.T, marker, pending, part string)
+		requested string
+		wantImage string
+		wantOK    bool
+	}{
+		{
+			name:      "empty request clears backing without data disk readiness",
+			wantImage: "",
+			wantOK:    true,
+		},
+		{
+			name: "explicit data partition always requires virtual disk toggle",
+			setup: func(t *testing.T, marker, _pending, part string) {
+				touch(t, marker)
+				touch(t, part)
+			},
+			requested: "DATA_PART",
+			wantOK:    false,
+		},
+		{
+			name: "whitespace data partition always requires virtual disk toggle",
+			setup: func(t *testing.T, marker, _pending, part string) {
+				touch(t, marker)
+				touch(t, part)
+			},
+			requested: " WHITESPACE_DATA_PART ",
+			wantOK:    false,
+		},
+		{
+			name: "explicit data partition blocked without ready marker",
+			setup: func(t *testing.T, _marker, _pending, part string) {
+				touch(t, part)
+			},
+			requested: "DATA_PART",
+			wantOK:    false,
+		},
+		{
+			name: "explicit data partition with whitespace blocked without ready marker",
+			setup: func(t *testing.T, _marker, _pending, part string) {
+				touch(t, part)
+			},
+			requested: " WHITESPACE_DATA_PART ",
+			wantOK:    false,
+		},
+		{
+			name: "explicit data partition blocked while format pending",
+			setup: func(t *testing.T, marker, pending, part string) {
+				touch(t, marker)
+				touch(t, pending)
+				touch(t, part)
+			},
+			requested: "DATA_PART",
+			wantOK:    false,
+		},
+		{
+			name: "explicit data partition with whitespace blocked while format pending",
+			setup: func(t *testing.T, marker, pending, part string) {
+				touch(t, marker)
+				touch(t, pending)
+				touch(t, part)
+			},
+			requested: " WHITESPACE_DATA_PART ",
+			wantOK:    false,
+		},
+		{
+			name: "explicit data partition blocked when partition missing",
+			setup: func(t *testing.T, marker, _pending, _part string) {
+				touch(t, marker)
+			},
+			requested: "DATA_PART",
+			wantOK:    false,
+		},
+		{
+			name:      "custom image allowed without data disk readiness",
+			requested: "/data/custom.iso",
+			wantImage: "/data/custom.iso",
+			wantOK:    true,
+		},
+		{
+			name:      "custom image path is trimmed",
+			requested: "  /data/custom.iso  ",
+			wantImage: "/data/custom.iso",
+			wantOK:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			marker, pending, part := withDataDiskPaths(t)
+			if tt.setup != nil {
+				tt.setup(t, marker, pending, part)
+			}
+
+			requested := tt.requested
+			if requested == "DATA_PART" {
+				requested = part
+			}
+			if requested == " WHITESPACE_DATA_PART " {
+				requested = "  " + part + "  "
+			}
+
+			got, ok := mountImagePath(requested)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+
+			want := tt.wantImage
+			if want == "DATA_PART" {
+				want = part
+			}
+			if got != want {
+				t.Fatalf("image = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestMountImagePathRejectsAliasToDataPartition(t *testing.T) {
+	_, _, part := withDataDiskPaths(t)
+	touch(t, part)
+
+	alias := filepath.Join(t.TempDir(), "data-alias")
+	if err := os.Symlink(part, alias); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := mountImagePath(alias); ok {
+		t.Fatalf("mountImagePath(%q) allowed an alias of the data partition", alias)
+	}
+}
+
+func TestMountImageDefaultDataDiskNotReadyHasNoSideEffects(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	withDataDiskPaths(t)
+
+	oldMountDevice := mountDevice
+	oldRoFlag := roFlag
+	oldCdromFlag := cdromFlag
+	oldInquiryString := inquiryString
+
+	dir := t.TempDir()
+	mountDevice = filepath.Join(dir, "file")
+	roFlag = filepath.Join(dir, "ro")
+	cdromFlag = filepath.Join(dir, "cdrom")
+	inquiryString = filepath.Join(dir, "inquiry")
+
+	t.Cleanup(func() {
+		mountDevice = oldMountDevice
+		roFlag = oldRoFlag
+		cdromFlag = oldCdromFlag
+		inquiryString = oldInquiryString
+	})
+
+	writeFile := func(path, content string) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	readFile := func(path string) string {
+		t.Helper()
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		return string(content)
+	}
+
+	writeFile(mountDevice, "/data/current.iso")
+	writeFile(roFlag, "1")
+	writeFile(cdromFlag, "1")
+	writeFile(inquiryString, "old inquiry")
+
+	response := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(response)
+	context.Request = httptest.NewRequest("POST", "/storage/image/mount", strings.NewReader(fmt.Sprintf(`{"file":%q}`, dataPartitionPath)))
+	context.Request.Header.Set("Content-Type", "application/json")
+
+	NewService().MountImage(context)
+
+	if !strings.Contains(response.Body.String(), "data disk is not ready") {
+		t.Fatalf("response = %s, want data disk readiness error", response.Body.String())
+	}
+	if got := readFile(mountDevice); got != "/data/current.iso" {
+		t.Fatalf("mountDevice = %q, want unchanged current image", got)
+	}
+	if got := readFile(roFlag); got != "1" {
+		t.Fatalf("roFlag = %q, want unchanged", got)
+	}
+	if got := readFile(cdromFlag); got != "1" {
+		t.Fatalf("cdromFlag = %q, want unchanged", got)
+	}
+	if got := readFile(inquiryString); got != "old inquiry" {
+		t.Fatalf("inquiryString = %q, want unchanged", got)
+	}
+}
+
+func TestMountImageEmptyRequestClearsCurrentImageWhenDataDiskNotReady(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	withDataDiskPaths(t)
+
+	oldMountDevice := mountDevice
+	oldRoFlag := roFlag
+	oldCdromFlag := cdromFlag
+	oldInquiryString := inquiryString
+
+	dir := t.TempDir()
+	mountDevice = filepath.Join(dir, "file")
+	roFlag = filepath.Join(dir, "ro")
+	cdromFlag = filepath.Join(dir, "cdrom")
+	inquiryString = filepath.Join(dir, "inquiry")
+
+	t.Cleanup(func() {
+		mountDevice = oldMountDevice
+		roFlag = oldRoFlag
+		cdromFlag = oldCdromFlag
+		inquiryString = oldInquiryString
+	})
+
+	writeFile := func(path, content string) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	readFile := func(path string) string {
+		t.Helper()
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		return string(content)
+	}
+
+	writeFile(mountDevice, "/data/current.iso")
+	writeFile(roFlag, "1")
+	writeFile(cdromFlag, "1")
+	writeFile(inquiryString, "old inquiry")
+
+	response := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(response)
+	context.Request = httptest.NewRequest("POST", "/storage/image/mount", strings.NewReader(`{"file":""}`))
+	context.Request.Header.Set("Content-Type", "application/json")
+
+	NewService().MountImage(context)
+
+	if strings.Contains(response.Body.String(), "data disk is not ready") {
+		t.Fatalf("response = %s, should allow empty unmount request", response.Body.String())
+	}
+	if got := readFile(mountDevice); got != "" {
+		t.Fatalf("mountDevice = %q, want cleared backing file", got)
+	}
+	if got := readFile(roFlag); got != "0" {
+		t.Fatalf("roFlag = %q, want reset", got)
+	}
+	if got := readFile(cdromFlag); got != "0" {
+		t.Fatalf("cdromFlag = %q, want reset", got)
+	}
+}

--- a/server/service/storage/image_test.go
+++ b/server/service/storage/image_test.go
@@ -17,6 +17,9 @@ func withDataDiskPaths(t *testing.T) (marker string, pending string, part string
 	oldMarker := dataDiskMarkerPath
 	oldPending := formatPendingPath
 	oldPart := dataPartitionPath
+	oldVirtualDisk := virtualDiskPath
+	oldMounted := dataDirectoryMount
+	oldRunCommand := runShellCommand
 
 	dir := t.TempDir()
 	marker = filepath.Join(dir, "kvm.disk0")
@@ -26,11 +29,17 @@ func withDataDiskPaths(t *testing.T) (marker string, pending string, part string
 	dataDiskMarkerPath = marker
 	formatPendingPath = pending
 	dataPartitionPath = part
+	virtualDiskPath = filepath.Join(dir, "usb.disk0")
+	dataDirectoryMount = func(string) bool { return true }
+	runShellCommand = func(string) error { return nil }
 
 	t.Cleanup(func() {
 		dataDiskMarkerPath = oldMarker
 		formatPendingPath = oldPending
 		dataPartitionPath = oldPart
+		virtualDiskPath = oldVirtualDisk
+		dataDirectoryMount = oldMounted
+		runShellCommand = oldRunCommand
 	})
 
 	return marker, pending, part
@@ -41,6 +50,15 @@ func touch(t *testing.T, path string) {
 	if err := os.WriteFile(path, nil, 0o600); err != nil {
 		t.Fatalf("touch %s: %v", path, err)
 	}
+}
+
+func readText(t *testing.T, path string) string {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(content)
 }
 
 func TestMountImagePathDefaultDataDisk(t *testing.T) {
@@ -295,6 +313,9 @@ func TestMountImageEmptyRequestClearsCurrentImageWhenDataDiskNotReady(t *testing
 
 	NewService().MountImage(context)
 
+	if !strings.Contains(response.Body.String(), `"code":0`) {
+		t.Fatalf("response = %s, want success", response.Body.String())
+	}
 	if strings.Contains(response.Body.String(), "data disk is not ready") {
 		t.Fatalf("response = %s, should allow empty unmount request", response.Body.String())
 	}
@@ -306,5 +327,150 @@ func TestMountImageEmptyRequestClearsCurrentImageWhenDataDiskNotReady(t *testing
 	}
 	if got := readFile(cdromFlag); got != "0" {
 		t.Fatalf("cdromFlag = %q, want reset", got)
+	}
+}
+
+func TestMountImageEmptyRequestRestoresReadyDefaultBacking(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	_, _, part := withDataDiskPaths(t)
+	dataDirectoryMount = func(string) bool { return false }
+	touch(t, part)
+	touch(t, dataDiskMarkerPath)
+	touch(t, virtualDiskPath)
+
+	oldMountDevice := mountDevice
+	oldRoFlag := roFlag
+	oldCdromFlag := cdromFlag
+	oldInquiryString := inquiryString
+	dir := t.TempDir()
+	mountDevice = filepath.Join(dir, "file")
+	roFlag = filepath.Join(dir, "ro")
+	cdromFlag = filepath.Join(dir, "cdrom")
+	inquiryString = filepath.Join(dir, "inquiry")
+	t.Cleanup(func() {
+		mountDevice = oldMountDevice
+		roFlag = oldRoFlag
+		cdromFlag = oldCdromFlag
+		inquiryString = oldInquiryString
+	})
+
+	response := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(response)
+	context.Request = httptest.NewRequest("POST", "/storage/image/mount", strings.NewReader(`{"file":""}`))
+	context.Request.Header.Set("Content-Type", "application/json")
+
+	NewService().MountImage(context)
+
+	if !strings.Contains(response.Body.String(), `"code":0`) {
+		t.Fatalf("response = %s, want success", response.Body.String())
+	}
+	if got := readText(t, mountDevice); got != part {
+		t.Fatalf("mountDevice = %q, want default partition %q", got, part)
+	}
+	if got := readText(t, roFlag); got != "0" {
+		t.Fatalf("roFlag = %q, want reset", got)
+	}
+	if got := readText(t, cdromFlag); got != "0" {
+		t.Fatalf("cdromFlag = %q, want reset", got)
+	}
+}
+
+func TestMountImageEmptyRequestDoesNotExposeMountedDefaultBacking(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	_, _, part := withDataDiskPaths(t)
+	touch(t, part)
+	touch(t, dataDiskMarkerPath)
+	touch(t, virtualDiskPath)
+
+	oldMountDevice := mountDevice
+	oldRoFlag := roFlag
+	oldCdromFlag := cdromFlag
+	oldInquiryString := inquiryString
+	dir := t.TempDir()
+	mountDevice = filepath.Join(dir, "file")
+	roFlag = filepath.Join(dir, "ro")
+	cdromFlag = filepath.Join(dir, "cdrom")
+	inquiryString = filepath.Join(dir, "inquiry")
+	t.Cleanup(func() {
+		mountDevice = oldMountDevice
+		roFlag = oldRoFlag
+		cdromFlag = oldCdromFlag
+		inquiryString = oldInquiryString
+	})
+
+	response := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(response)
+	context.Request = httptest.NewRequest("POST", "/storage/image/mount", strings.NewReader(`{"file":""}`))
+	context.Request.Header.Set("Content-Type", "application/json")
+
+	NewService().MountImage(context)
+
+	if !strings.Contains(response.Body.String(), `"code":0`) {
+		t.Fatalf("response = %s, want success", response.Body.String())
+	}
+	if got := readText(t, mountDevice); got != "" {
+		t.Fatalf("mountDevice = %q, want mounted data disk left detached", got)
+	}
+}
+
+func TestMountImageWhitespaceRequestResetsFlags(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	withDataDiskPaths(t)
+
+	oldMountDevice := mountDevice
+	oldRoFlag := roFlag
+	oldCdromFlag := cdromFlag
+	oldInquiryString := inquiryString
+	dir := t.TempDir()
+	mountDevice = filepath.Join(dir, "file")
+	roFlag = filepath.Join(dir, "ro")
+	cdromFlag = filepath.Join(dir, "cdrom")
+	inquiryString = filepath.Join(dir, "inquiry")
+	t.Cleanup(func() {
+		mountDevice = oldMountDevice
+		roFlag = oldRoFlag
+		cdromFlag = oldCdromFlag
+		inquiryString = oldInquiryString
+	})
+
+	if err := os.WriteFile(roFlag, []byte("1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cdromFlag, []byte("1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	response := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(response)
+	context.Request = httptest.NewRequest("POST", "/storage/image/mount", strings.NewReader(`{"file":"   "}`))
+	context.Request.Header.Set("Content-Type", "application/json")
+
+	NewService().MountImage(context)
+
+	if !strings.Contains(response.Body.String(), `"code":0`) {
+		t.Fatalf("response = %s, want success", response.Body.String())
+	}
+	if got := readText(t, roFlag); got != "0" {
+		t.Fatalf("roFlag = %q, want reset", got)
+	}
+	if got := readText(t, cdromFlag); got != "0" {
+		t.Fatalf("cdromFlag = %q, want reset", got)
+	}
+}
+
+func TestMountImageDataPathRequiresMountedDataDisk(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	withDataDiskPaths(t)
+	dataDirectoryMount = func(string) bool { return false }
+
+	response := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(response)
+	context.Request = httptest.NewRequest("POST", "/storage/image/mount", strings.NewReader(`{"file":"/data/custom.iso"}`))
+	context.Request.Header.Set("Content-Type", "application/json")
+
+	NewService().MountImage(context)
+
+	if !strings.Contains(response.Body.String(), "data disk is not mounted") {
+		t.Fatalf("response = %s, want data mount error", response.Body.String())
 	}
 }

--- a/server/service/vm/virtual-device.go
+++ b/server/service/vm/virtual-device.go
@@ -10,11 +10,22 @@ import (
 
 	"NanoKVM-Server/proto"
 	"NanoKVM-Server/service/hid"
+	"NanoKVM-Server/service/vm/virtualdisk"
 )
 
 const (
 	virtualNetwork = "/boot/usb.rndis0"
 	virtualDisk    = "/boot/usb.disk0"
+	dataDiskMarker = "/etc/kvm.disk0"
+	formatPending  = "/etc/kvm.disk0.formatting"
+	dataPartition  = "/dev/mmcblk0p3"
+)
+
+var (
+	virtualDiskPath    = virtualDisk
+	dataDiskMarkerPath = dataDiskMarker
+	formatPendingPath  = formatPending
+	dataPartitionPath  = dataPartition
 )
 
 var (
@@ -49,7 +60,7 @@ func (s *Service) GetVirtualDevice(c *gin.Context) {
 	var rsp proto.Response
 
 	network, _ := isDeviceExist(virtualNetwork)
-	disk, _ := isDeviceExist(virtualDisk)
+	disk := isVirtualDiskConfigured()
 
 	rsp.OkRspWithData(c, &proto.GetVirtualDeviceRsp{
 		Network: network,
@@ -81,14 +92,8 @@ func (s *Service) UpdateVirtualDevice(c *gin.Context) {
 			commands = unmountNetworkCommands
 		}
 	case "disk":
-		device = virtualDisk
-
-		exist, _ := isDeviceExist(device)
-		if !exist {
-			commands = mountDiskCommands
-		} else {
-			commands = unmountDiskCommands
-		}
+		device = virtualDiskPath
+		commands = virtualDiskCommands()
 	default:
 		rsp.ErrRsp(c, -2, "invalid arguments")
 		return
@@ -111,11 +116,27 @@ func (s *Service) UpdateVirtualDevice(c *gin.Context) {
 	}
 
 	on, _ := isDeviceExist(device)
+	if req.Device == "disk" {
+		on = isVirtualDiskConfigured()
+	}
 	rsp.OkRspWithData(c, &proto.UpdateVirtualDeviceRsp{
 		On: on,
 	})
 
 	log.Debugf("update virtual device %s success", req.Device)
+}
+
+func virtualDiskCommands() []string {
+	return virtualdisk.Commands(isVirtualDiskConfigured(), mountDiskCommands, unmountDiskCommands)
+}
+
+func isVirtualDiskConfigured() bool {
+	return virtualdisk.IsConfigured(virtualdisk.Paths{
+		Config:    virtualDiskPath,
+		Marker:    dataDiskMarkerPath,
+		Pending:   formatPendingPath,
+		Partition: dataPartitionPath,
+	})
 }
 
 func isDeviceExist(device string) (bool, error) {

--- a/server/service/vm/virtual-device.go
+++ b/server/service/vm/virtual-device.go
@@ -100,6 +100,10 @@ func (s *Service) UpdateVirtualDevice(c *gin.Context) {
 		h.Unlock()
 	}()
 	if req.Device == "disk" {
+		if !isVirtualDiskConfigured() && !isDefaultVirtualDiskReady() {
+			rsp.ErrRsp(c, -3, "data disk is not ready")
+			return
+		}
 		commands = virtualDiskCommands()
 	}
 
@@ -131,6 +135,15 @@ func virtualDiskCommands() []string {
 
 func isDefaultVirtualDiskConfigured() bool {
 	return virtualdisk.IsDefaultConfigured(virtualdisk.Paths{
+		Config:    virtualDiskPath,
+		Marker:    dataDiskMarkerPath,
+		Pending:   formatPendingPath,
+		Partition: dataPartitionPath,
+	})
+}
+
+func isDefaultVirtualDiskReady() bool {
+	return virtualdisk.IsDefaultReady(virtualdisk.Paths{
 		Config:    virtualDiskPath,
 		Marker:    dataDiskMarkerPath,
 		Pending:   formatPendingPath,

--- a/server/service/vm/virtual-device.go
+++ b/server/service/vm/virtual-device.go
@@ -10,11 +10,22 @@ import (
 
 	"NanoKVM-Server/proto"
 	"NanoKVM-Server/service/hid"
+	"NanoKVM-Server/service/vm/virtualdisk"
 )
 
 const (
 	virtualNetwork = "/boot/usb.rndis0"
 	virtualDisk    = "/boot/usb.disk0"
+	dataDiskMarker = "/etc/kvm.disk0"
+	formatPending  = "/etc/kvm.disk0.formatting"
+	dataPartition  = "/dev/mmcblk0p3"
+)
+
+var (
+	virtualDiskPath    = virtualDisk
+	dataDiskMarkerPath = dataDiskMarker
+	formatPendingPath  = formatPending
+	dataPartitionPath  = dataPartition
 )
 
 var (
@@ -31,13 +42,7 @@ var (
 		"/etc/init.d/S03usbdev start",
 	}
 
-	mountDiskCommands = []string{
-		"touch /boot/usb.disk0",
-		"/etc/init.d/S03usbdev stop",
-		"/etc/init.d/S03usbdev start",
-	}
-
-	unmountDiskCommands = []string{
+	unmountCustomDiskCommands = []string{
 		"/etc/init.d/S03usbdev stop",
 		"rm -rf /sys/kernel/config/usb_gadget/g0/configs/c.1/mass_storage.disk0",
 		"rm /boot/usb.disk0",
@@ -49,7 +54,7 @@ func (s *Service) GetVirtualDevice(c *gin.Context) {
 	var rsp proto.Response
 
 	network, _ := isDeviceExist(virtualNetwork)
-	disk, _ := isDeviceExist(virtualDisk)
+	disk := isVirtualDiskConfigured()
 
 	rsp.OkRspWithData(c, &proto.GetVirtualDeviceRsp{
 		Network: network,
@@ -81,14 +86,7 @@ func (s *Service) UpdateVirtualDevice(c *gin.Context) {
 			commands = unmountNetworkCommands
 		}
 	case "disk":
-		device = virtualDisk
-
-		exist, _ := isDeviceExist(device)
-		if !exist {
-			commands = mountDiskCommands
-		} else {
-			commands = unmountDiskCommands
-		}
+		device = virtualDiskPath
 	default:
 		rsp.ErrRsp(c, -2, "invalid arguments")
 		return
@@ -101,6 +99,9 @@ func (s *Service) UpdateVirtualDevice(c *gin.Context) {
 		h.OpenNoLock()
 		h.Unlock()
 	}()
+	if req.Device == "disk" {
+		commands = virtualDiskCommands()
+	}
 
 	for _, command := range commands {
 		err := exec.Command("sh", "-c", command).Run()
@@ -111,11 +112,39 @@ func (s *Service) UpdateVirtualDevice(c *gin.Context) {
 	}
 
 	on, _ := isDeviceExist(device)
+	if req.Device == "disk" {
+		on = isVirtualDiskConfigured()
+	}
 	rsp.OkRspWithData(c, &proto.UpdateVirtualDeviceRsp{
 		On: on,
 	})
 
 	log.Debugf("update virtual device %s success", req.Device)
+}
+
+func virtualDiskCommands() []string {
+	if isVirtualDiskConfigured() && !isDefaultVirtualDiskConfigured() {
+		return unmountCustomDiskCommands
+	}
+	return virtualdisk.ToggleCommands(isVirtualDiskConfigured())
+}
+
+func isDefaultVirtualDiskConfigured() bool {
+	return virtualdisk.IsDefaultConfigured(virtualdisk.Paths{
+		Config:    virtualDiskPath,
+		Marker:    dataDiskMarkerPath,
+		Pending:   formatPendingPath,
+		Partition: dataPartitionPath,
+	})
+}
+
+func isVirtualDiskConfigured() bool {
+	return virtualdisk.IsConfigured(virtualdisk.Paths{
+		Config:    virtualDiskPath,
+		Marker:    dataDiskMarkerPath,
+		Pending:   formatPendingPath,
+		Partition: dataPartitionPath,
+	})
 }
 
 func isDeviceExist(device string) (bool, error) {

--- a/server/service/vm/virtualdisk/state.go
+++ b/server/service/vm/virtualdisk/state.go
@@ -1,0 +1,43 @@
+package virtualdisk
+
+import (
+	"os"
+	"strings"
+)
+
+type Paths struct {
+	Config    string
+	Marker    string
+	Pending   string
+	Partition string
+}
+
+func IsConfigured(paths Paths) bool {
+	content, err := os.ReadFile(paths.Config)
+	if err != nil {
+		return false
+	}
+
+	disk := strings.TrimSpace(string(content))
+	if disk != "" && disk != paths.Partition {
+		return true
+	}
+
+	if _, err := os.Stat(paths.Marker); err != nil {
+		return false
+	}
+	if _, err := os.Stat(paths.Pending); err == nil {
+		return false
+	}
+	if _, err := os.Stat(paths.Partition); err != nil {
+		return false
+	}
+	return true
+}
+
+func Commands(configured bool, mountCommands, unmountCommands []string) []string {
+	if configured {
+		return unmountCommands
+	}
+	return mountCommands
+}

--- a/server/service/vm/virtualdisk/state.go
+++ b/server/service/vm/virtualdisk/state.go
@@ -1,0 +1,89 @@
+package virtualdisk
+
+import (
+	"os"
+	"strings"
+)
+
+type Paths struct {
+	Config    string
+	Marker    string
+	Pending   string
+	Partition string
+}
+
+var (
+	mountCommands = []string{
+		"sync",
+		"umount /data",
+		"touch /boot/usb.disk0",
+		"/etc/init.d/S03usbdev stop",
+		"/etc/init.d/S03usbdev start",
+	}
+
+	unmountCommands = []string{
+		"/etc/init.d/S03usbdev stop",
+		"printf '\\n' > /sys/kernel/config/usb_gadget/g0/functions/mass_storage.disk0/lun.0/file",
+		"sync",
+		"mount /dev/mmcblk0p3 /data",
+		"rm /boot/usb.disk0",
+		"/etc/init.d/S03usbdev start",
+	}
+)
+
+func IsConfigured(paths Paths) bool {
+	return ConfiguredDisk(paths) != ""
+}
+
+func IsDefaultConfigured(paths Paths) bool {
+	disk := ConfiguredDisk(paths)
+	if disk == paths.Partition {
+		return true
+	}
+
+	diskInfo, err := os.Stat(disk)
+	if err != nil {
+		return false
+	}
+	partitionInfo, err := os.Stat(paths.Partition)
+	return err == nil && os.SameFile(diskInfo, partitionInfo)
+}
+
+func ConfiguredDisk(paths Paths) string {
+	content, err := os.ReadFile(paths.Config)
+	if err != nil {
+		return ""
+	}
+
+	disk := strings.TrimSpace(string(content))
+	if disk != "" && disk != paths.Partition {
+		return disk
+	}
+
+	if IsDefaultReady(paths) {
+		return paths.Partition
+	}
+	return ""
+}
+
+func IsDefaultReady(paths Paths) bool {
+	if _, err := os.Stat(paths.Marker); err != nil {
+		return false
+	}
+	if _, err := os.Stat(paths.Pending); err == nil {
+		return false
+	}
+	_, err := os.Stat(paths.Partition)
+	return err == nil
+}
+
+func Commands(configured bool, mountCommands, unmountCommands []string) []string {
+	if configured {
+		return unmountCommands
+	}
+	return mountCommands
+}
+
+func ToggleCommands(configured bool) []string {
+	return Commands(configured, mountCommands, unmountCommands)
+}

--- a/server/service/vm/virtualdisk/state.go
+++ b/server/service/vm/virtualdisk/state.go
@@ -37,16 +37,7 @@ func IsConfigured(paths Paths) bool {
 
 func IsDefaultConfigured(paths Paths) bool {
 	disk := ConfiguredDisk(paths)
-	if disk == paths.Partition {
-		return true
-	}
-
-	diskInfo, err := os.Stat(disk)
-	if err != nil {
-		return false
-	}
-	partitionInfo, err := os.Stat(paths.Partition)
-	return err == nil && os.SameFile(diskInfo, partitionInfo)
+	return disk == paths.Partition
 }
 
 func ConfiguredDisk(paths Paths) string {

--- a/server/service/vm/virtualdisk/state_test.go
+++ b/server/service/vm/virtualdisk/state_test.go
@@ -1,0 +1,138 @@
+package virtualdisk
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func testPaths(t *testing.T) Paths {
+	t.Helper()
+
+	dir := t.TempDir()
+	return Paths{
+		Config:    filepath.Join(dir, "usb.disk0"),
+		Marker:    filepath.Join(dir, "kvm.disk0"),
+		Pending:   filepath.Join(dir, "kvm.disk0.formatting"),
+		Partition: filepath.Join(dir, "mmcblk0p3"),
+	}
+}
+
+func touch(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatalf("touch %s: %v", path, err)
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestIsConfigured(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, paths Paths)
+		want  bool
+	}{
+		{
+			name: "ready default data partition",
+			setup: func(t *testing.T, paths Paths) {
+				touch(t, paths.Config)
+				touch(t, paths.Marker)
+				touch(t, paths.Partition)
+			},
+			want: true,
+		},
+		{
+			name: "explicit ready data partition",
+			setup: func(t *testing.T, paths Paths) {
+				writeFile(t, paths.Config, paths.Partition+"\n")
+				touch(t, paths.Marker)
+				touch(t, paths.Partition)
+			},
+			want: true,
+		},
+		{
+			name: "explicit ready data partition with whitespace",
+			setup: func(t *testing.T, paths Paths) {
+				writeFile(t, paths.Config, "  "+paths.Partition+"  \n")
+				touch(t, paths.Marker)
+				touch(t, paths.Partition)
+			},
+			want: true,
+		},
+		{
+			name: "pending data partition",
+			setup: func(t *testing.T, paths Paths) {
+				touch(t, paths.Config)
+				touch(t, paths.Marker)
+				touch(t, paths.Pending)
+				touch(t, paths.Partition)
+			},
+		},
+		{
+			name: "missing ready marker",
+			setup: func(t *testing.T, paths Paths) {
+				touch(t, paths.Config)
+				touch(t, paths.Partition)
+			},
+		},
+		{
+			name: "missing data partition",
+			setup: func(t *testing.T, paths Paths) {
+				touch(t, paths.Config)
+				touch(t, paths.Marker)
+			},
+		},
+		{
+			name: "custom backing file",
+			setup: func(t *testing.T, paths Paths) {
+				writeFile(t, paths.Config, "/data/custom.img\n")
+			},
+			want: true,
+		},
+		{
+			name: "custom backing file ignores pending data partition",
+			setup: func(t *testing.T, paths Paths) {
+				writeFile(t, paths.Config, "/data/custom.img\n")
+				touch(t, paths.Marker)
+				touch(t, paths.Pending)
+				touch(t, paths.Partition)
+			},
+			want: true,
+		},
+		{
+			name: "no disk config",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			paths := testPaths(t)
+			if tt.setup != nil {
+				tt.setup(t, paths)
+			}
+
+			if got := IsConfigured(paths); got != tt.want {
+				t.Fatalf("IsConfigured() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCommands(t *testing.T) {
+	mount := []string{"mount"}
+	unmount := []string{"unmount"}
+
+	if got := Commands(false, mount, unmount); !reflect.DeepEqual(got, mount) {
+		t.Fatalf("Commands(false) = %#v, want mount commands", got)
+	}
+	if got := Commands(true, mount, unmount); !reflect.DeepEqual(got, unmount) {
+		t.Fatalf("Commands(true) = %#v, want unmount commands", got)
+	}
+}

--- a/server/service/vm/virtualdisk/state_test.go
+++ b/server/service/vm/virtualdisk/state_test.go
@@ -1,0 +1,205 @@
+package virtualdisk
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func testPaths(t *testing.T) Paths {
+	t.Helper()
+
+	dir := t.TempDir()
+	return Paths{
+		Config:    filepath.Join(dir, "usb.disk0"),
+		Marker:    filepath.Join(dir, "kvm.disk0"),
+		Pending:   filepath.Join(dir, "kvm.disk0.formatting"),
+		Partition: filepath.Join(dir, "mmcblk0p3"),
+	}
+}
+
+func touch(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatalf("touch %s: %v", path, err)
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestIsConfigured(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, paths Paths)
+		want  bool
+	}{
+		{
+			name: "ready default data partition",
+			setup: func(t *testing.T, paths Paths) {
+				touch(t, paths.Config)
+				touch(t, paths.Marker)
+				touch(t, paths.Partition)
+			},
+			want: true,
+		},
+		{
+			name: "explicit ready data partition",
+			setup: func(t *testing.T, paths Paths) {
+				writeFile(t, paths.Config, paths.Partition+"\n")
+				touch(t, paths.Marker)
+				touch(t, paths.Partition)
+			},
+			want: true,
+		},
+		{
+			name: "explicit ready data partition with whitespace",
+			setup: func(t *testing.T, paths Paths) {
+				writeFile(t, paths.Config, "  "+paths.Partition+"  \n")
+				touch(t, paths.Marker)
+				touch(t, paths.Partition)
+			},
+			want: true,
+		},
+		{
+			name: "pending data partition",
+			setup: func(t *testing.T, paths Paths) {
+				touch(t, paths.Config)
+				touch(t, paths.Marker)
+				touch(t, paths.Pending)
+				touch(t, paths.Partition)
+			},
+		},
+		{
+			name: "missing ready marker",
+			setup: func(t *testing.T, paths Paths) {
+				touch(t, paths.Config)
+				touch(t, paths.Partition)
+			},
+		},
+		{
+			name: "missing data partition",
+			setup: func(t *testing.T, paths Paths) {
+				touch(t, paths.Config)
+				touch(t, paths.Marker)
+			},
+		},
+		{
+			name: "custom backing file",
+			setup: func(t *testing.T, paths Paths) {
+				writeFile(t, paths.Config, "/data/custom.img\n")
+			},
+			want: true,
+		},
+		{
+			name: "custom backing file ignores pending data partition",
+			setup: func(t *testing.T, paths Paths) {
+				writeFile(t, paths.Config, "/data/custom.img\n")
+				touch(t, paths.Marker)
+				touch(t, paths.Pending)
+				touch(t, paths.Partition)
+			},
+			want: true,
+		},
+		{
+			name: "no disk config",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			paths := testPaths(t)
+			if tt.setup != nil {
+				tt.setup(t, paths)
+			}
+
+			if got := IsConfigured(paths); got != tt.want {
+				t.Fatalf("IsConfigured() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsDefaultReady(t *testing.T) {
+	paths := testPaths(t)
+	if IsDefaultReady(paths) {
+		t.Fatal("missing default data disk reported ready")
+	}
+
+	touch(t, paths.Marker)
+	touch(t, paths.Partition)
+	if !IsDefaultReady(paths) {
+		t.Fatal("ready default data disk reported unavailable")
+	}
+
+	touch(t, paths.Pending)
+	if IsDefaultReady(paths) {
+		t.Fatal("pending default data disk reported ready")
+	}
+}
+
+func TestIsDefaultConfigured(t *testing.T) {
+	paths := testPaths(t)
+	touch(t, paths.Config)
+	touch(t, paths.Marker)
+	touch(t, paths.Partition)
+	if !IsDefaultConfigured(paths) {
+		t.Fatal("ready default data disk reported as custom or unavailable")
+	}
+
+	alias := filepath.Join(filepath.Dir(paths.Partition), "partition-alias")
+	if err := os.Symlink(paths.Partition, alias); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, paths.Config, alias)
+	if !IsDefaultConfigured(paths) {
+		t.Fatal("alias of ready default data disk reported as custom")
+	}
+
+	writeFile(t, paths.Config, "/data/custom.img")
+	if IsDefaultConfigured(paths) {
+		t.Fatal("custom backing file reported as default data disk")
+	}
+}
+
+func TestCommands(t *testing.T) {
+	mount := []string{"mount"}
+	unmount := []string{"unmount"}
+
+	if got := Commands(false, mount, unmount); !reflect.DeepEqual(got, mount) {
+		t.Fatalf("Commands(false) = %#v, want mount commands", got)
+	}
+	if got := Commands(true, mount, unmount); !reflect.DeepEqual(got, unmount) {
+		t.Fatalf("Commands(true) = %#v, want unmount commands", got)
+	}
+}
+
+func TestToggleCommandsTransferDataPartitionOwnership(t *testing.T) {
+	wantMount := []string{
+		"sync",
+		"umount /data",
+		"touch /boot/usb.disk0",
+		"/etc/init.d/S03usbdev stop",
+		"/etc/init.d/S03usbdev start",
+	}
+	if got := ToggleCommands(false); !reflect.DeepEqual(got, wantMount) {
+		t.Fatalf("ToggleCommands(false) = %#v, want %#v", got, wantMount)
+	}
+
+	wantUnmount := []string{
+		"/etc/init.d/S03usbdev stop",
+		"printf '\\n' > /sys/kernel/config/usb_gadget/g0/functions/mass_storage.disk0/lun.0/file",
+		"sync",
+		"mount /dev/mmcblk0p3 /data",
+		"rm /boot/usb.disk0",
+		"/etc/init.d/S03usbdev start",
+	}
+	if got := ToggleCommands(true); !reflect.DeepEqual(got, wantUnmount) {
+		t.Fatalf("ToggleCommands(true) = %#v, want %#v", got, wantUnmount)
+	}
+}

--- a/server/service/vm/virtualdisk/state_test.go
+++ b/server/service/vm/virtualdisk/state_test.go
@@ -157,8 +157,8 @@ func TestIsDefaultConfigured(t *testing.T) {
 		t.Fatal(err)
 	}
 	writeFile(t, paths.Config, alias)
-	if !IsDefaultConfigured(paths) {
-		t.Fatal("alias of ready default data disk reported as custom")
+	if IsDefaultConfigured(paths) {
+		t.Fatal("alias of ready default data disk was treated as owned default")
 	}
 
 	writeFile(t, paths.Config, "/data/custom.img")

--- a/server/utils/mount.go
+++ b/server/utils/mount.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"os"
+	"strings"
+)
+
+// IsMountPoint reports whether path is an actual mount point in this process's
+// mount namespace. This avoids treating an unmounted mount directory on the
+// root filesystem as the data volume.
+func IsMountPoint(path string) bool {
+	content, err := os.ReadFile("/proc/self/mountinfo")
+	return err == nil && IsMountPointInInfo(string(content), path)
+}
+
+func IsMountPointInInfo(content, path string) bool {
+	for line := range strings.SplitSeq(content, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) > 4 && fields[4] == path {
+			return true
+		}
+	}
+	return false
+}

--- a/server/utils/mount_test.go
+++ b/server/utils/mount_test.go
@@ -1,0 +1,15 @@
+package utils
+
+import "testing"
+
+func TestIsMountPointInInfo(t *testing.T) {
+	content := "36 25 179:3 / / rw,relatime - ext4 /dev/mmcblk0p2 rw\n" +
+		"37 36 179:4 / /data rw,relatime - exfat /dev/mmcblk0p3 rw\n"
+
+	if !IsMountPointInInfo(content, "/data") {
+		t.Fatal("/data mount was not detected")
+	}
+	if IsMountPointInInfo(content, "/data/child") {
+		t.Fatal("child path was incorrectly treated as a mount point")
+	}
+}

--- a/tools/test-s01fs-data-disk.sh
+++ b/tools/test-s01fs-data-disk.sh
@@ -1,0 +1,507 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+s01_script="$repo_root/kvmapp/system/init.d/S01fs"
+s03_script="$repo_root/kvmapp/system/init.d/S03usbdev"
+real_dd="$(command -v dd)"
+real_mkdir="$(command -v mkdir)"
+
+tmpdir=""
+original_path="$PATH"
+
+make_stubs() {
+	local bin="$1"
+
+	cat >"$bin/mount" <<'EOF'
+#!/bin/sh
+printf 'mount %s\n' "$*" >> "$NANOKVM_TEST_LOG"
+if [ "${NANOKVM_MOUNT_FAIL:-0}" = "1" ]; then
+	exit 1
+fi
+exit 0
+EOF
+
+	cat >"$bin/mkdir" <<'EOF'
+#!/bin/sh
+"$NANOKVM_REAL_MKDIR" "$@"
+for path do
+	case "$path" in
+		*/functions/mass_storage.disk0|functions/mass_storage.disk0)
+			"$NANOKVM_REAL_MKDIR" -p "$path/lun.0"
+			;;
+	esac
+done
+EOF
+
+	cat >"$bin/resize2fs" <<'EOF'
+#!/bin/sh
+printf 'resize2fs %s\n' "$*" >> "$NANOKVM_TEST_LOG"
+exit 0
+EOF
+
+	cat >"$bin/sleep" <<'EOF'
+#!/bin/sh
+if [ "${NANOKVM_DELAY_DATA_PART_UNTIL_SLEEP:-0}" = "1" ] && [ ! -e "$NANOKVM_DATA_PART" ]; then
+	: > "$NANOKVM_DATA_PART"
+fi
+exit 0
+EOF
+
+	cat >"$bin/parted" <<'EOF'
+#!/bin/sh
+printf 'parted %s\n' "$*" >> "$NANOKVM_TEST_LOG"
+case " $* " in
+	*" mkpart primary 8193MB 100% "*)
+		if [ "${NANOKVM_DELAY_DATA_PART_UNTIL_SLEEP:-0}" != "1" ] && [ "${NANOKVM_NEVER_CREATE_DATA_PART:-0}" != "1" ]; then
+			: > "$NANOKVM_DATA_PART"
+			if [ "${NANOKVM_PARTED_CREATES_STALE_FS:-0}" = "1" ]; then
+				: > "$NANOKVM_DATA_PART.hasfs"
+			fi
+		fi
+		;;
+esac
+exit 0
+EOF
+
+	cat >"$bin/blkid" <<'EOF'
+#!/bin/sh
+printf 'blkid %s\n' "$*" >> "$NANOKVM_TEST_LOG"
+if [ -e "$1.hasfs" ]; then
+	printf '%s: UUID="test" TYPE="exfat"\n' "$1"
+fi
+exit 0
+EOF
+
+	cat >"$bin/mkfs.exfat" <<'EOF'
+#!/bin/sh
+printf 'mkfs.exfat %s\n' "$*" >> "$NANOKVM_TEST_LOG"
+if [ "${NANOKVM_MKFS_FAIL:-0}" = "1" ]; then
+	exit 1
+fi
+: > "$1.hasfs"
+exit 0
+EOF
+
+	cat >"$bin/dd" <<'EOF'
+#!/bin/sh
+printf 'dd %s\n' "$*" >> "$NANOKVM_TEST_LOG"
+exec "$NANOKVM_REAL_DD" "$@"
+EOF
+
+	chmod +x "$bin/mount" "$bin/mkdir" "$bin/resize2fs" "$bin/sleep" "$bin/parted" "$bin/blkid" "$bin/mkfs.exfat" "$bin/dd"
+}
+
+setup_case() {
+	tmpdir="$(mktemp -d)"
+	original_path="$PATH"
+	mkdir -p "$tmpdir/bin" "$tmpdir/boot" "$tmpdir/data" "$tmpdir/dev" "$tmpdir/etc"
+	make_stubs "$tmpdir/bin"
+
+	export PATH="$tmpdir/bin:$PATH"
+	export NANOKVM_TEST_LOG="$tmpdir/log"
+	export NANOKVM_DISK="$tmpdir/dev/mmcblk0"
+	export NANOKVM_BOOT_PART="$tmpdir/dev/mmcblk0p1"
+	export NANOKVM_ROOT_PART="$tmpdir/dev/mmcblk0p2"
+	export NANOKVM_DATA_PART="$tmpdir/dev/mmcblk0p3"
+	export NANOKVM_BOOT_DIR="$tmpdir/boot"
+	export NANOKVM_DATA_DIR="$tmpdir/data"
+	export NANOKVM_DISK0_MARKER="$tmpdir/etc/kvm.disk0"
+	export NANOKVM_DATA_FORMAT_PENDING="$tmpdir/etc/kvm.disk0.formatting"
+	export NANOKVM_PROFILE="$tmpdir/profile"
+	export NANOKVM_REAL_DD="$real_dd"
+	export NANOKVM_REAL_MKDIR="$real_mkdir"
+
+	: > "$NANOKVM_DISK"
+	: > "$NANOKVM_BOOT_PART"
+	: > "$NANOKVM_ROOT_PART"
+	: > "$NANOKVM_BOOT_DIR/usb.disk0"
+	: > "$NANOKVM_TEST_LOG"
+	: > "$NANOKVM_PROFILE"
+}
+
+teardown_case() {
+	PATH="$original_path"
+	export PATH
+	if [ -n "$tmpdir" ]; then
+		rm -rf "$tmpdir"
+	fi
+	tmpdir=""
+}
+
+run_s01() {
+	"$s01_script" start >/dev/null
+}
+
+load_s03_helpers() {
+	# shellcheck disable=SC1090
+	. <(sed -n '1,/^start_usb_dev()/ { /^start_usb_dev()/q; p; }' "$s03_script")
+}
+
+run_case() {
+	local name="$1"
+	local setup_fn="$2"
+	local run_fn="$3"
+	local assert_fn="$4"
+
+	setup_case
+	trap teardown_case RETURN
+	"$setup_fn"
+	"$run_fn"
+	"$assert_fn"
+	teardown_case
+	trap - RETURN
+	printf 'ok - %s\n' "$name"
+}
+
+noop() {
+	:
+}
+
+exists() {
+	[ -e "$1" ]
+}
+
+missing() {
+	[ ! -e "$1" ]
+}
+
+log_contains() {
+	local pattern="$1"
+	if ! grep -Fq "$pattern" "$NANOKVM_TEST_LOG"; then
+		printf 'expected log to contain: %s\n' "$pattern" >&2
+		cat "$NANOKVM_TEST_LOG" >&2
+		exit 1
+	fi
+}
+
+log_not_contains() {
+	local pattern="$1"
+	if grep -Fq "$pattern" "$NANOKVM_TEST_LOG"; then
+		printf 'expected log not to contain: %s\n' "$pattern" >&2
+		cat "$NANOKVM_TEST_LOG" >&2
+		exit 1
+	fi
+}
+
+given_pending_partition() {
+	: > "$NANOKVM_DATA_PART"
+	: > "$NANOKVM_DISK0_MARKER"
+	: > "$NANOKVM_DATA_FORMAT_PENDING"
+}
+
+assert_pending_partition_formatted() {
+	exists "$NANOKVM_DATA_PART.hasfs"
+	exists "$NANOKVM_DISK0_MARKER"
+	missing "$NANOKVM_DATA_FORMAT_PENDING"
+	log_not_contains "blkid $NANOKVM_DATA_PART"
+	log_contains "mkfs.exfat $NANOKVM_DATA_PART"
+	log_contains "mount $NANOKVM_DATA_PART $NANOKVM_DATA_DIR"
+}
+
+given_format_fails() {
+	given_pending_partition
+	export NANOKVM_MKFS_FAIL=1
+}
+
+assert_format_failure_keeps_pending() {
+	missing "$NANOKVM_DISK0_MARKER"
+	exists "$NANOKVM_DATA_FORMAT_PENDING"
+	log_contains "mkfs.exfat $NANOKVM_DATA_PART"
+	unset NANOKVM_MKFS_FAIL
+}
+
+given_delayed_partition_and_format_fails() {
+	export NANOKVM_DELAY_DATA_PART_UNTIL_SLEEP=1
+	export NANOKVM_MKFS_FAIL=1
+}
+
+assert_delayed_partition_failure_keeps_pending() {
+	exists "$NANOKVM_DATA_PART"
+	missing "$NANOKVM_DISK0_MARKER"
+	exists "$NANOKVM_DATA_FORMAT_PENDING"
+	log_contains "parted -s $NANOKVM_DISK mkpart primary 8193MB 100%"
+	log_contains "mkfs.exfat $NANOKVM_DATA_PART"
+	unset NANOKVM_DELAY_DATA_PART_UNTIL_SLEEP
+	unset NANOKVM_MKFS_FAIL
+}
+
+given_partition_never_appears() {
+	export NANOKVM_NEVER_CREATE_DATA_PART=1
+}
+
+assert_late_device_keeps_pending_without_format() {
+	missing "$NANOKVM_DATA_PART"
+	missing "$NANOKVM_DISK0_MARKER"
+	exists "$NANOKVM_DATA_FORMAT_PENDING"
+	log_contains "parted -s $NANOKVM_DISK mkpart primary 8193MB 100%"
+	log_not_contains "mkfs.exfat $NANOKVM_DATA_PART"
+	unset NANOKVM_NEVER_CREATE_DATA_PART
+}
+
+given_mount_fails_after_format() {
+	given_pending_partition
+	export NANOKVM_MOUNT_FAIL=1
+}
+
+assert_mount_failure_clears_ready_marker() {
+	exists "$NANOKVM_DATA_PART.hasfs"
+	missing "$NANOKVM_DISK0_MARKER"
+	missing "$NANOKVM_DATA_FORMAT_PENDING"
+	log_contains "mkfs.exfat $NANOKVM_DATA_PART"
+	log_contains "mount $NANOKVM_DATA_PART $NANOKVM_DATA_DIR"
+	unset NANOKVM_MOUNT_FAIL
+}
+
+given_unknown_existing_partition() {
+	printf 'user data' > "$NANOKVM_DATA_PART"
+	: > "$NANOKVM_DISK0_MARKER"
+}
+
+assert_unknown_partition_ignored() {
+	missing "$NANOKVM_DISK0_MARKER"
+	log_contains "blkid $NANOKVM_DATA_PART"
+	log_not_contains "mkfs.exfat $NANOKVM_DATA_PART"
+	log_not_contains "mount $NANOKVM_DATA_PART $NANOKVM_DATA_DIR"
+}
+
+given_empty_legacy_marked_partition() {
+	: > "$NANOKVM_DATA_PART"
+	: > "$NANOKVM_DISK0_MARKER"
+}
+
+assert_empty_legacy_partition_recovered() {
+	exists "$NANOKVM_DATA_PART.hasfs"
+	exists "$NANOKVM_DISK0_MARKER"
+	missing "$NANOKVM_DATA_FORMAT_PENDING"
+	log_contains "blkid $NANOKVM_DATA_PART"
+	log_contains "dd if=$NANOKVM_DATA_PART"
+	log_contains "mkfs.exfat $NANOKVM_DATA_PART"
+	log_contains "mount $NANOKVM_DATA_PART $NANOKVM_DATA_DIR"
+}
+
+given_empty_unmarked_partition() {
+	: > "$NANOKVM_DATA_PART"
+}
+
+assert_empty_unmarked_partition_ignored() {
+	missing "$NANOKVM_DISK0_MARKER"
+	log_contains "blkid $NANOKVM_DATA_PART"
+	log_not_contains "dd if=$NANOKVM_DATA_PART"
+	log_not_contains "mkfs.exfat $NANOKVM_DATA_PART"
+	log_not_contains "mount $NANOKVM_DATA_PART $NANOKVM_DATA_DIR"
+}
+
+given_existing_filesystem() {
+	: > "$NANOKVM_DATA_PART"
+	: > "$NANOKVM_DATA_PART.hasfs"
+}
+
+assert_existing_filesystem_mounted() {
+	log_contains "mount $NANOKVM_DATA_PART $NANOKVM_DATA_DIR"
+	exists "$NANOKVM_DISK0_MARKER"
+	log_contains "blkid $NANOKVM_DATA_PART"
+	log_not_contains "mkfs.exfat $NANOKVM_DATA_PART"
+}
+
+given_existing_filesystem_mount_fails() {
+	given_existing_filesystem
+	: > "$NANOKVM_DISK0_MARKER"
+	export NANOKVM_MOUNT_FAIL=1
+}
+
+assert_existing_filesystem_mount_failure_clears_marker() {
+	missing "$NANOKVM_DISK0_MARKER"
+	log_contains "blkid $NANOKVM_DATA_PART"
+	log_contains "mount $NANOKVM_DATA_PART $NANOKVM_DATA_DIR"
+	log_not_contains "mkfs.exfat $NANOKVM_DATA_PART"
+	unset NANOKVM_MOUNT_FAIL
+}
+
+given_new_partition_with_stale_signature() {
+	export NANOKVM_PARTED_CREATES_STALE_FS=1
+}
+
+assert_new_partition_formatted_despite_stale_signature() {
+	exists "$NANOKVM_DATA_PART"
+	exists "$NANOKVM_DISK0_MARKER"
+	missing "$NANOKVM_DATA_FORMAT_PENDING"
+	log_contains "parted -s $NANOKVM_DISK mkpart primary 8193MB 100%"
+	log_not_contains "blkid $NANOKVM_DATA_PART"
+	log_contains "mkfs.exfat $NANOKVM_DATA_PART"
+	log_contains "mount $NANOKVM_DATA_PART $NANOKVM_DATA_DIR"
+	unset NANOKVM_PARTED_CREATES_STALE_FS
+}
+
+assert_missing_partition_created_and_formatted() {
+	exists "$NANOKVM_DATA_PART"
+	exists "$NANOKVM_DATA_PART.hasfs"
+	exists "$NANOKVM_DISK0_MARKER"
+	missing "$NANOKVM_DATA_FORMAT_PENDING"
+	log_contains "parted -s $NANOKVM_DISK mkpart primary 8193MB 100%"
+	log_contains "mkfs.exfat $NANOKVM_DATA_PART"
+	log_contains "mount $NANOKVM_DATA_PART $NANOKVM_DATA_DIR"
+}
+
+given_custom_backing_file_configured() {
+	printf '%s\n' "$tmpdir/custom.img" > "$NANOKVM_BOOT_DIR/usb.disk0"
+}
+
+given_custom_backing_with_pending_default_partition() {
+	given_custom_backing_file_configured
+	: > "$NANOKVM_DATA_PART"
+	: > "$NANOKVM_DATA_FORMAT_PENDING"
+}
+
+given_custom_backing_with_unknown_marked_partition() {
+	given_custom_backing_file_configured
+	printf 'user data' > "$NANOKVM_DATA_PART"
+	: > "$NANOKVM_DISK0_MARKER"
+}
+
+assert_custom_backing_does_not_create_default_partition() {
+	missing "$NANOKVM_DATA_PART"
+	missing "$NANOKVM_DISK0_MARKER"
+	missing "$NANOKVM_DATA_FORMAT_PENDING"
+	log_not_contains "parted -s $NANOKVM_DISK mkpart primary 8193MB 100%"
+	log_not_contains "mkfs.exfat $NANOKVM_DATA_PART"
+	log_not_contains "mount $NANOKVM_DATA_PART $NANOKVM_DATA_DIR"
+}
+
+assert_pending_default_partition_retried_with_custom_backing() {
+	exists "$NANOKVM_DATA_PART.hasfs"
+	exists "$NANOKVM_DISK0_MARKER"
+	missing "$NANOKVM_DATA_FORMAT_PENDING"
+	log_contains "mkfs.exfat $NANOKVM_DATA_PART"
+	log_contains "mount $NANOKVM_DATA_PART $NANOKVM_DATA_DIR"
+}
+
+assert_custom_backing_unknown_partition_clears_marker() {
+	missing "$NANOKVM_DISK0_MARKER"
+	log_contains "blkid $NANOKVM_DATA_PART"
+	log_not_contains "mkfs.exfat $NANOKVM_DATA_PART"
+	log_not_contains "mount $NANOKVM_DATA_PART $NANOKVM_DATA_DIR"
+}
+
+given_explicit_default_partition_configured() {
+	printf '%s\n' "$NANOKVM_DATA_PART" > "$NANOKVM_BOOT_DIR/usb.disk0"
+}
+
+given_explicit_default_partition_with_whitespace_configured() {
+	printf '  %s  \n' "$NANOKVM_DATA_PART" > "$NANOKVM_BOOT_DIR/usb.disk0"
+}
+
+run_s03_helper() {
+	load_s03_helpers
+}
+
+run_s03_mass_storage() {
+	load_s03_helpers
+	mkdir -p "$tmpdir/gadget/functions" "$tmpdir/gadget/configs/c.1"
+	(
+		cd "$tmpdir/gadget"
+		configure_mass_storage
+	)
+}
+
+given_s03_ready_default() {
+	: > "$NANOKVM_DATA_PART"
+	: > "$NANOKVM_DISK0_MARKER"
+}
+
+assert_s03_default_ready() {
+	[ "$(default_data_disk_file)" = "$NANOKVM_DATA_PART" ]
+	[ "$(resolve_disk_file "")" = "$NANOKVM_DATA_PART" ]
+	[ "$(resolve_disk_file "$NANOKVM_DATA_PART")" = "$NANOKVM_DATA_PART" ]
+}
+
+given_s03_pending_default() {
+	given_s03_ready_default
+	: > "$NANOKVM_DATA_FORMAT_PENDING"
+}
+
+assert_s03_default_hidden() {
+	[ -z "$(default_data_disk_file)" ]
+	[ -z "$(resolve_disk_file "")" ]
+	[ -z "$(resolve_disk_file "$NANOKVM_DATA_PART")" ]
+}
+
+given_s03_missing_marker() {
+	: > "$NANOKVM_DATA_PART"
+}
+
+given_s03_missing_device() {
+	: > "$NANOKVM_DISK0_MARKER"
+}
+
+assert_s03_custom_disk_allowed() {
+	[ "$(resolve_disk_file "/data/custom.img")" = "/data/custom.img" ]
+	[ "$(resolve_disk_file "  /data/custom.img  ")" = "/data/custom.img" ]
+}
+
+assert_s03_explicit_default_with_whitespace_ready() {
+	[ "$(resolve_disk_file "  $NANOKVM_DATA_PART  ")" = "$NANOKVM_DATA_PART" ]
+}
+
+assert_s03_explicit_default_with_whitespace_hidden() {
+	[ -z "$(resolve_disk_file "  $NANOKVM_DATA_PART  ")" ]
+}
+
+assert_s03_mass_storage_created_for_ready_default() {
+	exists "$tmpdir/gadget/functions/mass_storage.disk0"
+	[ -L "$tmpdir/gadget/configs/c.1/mass_storage.disk0" ]
+	[ "$(cat "$tmpdir/gadget/functions/mass_storage.disk0/lun.0/file")" = "$NANOKVM_DATA_PART" ]
+	[ "$(cat "$tmpdir/gadget/functions/mass_storage.disk0/lun.0/removable")" = "1" ]
+	[ "$(cat "$tmpdir/gadget/functions/mass_storage.disk0/lun.0/inquiry_string")" = "NanoKVM USB Mass Storage0520" ]
+}
+
+assert_s03_mass_storage_not_created() {
+	missing "$tmpdir/gadget/functions/mass_storage.disk0"
+	missing "$tmpdir/gadget/configs/c.1/mass_storage.disk0"
+}
+
+given_s03_custom_disk() {
+	printf '%s\n' "$tmpdir/custom.img" > "$NANOKVM_BOOT_DIR/usb.disk0"
+}
+
+given_s03_explicit_default_with_whitespace() {
+	given_s03_ready_default
+	printf '  %s  \n' "$NANOKVM_DATA_PART" > "$NANOKVM_BOOT_DIR/usb.disk0"
+}
+
+assert_s03_mass_storage_created_for_custom_disk() {
+	exists "$tmpdir/gadget/functions/mass_storage.disk0"
+	[ -L "$tmpdir/gadget/configs/c.1/mass_storage.disk0" ]
+	[ "$(cat "$tmpdir/gadget/functions/mass_storage.disk0/lun.0/file")" = "$tmpdir/custom.img" ]
+}
+
+run_case "retries pending unformatted partition" given_pending_partition run_s01 assert_pending_partition_formatted
+run_case "keeps pending marker when mkfs fails" given_format_fails run_s01 assert_format_failure_keeps_pending
+run_case "keeps pending marker when delayed partition format fails" given_delayed_partition_and_format_fails run_s01 assert_delayed_partition_failure_keeps_pending
+run_case "keeps pending marker when new partition device is late" given_partition_never_appears run_s01 assert_late_device_keeps_pending_without_format
+run_case "removes marker when mount fails after format" given_mount_fails_after_format run_s01 assert_mount_failure_clears_ready_marker
+run_case "does not format or mount unknown existing partition" given_unknown_existing_partition run_s01 assert_unknown_partition_ignored
+run_case "recovers zero-filled legacy marked partition" given_empty_legacy_marked_partition run_s01 assert_empty_legacy_partition_recovered
+run_case "does not recover zero-filled partition without legacy marker" given_empty_unmarked_partition run_s01 assert_empty_unmarked_partition_ignored
+run_case "mounts existing filesystem without formatting" given_existing_filesystem run_s01 assert_existing_filesystem_mounted
+run_case "removes marker when existing filesystem mount fails" given_existing_filesystem_mount_fails run_s01 assert_existing_filesystem_mount_failure_clears_marker
+run_case "formats new partition even with stale signature" given_new_partition_with_stale_signature run_s01 assert_new_partition_formatted_despite_stale_signature
+run_case "creates and formats missing partition" noop run_s01 assert_missing_partition_created_and_formatted
+run_case "does not create default partition for custom backing file" given_custom_backing_file_configured run_s01 assert_custom_backing_does_not_create_default_partition
+run_case "retries pending default partition with custom backing file" given_custom_backing_with_pending_default_partition run_s01 assert_pending_default_partition_retried_with_custom_backing
+run_case "clears stale marker for unknown partition with custom backing file" given_custom_backing_with_unknown_marked_partition run_s01 assert_custom_backing_unknown_partition_clears_marker
+run_case "creates default partition when explicitly configured" given_explicit_default_partition_configured run_s01 assert_missing_partition_created_and_formatted
+run_case "trims explicit default partition config before creating it" given_explicit_default_partition_with_whitespace_configured run_s01 assert_missing_partition_created_and_formatted
+run_case "S03 exposes default data disk only when ready" given_s03_ready_default run_s03_helper assert_s03_default_ready
+run_case "S03 hides default and explicit p3 when format is pending" given_s03_pending_default run_s03_helper assert_s03_default_hidden
+run_case "S03 hides default and explicit p3 without ready marker" given_s03_missing_marker run_s03_helper assert_s03_default_hidden
+run_case "S03 hides default and explicit p3 when device is missing" given_s03_missing_device run_s03_helper assert_s03_default_hidden
+run_case "S03 still allows custom backing files" noop run_s03_helper assert_s03_custom_disk_allowed
+run_case "S03 trims explicit p3 before resolving readiness" given_s03_ready_default run_s03_helper assert_s03_explicit_default_with_whitespace_ready
+run_case "S03 hides whitespace explicit p3 while format is pending" given_s03_pending_default run_s03_helper assert_s03_explicit_default_with_whitespace_hidden
+run_case "S03 creates mass storage for ready default data disk" given_s03_ready_default run_s03_mass_storage assert_s03_mass_storage_created_for_ready_default
+run_case "S03 skips mass storage while default data disk is pending" given_s03_pending_default run_s03_mass_storage assert_s03_mass_storage_not_created
+run_case "S03 creates mass storage for custom backing files" given_s03_custom_disk run_s03_mass_storage assert_s03_mass_storage_created_for_custom_disk
+run_case "S03 trims explicit p3 before creating mass storage" given_s03_explicit_default_with_whitespace run_s03_mass_storage assert_s03_mass_storage_created_for_ready_default
+
+echo "S01fs data disk tests passed"

--- a/tools/test-s01fs-data-disk.sh
+++ b/tools/test-s01fs-data-disk.sh
@@ -1,0 +1,576 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+s01_script="$repo_root/kvmapp/system/init.d/S01fs"
+s03_script="$repo_root/kvmapp/system/init.d/S03usbdev"
+real_dd="$(command -v dd)"
+real_mkdir="$(command -v mkdir)"
+
+tmpdir=""
+original_path="$PATH"
+
+make_stubs() {
+	local bin="$1"
+
+	cat >"$bin/mount" <<'EOF'
+#!/bin/sh
+printf 'mount %s\n' "$*" >> "$NANOKVM_TEST_LOG"
+if [ "${NANOKVM_MOUNT_FAIL:-0}" = "1" ]; then
+	exit 1
+fi
+exit 0
+EOF
+
+	cat >"$bin/mkdir" <<'EOF'
+#!/bin/sh
+"$NANOKVM_REAL_MKDIR" "$@"
+for path do
+	case "$path" in
+		*/functions/mass_storage.disk0|functions/mass_storage.disk0)
+			"$NANOKVM_REAL_MKDIR" -p "$path/lun.0"
+			;;
+	esac
+done
+EOF
+
+	cat >"$bin/resize2fs" <<'EOF'
+#!/bin/sh
+printf 'resize2fs %s\n' "$*" >> "$NANOKVM_TEST_LOG"
+exit 0
+EOF
+
+	cat >"$bin/sleep" <<'EOF'
+#!/bin/sh
+if [ "${NANOKVM_DELAY_DATA_PART_UNTIL_SLEEP:-0}" = "1" ] && [ ! -e "$NANOKVM_DATA_PART" ]; then
+	: > "$NANOKVM_DATA_PART"
+fi
+exit 0
+EOF
+
+	cat >"$bin/parted" <<'EOF'
+#!/bin/sh
+printf 'parted %s\n' "$*" >> "$NANOKVM_TEST_LOG"
+case " $* " in
+	*" mkpart primary 8193MB 100% "*)
+		if [ "${NANOKVM_DELAY_DATA_PART_UNTIL_SLEEP:-0}" != "1" ] && [ "${NANOKVM_NEVER_CREATE_DATA_PART:-0}" != "1" ]; then
+			: > "$NANOKVM_DATA_PART"
+			if [ "${NANOKVM_PARTED_CREATES_STALE_FS:-0}" = "1" ]; then
+				: > "$NANOKVM_DATA_PART.hasfs"
+			fi
+		fi
+		;;
+esac
+exit 0
+EOF
+
+	cat >"$bin/blkid" <<'EOF'
+#!/bin/sh
+printf 'blkid %s\n' "$*" >> "$NANOKVM_TEST_LOG"
+if [ -e "$1.hasfs" ]; then
+	printf '%s: UUID="test" TYPE="exfat"\n' "$1"
+fi
+exit 0
+EOF
+
+	cat >"$bin/mkfs.exfat" <<'EOF'
+#!/bin/sh
+printf 'mkfs.exfat %s\n' "$*" >> "$NANOKVM_TEST_LOG"
+if [ "${NANOKVM_MKFS_FAIL:-0}" = "1" ]; then
+	exit 1
+fi
+: > "$1.hasfs"
+exit 0
+EOF
+
+	cat >"$bin/dd" <<'EOF'
+#!/bin/sh
+printf 'dd %s\n' "$*" >> "$NANOKVM_TEST_LOG"
+exec "$NANOKVM_REAL_DD" "$@"
+EOF
+
+	chmod +x "$bin/mount" "$bin/mkdir" "$bin/resize2fs" "$bin/sleep" "$bin/parted" "$bin/blkid" "$bin/mkfs.exfat" "$bin/dd"
+}
+
+setup_case() {
+	tmpdir="$(mktemp -d)"
+	original_path="$PATH"
+	mkdir -p "$tmpdir/bin" "$tmpdir/boot" "$tmpdir/data" "$tmpdir/dev" "$tmpdir/etc"
+	make_stubs "$tmpdir/bin"
+
+	export PATH="$tmpdir/bin:$PATH"
+	export NANOKVM_TEST_LOG="$tmpdir/log"
+	export NANOKVM_DISK="$tmpdir/dev/mmcblk0"
+	export NANOKVM_BOOT_PART="$tmpdir/dev/mmcblk0p1"
+	export NANOKVM_ROOT_PART="$tmpdir/dev/mmcblk0p2"
+	export NANOKVM_DATA_PART="$tmpdir/dev/mmcblk0p3"
+	export NANOKVM_BOOT_DIR="$tmpdir/boot"
+	export NANOKVM_DATA_DIR="$tmpdir/data"
+	export NANOKVM_DISK0_MARKER="$tmpdir/etc/kvm.disk0"
+	export NANOKVM_DATA_FORMAT_PENDING="$tmpdir/etc/kvm.disk0.formatting"
+	export NANOKVM_PROFILE="$tmpdir/profile"
+	export NANOKVM_REAL_DD="$real_dd"
+	export NANOKVM_REAL_MKDIR="$real_mkdir"
+
+	: > "$NANOKVM_DISK"
+	: > "$NANOKVM_BOOT_PART"
+	: > "$NANOKVM_ROOT_PART"
+	: > "$NANOKVM_TEST_LOG"
+	: > "$NANOKVM_PROFILE"
+}
+
+teardown_case() {
+	PATH="$original_path"
+	export PATH
+	if [ -n "$tmpdir" ]; then
+		rm -rf "$tmpdir"
+	fi
+	tmpdir=""
+}
+
+run_s01() {
+	"$s01_script" start >/dev/null
+}
+
+load_s03_helpers() {
+	# shellcheck disable=SC1090
+	. <(sed -n '1,/^start_usb_dev()/ { /^start_usb_dev()/q; p; }' "$s03_script")
+}
+
+run_case() {
+	local name="$1"
+	local setup_fn="$2"
+	local run_fn="$3"
+	local assert_fn="$4"
+
+	setup_case
+	local status=0
+	"$setup_fn" || status=$?
+	[ "$status" -ne 0 ] || "$run_fn" || status=$?
+	[ "$status" -ne 0 ] || "$assert_fn" || status=$?
+	teardown_case
+	if [ "$status" -ne 0 ]; then
+		return "$status"
+	fi
+	printf 'ok - %s\n' "$name"
+}
+
+noop() {
+	:
+}
+
+exists() {
+	[ -e "$1" ]
+}
+
+missing() {
+	[ ! -e "$1" ]
+}
+
+log_contains() {
+	local pattern="$1"
+	if ! grep -Fq "$pattern" "$NANOKVM_TEST_LOG"; then
+		printf 'expected log to contain: %s\n' "$pattern" >&2
+		cat "$NANOKVM_TEST_LOG" >&2
+		exit 1
+	fi
+}
+
+log_not_contains() {
+	local pattern="$1"
+	if grep -Fq "$pattern" "$NANOKVM_TEST_LOG"; then
+		printf 'expected log not to contain: %s\n' "$pattern" >&2
+		cat "$NANOKVM_TEST_LOG" >&2
+		exit 1
+	fi
+}
+
+given_pending_partition() {
+	: > "$NANOKVM_DATA_PART"
+	: > "$NANOKVM_DISK0_MARKER"
+	: > "$NANOKVM_DATA_FORMAT_PENDING"
+}
+
+assert_pending_partition_formatted() {
+	exists "$NANOKVM_DATA_PART.hasfs"
+	exists "$NANOKVM_DISK0_MARKER"
+	missing "$NANOKVM_DATA_FORMAT_PENDING"
+	log_not_contains "blkid $NANOKVM_DATA_PART"
+	log_contains "mkfs.exfat $NANOKVM_DATA_PART"
+	log_contains "mount $NANOKVM_DATA_PART $NANOKVM_DATA_DIR"
+}
+
+given_format_fails() {
+	given_pending_partition
+	export NANOKVM_MKFS_FAIL=1
+}
+
+assert_format_failure_keeps_pending() {
+	missing "$NANOKVM_DISK0_MARKER"
+	exists "$NANOKVM_DATA_FORMAT_PENDING"
+	log_contains "mkfs.exfat $NANOKVM_DATA_PART"
+	unset NANOKVM_MKFS_FAIL
+}
+
+given_delayed_partition_and_format_fails() {
+	given_default_disk_configured
+	export NANOKVM_DELAY_DATA_PART_UNTIL_SLEEP=1
+	export NANOKVM_MKFS_FAIL=1
+}
+
+assert_delayed_partition_failure_keeps_pending() {
+	exists "$NANOKVM_DATA_PART"
+	missing "$NANOKVM_DISK0_MARKER"
+	exists "$NANOKVM_DATA_FORMAT_PENDING"
+	log_contains "parted -s $NANOKVM_DISK mkpart primary 8193MB 100%"
+	log_contains "mkfs.exfat $NANOKVM_DATA_PART"
+	unset NANOKVM_DELAY_DATA_PART_UNTIL_SLEEP
+	unset NANOKVM_MKFS_FAIL
+}
+
+given_partition_never_appears() {
+	given_default_disk_configured
+	export NANOKVM_NEVER_CREATE_DATA_PART=1
+}
+
+assert_late_device_keeps_pending_without_format() {
+	missing "$NANOKVM_DATA_PART"
+	missing "$NANOKVM_DISK0_MARKER"
+	exists "$NANOKVM_DATA_FORMAT_PENDING"
+	log_contains "parted -s $NANOKVM_DISK mkpart primary 8193MB 100%"
+	log_not_contains "mkfs.exfat $NANOKVM_DATA_PART"
+	unset NANOKVM_NEVER_CREATE_DATA_PART
+}
+
+given_mount_fails_after_format() {
+	given_pending_partition
+	export NANOKVM_MOUNT_FAIL=1
+}
+
+assert_mount_failure_clears_ready_marker() {
+	exists "$NANOKVM_DATA_PART.hasfs"
+	missing "$NANOKVM_DISK0_MARKER"
+	missing "$NANOKVM_DATA_FORMAT_PENDING"
+	log_contains "mkfs.exfat $NANOKVM_DATA_PART"
+	log_contains "mount $NANOKVM_DATA_PART $NANOKVM_DATA_DIR"
+	unset NANOKVM_MOUNT_FAIL
+}
+
+given_unknown_existing_partition() {
+	printf 'user data' > "$NANOKVM_DATA_PART"
+	: > "$NANOKVM_DISK0_MARKER"
+}
+
+assert_unknown_partition_ignored() {
+	missing "$NANOKVM_DISK0_MARKER"
+	log_contains "blkid $NANOKVM_DATA_PART"
+	log_not_contains "mkfs.exfat $NANOKVM_DATA_PART"
+	log_not_contains "mount $NANOKVM_DATA_PART $NANOKVM_DATA_DIR"
+}
+
+given_empty_legacy_marked_partition() {
+	: > "$NANOKVM_DATA_PART"
+	: > "$NANOKVM_DISK0_MARKER"
+}
+
+assert_empty_legacy_partition_left_unformatted() {
+	missing "$NANOKVM_DATA_PART.hasfs"
+	missing "$NANOKVM_DISK0_MARKER"
+	missing "$NANOKVM_DATA_FORMAT_PENDING"
+	log_contains "blkid $NANOKVM_DATA_PART"
+	log_not_contains "dd if=$NANOKVM_DATA_PART"
+	log_not_contains "mkfs.exfat $NANOKVM_DATA_PART"
+	log_not_contains "mount $NANOKVM_DATA_PART $NANOKVM_DATA_DIR"
+}
+
+given_empty_unmarked_partition() {
+	: > "$NANOKVM_DATA_PART"
+}
+
+assert_empty_unmarked_partition_ignored() {
+	missing "$NANOKVM_DISK0_MARKER"
+	log_contains "blkid $NANOKVM_DATA_PART"
+	log_not_contains "dd if=$NANOKVM_DATA_PART"
+	log_not_contains "mkfs.exfat $NANOKVM_DATA_PART"
+	log_not_contains "mount $NANOKVM_DATA_PART $NANOKVM_DATA_DIR"
+}
+
+given_existing_filesystem() {
+	: > "$NANOKVM_DATA_PART"
+	: > "$NANOKVM_DATA_PART.hasfs"
+}
+
+assert_existing_filesystem_mounted() {
+	log_contains "mount $NANOKVM_DATA_PART $NANOKVM_DATA_DIR"
+	exists "$NANOKVM_DISK0_MARKER"
+	log_contains "blkid $NANOKVM_DATA_PART"
+	log_not_contains "mkfs.exfat $NANOKVM_DATA_PART"
+}
+
+given_existing_filesystem_mount_fails() {
+	given_existing_filesystem
+	: > "$NANOKVM_DISK0_MARKER"
+	export NANOKVM_MOUNT_FAIL=1
+}
+
+assert_existing_filesystem_mount_failure_clears_marker() {
+	missing "$NANOKVM_DISK0_MARKER"
+	log_contains "blkid $NANOKVM_DATA_PART"
+	log_contains "mount $NANOKVM_DATA_PART $NANOKVM_DATA_DIR"
+	log_not_contains "mkfs.exfat $NANOKVM_DATA_PART"
+	unset NANOKVM_MOUNT_FAIL
+}
+
+given_new_partition_with_stale_signature() {
+	given_default_disk_configured
+	export NANOKVM_PARTED_CREATES_STALE_FS=1
+}
+
+assert_new_partition_formatted_despite_stale_signature() {
+	exists "$NANOKVM_DATA_PART"
+	exists "$NANOKVM_DISK0_MARKER"
+	missing "$NANOKVM_DATA_FORMAT_PENDING"
+	log_contains "parted -s $NANOKVM_DISK mkpart primary 8193MB 100%"
+	log_not_contains "blkid $NANOKVM_DATA_PART"
+	log_contains "mkfs.exfat $NANOKVM_DATA_PART"
+	log_not_contains "mount $NANOKVM_DATA_PART $NANOKVM_DATA_DIR"
+	unset NANOKVM_PARTED_CREATES_STALE_FS
+}
+
+assert_missing_partition_created_and_formatted() {
+	exists "$NANOKVM_DATA_PART"
+	exists "$NANOKVM_DATA_PART.hasfs"
+	exists "$NANOKVM_DISK0_MARKER"
+	missing "$NANOKVM_DATA_FORMAT_PENDING"
+	log_contains "parted -s $NANOKVM_DISK mkpart primary 8193MB 100%"
+	log_contains "mkfs.exfat $NANOKVM_DATA_PART"
+	log_not_contains "mount $NANOKVM_DATA_PART $NANOKVM_DATA_DIR"
+}
+
+given_default_disk_configured() {
+	: > "$NANOKVM_BOOT_DIR/usb.disk0"
+}
+
+given_custom_backing_file_configured() {
+	printf '%s\n' "$tmpdir/custom.img" > "$NANOKVM_BOOT_DIR/usb.disk0"
+}
+
+given_custom_backing_with_pending_default_partition() {
+	given_custom_backing_file_configured
+	: > "$NANOKVM_DATA_PART"
+	: > "$NANOKVM_DATA_FORMAT_PENDING"
+}
+
+given_custom_backing_with_unknown_marked_partition() {
+	given_custom_backing_file_configured
+	printf 'user data' > "$NANOKVM_DATA_PART"
+	: > "$NANOKVM_DISK0_MARKER"
+}
+
+assert_custom_backing_does_not_create_default_partition() {
+	missing "$NANOKVM_DATA_PART"
+	missing "$NANOKVM_DISK0_MARKER"
+	missing "$NANOKVM_DATA_FORMAT_PENDING"
+	log_not_contains "parted -s $NANOKVM_DISK mkpart primary 8193MB 100%"
+	log_not_contains "mkfs.exfat $NANOKVM_DATA_PART"
+	log_not_contains "mount $NANOKVM_DATA_PART $NANOKVM_DATA_DIR"
+}
+
+assert_pending_default_partition_retried_with_custom_backing() {
+	exists "$NANOKVM_DATA_PART.hasfs"
+	exists "$NANOKVM_DISK0_MARKER"
+	missing "$NANOKVM_DATA_FORMAT_PENDING"
+	log_contains "mkfs.exfat $NANOKVM_DATA_PART"
+	log_contains "mount $NANOKVM_DATA_PART $NANOKVM_DATA_DIR"
+}
+
+given_default_disk_with_unknown_partition() {
+	given_default_disk_configured
+	printf 'user data' > "$NANOKVM_DATA_PART"
+	: > "$NANOKVM_DISK0_MARKER"
+}
+
+assert_default_unknown_partition_is_not_exported() {
+	missing "$NANOKVM_DISK0_MARKER"
+	log_contains "blkid $NANOKVM_DATA_PART"
+	log_not_contains "mkfs.exfat $NANOKVM_DATA_PART"
+	log_not_contains "mount $NANOKVM_DATA_PART $NANOKVM_DATA_DIR"
+}
+
+assert_custom_backing_unknown_partition_clears_marker() {
+	missing "$NANOKVM_DISK0_MARKER"
+	log_contains "blkid $NANOKVM_DATA_PART"
+	log_not_contains "mkfs.exfat $NANOKVM_DATA_PART"
+	log_not_contains "mount $NANOKVM_DATA_PART $NANOKVM_DATA_DIR"
+}
+
+given_explicit_default_partition_configured() {
+	printf '%s\n' "$NANOKVM_DATA_PART" > "$NANOKVM_BOOT_DIR/usb.disk0"
+}
+
+given_explicit_default_partition_with_whitespace_configured() {
+	printf '  %s  \n' "$NANOKVM_DATA_PART" > "$NANOKVM_BOOT_DIR/usb.disk0"
+}
+
+given_enabled_virtual_data_disk() {
+	given_existing_filesystem
+	: > "$NANOKVM_DISK0_MARKER"
+	: > "$NANOKVM_BOOT_DIR/usb.disk0"
+}
+
+assert_enabled_virtual_data_disk_is_not_mounted_locally() {
+	exists "$NANOKVM_DISK0_MARKER"
+	log_not_contains "mount $NANOKVM_DATA_PART $NANOKVM_DATA_DIR"
+}
+
+given_enabled_virtual_data_disk_without_marker() {
+	given_existing_filesystem
+	: > "$NANOKVM_BOOT_DIR/usb.disk0"
+}
+
+assert_enabled_virtual_data_disk_recovers_marker_without_mounting() {
+	exists "$NANOKVM_DISK0_MARKER"
+	log_contains "blkid $NANOKVM_DATA_PART"
+	log_not_contains "mount $NANOKVM_DATA_PART $NANOKVM_DATA_DIR"
+}
+
+run_s01_then_s03_mass_storage() {
+	run_s01
+	run_s03_mass_storage
+}
+
+assert_enabled_virtual_data_disk_is_exported_without_local_mount() {
+	assert_enabled_virtual_data_disk_is_not_mounted_locally
+	assert_s03_mass_storage_created_for_ready_default
+}
+
+run_s03_helper() {
+	load_s03_helpers
+}
+
+run_s03_mass_storage() {
+	load_s03_helpers
+	mkdir -p "$tmpdir/gadget/functions" "$tmpdir/gadget/configs/c.1"
+	(
+		cd "$tmpdir/gadget"
+		configure_mass_storage
+	)
+}
+
+given_s03_ready_default() {
+	: > "$NANOKVM_DATA_PART"
+	: > "$NANOKVM_DISK0_MARKER"
+	: > "$NANOKVM_BOOT_DIR/usb.disk0"
+}
+
+assert_s03_default_ready() {
+	[ "$(default_data_disk_file)" = "$NANOKVM_DATA_PART" ]
+	[ "$(resolve_disk_file "")" = "$NANOKVM_DATA_PART" ]
+	[ "$(resolve_disk_file "$NANOKVM_DATA_PART")" = "$NANOKVM_DATA_PART" ]
+}
+
+given_s03_pending_default() {
+	given_s03_ready_default
+	: > "$NANOKVM_DATA_FORMAT_PENDING"
+}
+
+assert_s03_default_hidden() {
+	[ -z "$(default_data_disk_file)" ]
+	[ -z "$(resolve_disk_file "")" ]
+	[ -z "$(resolve_disk_file "$NANOKVM_DATA_PART")" ]
+}
+
+given_s03_missing_marker() {
+	: > "$NANOKVM_DATA_PART"
+}
+
+given_s03_missing_device() {
+	: > "$NANOKVM_DISK0_MARKER"
+}
+
+assert_s03_custom_disk_allowed() {
+	[ "$(resolve_disk_file "/data/custom.img")" = "/data/custom.img" ]
+	[ "$(resolve_disk_file "  /data/custom.img  ")" = "/data/custom.img" ]
+}
+
+assert_s03_explicit_default_with_whitespace_ready() {
+	[ "$(resolve_disk_file "  $NANOKVM_DATA_PART  ")" = "$NANOKVM_DATA_PART" ]
+}
+
+assert_s03_explicit_default_with_whitespace_hidden() {
+	[ -z "$(resolve_disk_file "  $NANOKVM_DATA_PART  ")" ]
+}
+
+given_s03_default_alias() {
+	given_s03_ready_default
+	ln -s "$NANOKVM_DATA_PART" "$tmpdir/data-alias"
+	printf '%s\n' "$tmpdir/data-alias" > "$NANOKVM_BOOT_DIR/usb.disk0"
+}
+
+assert_s03_alias_to_default_resolves_to_default() {
+	[ "$(resolve_disk_file "$tmpdir/data-alias")" = "$NANOKVM_DATA_PART" ]
+}
+
+assert_s03_mass_storage_created_for_ready_default() {
+	exists "$tmpdir/gadget/functions/mass_storage.disk0"
+	[ -L "$tmpdir/gadget/configs/c.1/mass_storage.disk0" ]
+	[ "$(cat "$tmpdir/gadget/functions/mass_storage.disk0/lun.0/file")" = "$NANOKVM_DATA_PART" ]
+	[ "$(cat "$tmpdir/gadget/functions/mass_storage.disk0/lun.0/removable")" = "1" ]
+	[ "$(cat "$tmpdir/gadget/functions/mass_storage.disk0/lun.0/inquiry_string")" = "NanoKVM USB Mass Storage0520" ]
+}
+
+assert_s03_mass_storage_not_created() {
+	missing "$tmpdir/gadget/functions/mass_storage.disk0"
+	missing "$tmpdir/gadget/configs/c.1/mass_storage.disk0"
+}
+
+given_s03_custom_disk() {
+	printf '%s\n' "$tmpdir/custom.img" > "$NANOKVM_BOOT_DIR/usb.disk0"
+}
+
+given_s03_explicit_default_with_whitespace() {
+	given_s03_ready_default
+	printf '  %s  \n' "$NANOKVM_DATA_PART" > "$NANOKVM_BOOT_DIR/usb.disk0"
+}
+
+assert_s03_mass_storage_created_for_custom_disk() {
+	exists "$tmpdir/gadget/functions/mass_storage.disk0"
+	[ -L "$tmpdir/gadget/configs/c.1/mass_storage.disk0" ]
+	[ "$(cat "$tmpdir/gadget/functions/mass_storage.disk0/lun.0/file")" = "$tmpdir/custom.img" ]
+}
+
+run_case "retries pending unformatted partition" given_pending_partition run_s01 assert_pending_partition_formatted
+run_case "keeps pending marker when mkfs fails" given_format_fails run_s01 assert_format_failure_keeps_pending
+run_case "keeps pending marker when delayed partition format fails" given_delayed_partition_and_format_fails run_s01 assert_delayed_partition_failure_keeps_pending
+run_case "keeps pending marker when new partition device is late" given_partition_never_appears run_s01 assert_late_device_keeps_pending_without_format
+run_case "removes marker when mount fails after format" given_mount_fails_after_format run_s01 assert_mount_failure_clears_ready_marker
+run_case "does not format or mount unknown existing partition" given_unknown_existing_partition run_s01 assert_unknown_partition_ignored
+run_case "does not format zero-filled legacy marked partition" given_empty_legacy_marked_partition run_s01 assert_empty_legacy_partition_left_unformatted
+run_case "does not recover zero-filled partition without legacy marker" given_empty_unmarked_partition run_s01 assert_empty_unmarked_partition_ignored
+run_case "mounts existing filesystem without formatting" given_existing_filesystem run_s01 assert_existing_filesystem_mounted
+run_case "removes marker when existing filesystem mount fails" given_existing_filesystem_mount_fails run_s01 assert_existing_filesystem_mount_failure_clears_marker
+run_case "formats new partition even with stale signature" given_new_partition_with_stale_signature run_s01 assert_new_partition_formatted_despite_stale_signature
+run_case "creates and formats missing partition" given_default_disk_configured run_s01 assert_missing_partition_created_and_formatted
+run_case "does not create default partition for custom backing file" given_custom_backing_file_configured run_s01 assert_custom_backing_does_not_create_default_partition
+run_case "retries pending default partition with custom backing file" given_custom_backing_with_pending_default_partition run_s01 assert_pending_default_partition_retried_with_custom_backing
+run_case "clears stale marker for unknown partition with custom backing file" given_custom_backing_with_unknown_marked_partition run_s01 assert_custom_backing_unknown_partition_clears_marker
+run_case "creates default partition when explicitly configured" given_explicit_default_partition_configured run_s01 assert_missing_partition_created_and_formatted
+run_case "trims explicit default partition config before creating it" given_explicit_default_partition_with_whitespace_configured run_s01 assert_missing_partition_created_and_formatted
+run_case "leaves enabled virtual data disk unmounted locally" given_enabled_virtual_data_disk run_s01 assert_enabled_virtual_data_disk_is_not_mounted_locally
+run_case "recovers enabled virtual data disk marker without mounting" given_enabled_virtual_data_disk_without_marker run_s01 assert_enabled_virtual_data_disk_recovers_marker_without_mounting
+run_case "exports enabled virtual data disk without local mount" given_enabled_virtual_data_disk run_s01_then_s03_mass_storage assert_enabled_virtual_data_disk_is_exported_without_local_mount
+run_case "does not export unknown default partition" given_default_disk_with_unknown_partition run_s01_then_s03_mass_storage assert_default_unknown_partition_is_not_exported
+run_case "S03 exposes default data disk only when ready" given_s03_ready_default run_s03_helper assert_s03_default_ready
+run_case "S03 hides default and explicit p3 when format is pending" given_s03_pending_default run_s03_helper assert_s03_default_hidden
+run_case "S03 hides default and explicit p3 without ready marker" given_s03_missing_marker run_s03_helper assert_s03_default_hidden
+run_case "S03 hides default and explicit p3 when device is missing" given_s03_missing_device run_s03_helper assert_s03_default_hidden
+run_case "S03 still allows custom backing files" noop run_s03_helper assert_s03_custom_disk_allowed
+run_case "S03 trims explicit p3 before resolving readiness" given_s03_ready_default run_s03_helper assert_s03_explicit_default_with_whitespace_ready
+run_case "S03 hides whitespace explicit p3 while format is pending" given_s03_pending_default run_s03_helper assert_s03_explicit_default_with_whitespace_hidden
+run_case "S03 normalizes aliases of the default data disk" given_s03_default_alias run_s03_helper assert_s03_alias_to_default_resolves_to_default
+run_case "S03 creates mass storage for ready default data disk" given_s03_ready_default run_s03_mass_storage assert_s03_mass_storage_created_for_ready_default
+run_case "S03 skips mass storage while default data disk is pending" given_s03_pending_default run_s03_mass_storage assert_s03_mass_storage_not_created
+run_case "S03 creates mass storage for custom backing files" given_s03_custom_disk run_s03_mass_storage assert_s03_mass_storage_created_for_custom_disk
+run_case "S03 trims explicit p3 before creating mass storage" given_s03_explicit_default_with_whitespace run_s03_mass_storage assert_s03_mass_storage_created_for_ready_default
+
+echo "S01fs data disk tests passed"

--- a/tools/test-s01fs-data-disk.sh
+++ b/tools/test-s01fs-data-disk.sh
@@ -6,6 +6,7 @@ s01_script="$repo_root/kvmapp/system/init.d/S01fs"
 s03_script="$repo_root/kvmapp/system/init.d/S03usbdev"
 real_dd="$(command -v dd)"
 real_mkdir="$(command -v mkdir)"
+real_touch="$(command -v touch)"
 
 tmpdir=""
 original_path="$PATH"
@@ -89,12 +90,27 @@ printf 'dd %s\n' "$*" >> "$NANOKVM_TEST_LOG"
 exec "$NANOKVM_REAL_DD" "$@"
 EOF
 
-	chmod +x "$bin/mount" "$bin/mkdir" "$bin/resize2fs" "$bin/sleep" "$bin/parted" "$bin/blkid" "$bin/mkfs.exfat" "$bin/dd"
+	cat >"$bin/touch" <<'EOF'
+#!/bin/sh
+case "$1" in
+	"$NANOKVM_DISK0_MARKER"|"$NANOKVM_DATA_FORMAT_PENDING")
+		if [ "${NANOKVM_TOUCH_FAIL:-0}" = "1" ]; then
+			exit 1
+		fi
+		;;
+esac
+exec "$NANOKVM_REAL_TOUCH" "$@"
+EOF
+
+	chmod +x "$bin/mount" "$bin/mkdir" "$bin/resize2fs" "$bin/sleep" "$bin/parted" "$bin/blkid" "$bin/mkfs.exfat" "$bin/dd" "$bin/touch"
 }
 
 setup_case() {
 	tmpdir="$(mktemp -d)"
 	original_path="$PATH"
+	unset NANOKVM_MKFS_FAIL NANOKVM_DELAY_DATA_PART_UNTIL_SLEEP \
+		NANOKVM_NEVER_CREATE_DATA_PART NANOKVM_MOUNT_FAIL \
+		NANOKVM_PARTED_CREATES_STALE_FS NANOKVM_TOUCH_FAIL
 	mkdir -p "$tmpdir/bin" "$tmpdir/boot" "$tmpdir/data" "$tmpdir/dev" "$tmpdir/etc"
 	make_stubs "$tmpdir/bin"
 
@@ -106,16 +122,19 @@ setup_case() {
 	export NANOKVM_DATA_PART="$tmpdir/dev/mmcblk0p3"
 	export NANOKVM_BOOT_DIR="$tmpdir/boot"
 	export NANOKVM_DATA_DIR="$tmpdir/data"
+	export NANOKVM_MOUNTS_FILE="$tmpdir/mounts"
 	export NANOKVM_DISK0_MARKER="$tmpdir/etc/kvm.disk0"
 	export NANOKVM_DATA_FORMAT_PENDING="$tmpdir/etc/kvm.disk0.formatting"
 	export NANOKVM_PROFILE="$tmpdir/profile"
 	export NANOKVM_REAL_DD="$real_dd"
 	export NANOKVM_REAL_MKDIR="$real_mkdir"
+	export NANOKVM_REAL_TOUCH="$real_touch"
 
 	: > "$NANOKVM_DISK"
 	: > "$NANOKVM_BOOT_PART"
 	: > "$NANOKVM_ROOT_PART"
 	: > "$NANOKVM_TEST_LOG"
+	: > "$NANOKVM_MOUNTS_FILE"
 	: > "$NANOKVM_PROFILE"
 }
 
@@ -145,9 +164,18 @@ run_case() {
 
 	setup_case
 	local status=0
-	"$setup_fn" || status=$?
-	[ "$status" -ne 0 ] || "$run_fn" || status=$?
-	[ "$status" -ne 0 ] || "$assert_fn" || status=$?
+	set +e
+	"$setup_fn"
+	status=$?
+	if [ "$status" -eq 0 ]; then
+		"$run_fn"
+		status=$?
+	fi
+	if [ "$status" -eq 0 ]; then
+		(set -e; "$assert_fn")
+		status=$?
+	fi
+	set -e
 	teardown_case
 	if [ "$status" -ne 0 ]; then
 		return "$status"
@@ -254,6 +282,36 @@ assert_mount_failure_clears_ready_marker() {
 	log_contains "mkfs.exfat $NANOKVM_DATA_PART"
 	log_contains "mount $NANOKVM_DATA_PART $NANOKVM_DATA_DIR"
 	unset NANOKVM_MOUNT_FAIL
+}
+
+given_ready_marker_write_fails() {
+	given_pending_partition
+	export NANOKVM_TOUCH_FAIL=1
+}
+
+assert_marker_write_failure_stays_unready() {
+	exists "$NANOKVM_DATA_PART.hasfs"
+	missing "$NANOKVM_DISK0_MARKER"
+	missing "$NANOKVM_DATA_FORMAT_PENDING"
+	log_contains "mkfs.exfat $NANOKVM_DATA_PART"
+	log_contains "mount $NANOKVM_DATA_PART $NANOKVM_DATA_DIR"
+	unset NANOKVM_TOUCH_FAIL
+}
+
+given_default_ready_marker_write_fails() {
+	: > "$NANOKVM_DATA_PART"
+	: > "$NANOKVM_DATA_FORMAT_PENDING"
+	: > "$NANOKVM_BOOT_DIR/usb.disk0"
+	export NANOKVM_TOUCH_FAIL=1
+}
+
+assert_default_marker_write_failure_mounts_locally() {
+	exists "$NANOKVM_DATA_PART.hasfs"
+	missing "$NANOKVM_DISK0_MARKER"
+	missing "$NANOKVM_DATA_FORMAT_PENDING"
+	log_contains "mkfs.exfat $NANOKVM_DATA_PART"
+	log_contains "mount $NANOKVM_DATA_PART $NANOKVM_DATA_DIR"
+	unset NANOKVM_TOUCH_FAIL
 }
 
 given_unknown_existing_partition() {
@@ -488,6 +546,21 @@ given_s03_missing_device() {
 	: > "$NANOKVM_DISK0_MARKER"
 }
 
+given_s03_mounted_default() {
+	given_s03_ready_default
+	printf '%s %s exfat rw,relatime 0 0\n' "$NANOKVM_DATA_PART" "$NANOKVM_DATA_DIR" > "$NANOKVM_MOUNTS_FILE"
+}
+
+given_s03_mounted_default_with_stale_lun() {
+	given_s03_mounted_default
+	mkdir -p "$tmpdir/gadget/functions/mass_storage.disk0/lun.0"
+	printf '%s\n' "$NANOKVM_DATA_PART" > "$tmpdir/gadget/functions/mass_storage.disk0/lun.0/file"
+}
+
+assert_s03_mounted_default_clears_stale_lun() {
+	[ "$(cat "$tmpdir/gadget/functions/mass_storage.disk0/lun.0/file")" = "" ]
+}
+
 assert_s03_custom_disk_allowed() {
 	[ "$(resolve_disk_file "/data/custom.img")" = "/data/custom.img" ]
 	[ "$(resolve_disk_file "  /data/custom.img  ")" = "/data/custom.img" ]
@@ -507,8 +580,8 @@ given_s03_default_alias() {
 	printf '%s\n' "$tmpdir/data-alias" > "$NANOKVM_BOOT_DIR/usb.disk0"
 }
 
-assert_s03_alias_to_default_resolves_to_default() {
-	[ "$(resolve_disk_file "$tmpdir/data-alias")" = "$NANOKVM_DATA_PART" ]
+assert_s03_alias_to_default_is_rejected() {
+	[ -z "$(resolve_disk_file "$tmpdir/data-alias")" ]
 }
 
 assert_s03_mass_storage_created_for_ready_default() {
@@ -544,6 +617,8 @@ run_case "keeps pending marker when mkfs fails" given_format_fails run_s01 asser
 run_case "keeps pending marker when delayed partition format fails" given_delayed_partition_and_format_fails run_s01 assert_delayed_partition_failure_keeps_pending
 run_case "keeps pending marker when new partition device is late" given_partition_never_appears run_s01 assert_late_device_keeps_pending_without_format
 run_case "removes marker when mount fails after format" given_mount_fails_after_format run_s01 assert_mount_failure_clears_ready_marker
+run_case "does not claim readiness when marker creation fails" given_ready_marker_write_fails run_s01 assert_marker_write_failure_stays_unready
+run_case "mounts default data locally when marker creation fails" given_default_ready_marker_write_fails run_s01 assert_default_marker_write_failure_mounts_locally
 run_case "does not format or mount unknown existing partition" given_unknown_existing_partition run_s01 assert_unknown_partition_ignored
 run_case "does not format zero-filled legacy marked partition" given_empty_legacy_marked_partition run_s01 assert_empty_legacy_partition_left_unformatted
 run_case "does not recover zero-filled partition without legacy marker" given_empty_unmarked_partition run_s01 assert_empty_unmarked_partition_ignored
@@ -564,10 +639,12 @@ run_case "S03 exposes default data disk only when ready" given_s03_ready_default
 run_case "S03 hides default and explicit p3 when format is pending" given_s03_pending_default run_s03_helper assert_s03_default_hidden
 run_case "S03 hides default and explicit p3 without ready marker" given_s03_missing_marker run_s03_helper assert_s03_default_hidden
 run_case "S03 hides default and explicit p3 when device is missing" given_s03_missing_device run_s03_helper assert_s03_default_hidden
+run_case "S03 hides default data disk while p3 is mounted" given_s03_mounted_default run_s03_helper assert_s03_default_hidden
+run_case "S03 clears stale backing while p3 is mounted" given_s03_mounted_default_with_stale_lun run_s03_mass_storage assert_s03_mounted_default_clears_stale_lun
 run_case "S03 still allows custom backing files" noop run_s03_helper assert_s03_custom_disk_allowed
 run_case "S03 trims explicit p3 before resolving readiness" given_s03_ready_default run_s03_helper assert_s03_explicit_default_with_whitespace_ready
 run_case "S03 hides whitespace explicit p3 while format is pending" given_s03_pending_default run_s03_helper assert_s03_explicit_default_with_whitespace_hidden
-run_case "S03 normalizes aliases of the default data disk" given_s03_default_alias run_s03_helper assert_s03_alias_to_default_resolves_to_default
+run_case "S03 rejects aliases of the default data disk" given_s03_default_alias run_s03_helper assert_s03_alias_to_default_is_rejected
 run_case "S03 creates mass storage for ready default data disk" given_s03_ready_default run_s03_mass_storage assert_s03_mass_storage_created_for_ready_default
 run_case "S03 skips mass storage while default data disk is pending" given_s03_pending_default run_s03_mass_storage assert_s03_mass_storage_not_created
 run_case "S03 creates mass storage for custom backing files" given_s03_custom_disk run_s03_mass_storage assert_s03_mass_storage_created_for_custom_disk


### PR DESCRIPTION
## Summary

Prevent NanoKVM from mounting or exporting `/dev/mmcblk0p3` as the default data disk until the partition setup has actually completed.

The old first-boot flow could leave `/etc/kvm.disk0` behind even if formatting or mounting failed. On later boots, that stale marker could make NanoKVM treat an unformatted or partially prepared partition as usable, then expose it through USB mass storage or the storage APIs.

This change makes the default data-partition state explicit:

- Track interrupted formatting with `/etc/kvm.disk0.formatting` and retry it on the next boot.
- Create `/etc/kvm.disk0` only after a filesystem is confirmed and the partition mounts successfully.
- Remove stale ready markers when p3 is missing, pending, or an unknown non-empty partition.
- Gate the default p3 USB export, storage mount API, and VM virtual-disk state on the same readiness checks.
- Preserve custom `/boot/usb.disk0` backing files; only the built-in default p3 path is blocked while setup is incomplete.

Fixes #76
Fixes #242

## Maintainer notes

This is intentionally scoped to the default data partition lifecycle. It avoids auto-formatting unknown non-empty partitions because they may contain user data, while still recovering empty legacy partitions that were previously marked ready.

There is overlap with #814 in `S03usbdev`. If that PR lands first, this branch should be rebased so the same readiness gate is applied to the refactored USB gadget setup.

## 中文说明

修复 NanoKVM 在数据分区文件系统准备完成前，将 `/dev/mmcblk0p3` 当作可用磁盘的问题。

旧的首次启动流程可能在格式化或挂载失败后留下 `/etc/kvm.disk0`。后续启动时，NanoKVM 可能误认为数据分区已经准备完成，并通过 USB 大容量存储、存储 API 或虚拟磁盘 API 暴露未格式化或未完整初始化的分区。

这个 PR：

- 使用 `/etc/kvm.disk0.formatting` 记录中断的格式化流程，并在下次启动时重试。
- 只有在确认文件系统存在且分区成功挂载后，才创建 `/etc/kvm.disk0`。
- 在分区缺失、准备中、挂载失败或属于未知非空分区时清理过期标记。
- 让 USB 大容量存储、存储挂载 API 和虚拟磁盘状态使用相同的数据分区就绪判断。
- 保留自定义 `/boot/usb.disk0` 文件，不会因为默认分区尚未准备好而阻止自定义镜像。
- 不会自动格式化未知的非空分区，以避免破坏用户数据。

## Branch-added tests

- `tools/test-s01fs-data-disk.sh` runs 28 isolated shell cases. The S01fs cases exercise creation and formatting of a missing p3, retry state across delayed devices and mkfs failures, marker cleanup after mount failures, reuse of valid filesystems, cautious handling of unknown or zero-filled partitions, and the distinction between the default partition and custom backing files. Its S03 cases exercise both the readiness resolver and the generated configfs mass-storage function, including pending, missing-marker, missing-device, whitespace, and custom-image paths.
- `server/service/storage/image_test.go` checks default-partition path resolution, verifies that an unready p3 request is rejected before changing configfs state, and verifies that an empty request can still clear the current image while p3 is unavailable.
- `server/service/vm/virtualdisk/state_test.go` checks when the virtual disk is reported configured for default and custom backing paths, then checks that command selection mounts only an unconfigured disk and otherwise unmounts it.

`make test` runs the shell suite plus both Go packages.