### PR TITLE
feat: USB CDC ACM virtual serial console

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,18 @@ UID := $(shell id -u)
 GID := $(shell id -g)
 PWD := $(shell pwd)
 
-# Docker run common parameters
-DOCKER_RUN_BASE := docker run -e UID=$(UID) -e GID=$(GID) -v $(PWD):/home/build/NanoKVM --rm
+# The host-tools toolchain is x86_64-only. Force linux/amd64 so the build
+# runs under QEMU emulation on arm64 hosts (Apple Silicon, arm64 Linux) and
+# directly on amd64 hosts.
+DOCKER_PLATFORM := --platform=linux/amd64
 
-# Build commands
-GO_BUILD_CMD := cd /home/build/NanoKVM/server && go mod tidy && CGO_ENABLED=1 GOOS=linux GOARCH=riscv64 CC=riscv64-unknown-linux-musl-gcc CGO_CFLAGS="-mcpu=c906fdv -march=rv64imafdcv0p7xthead -mcmodel=medany -mabi=lp64d" go build
+# Docker run common parameters
+DOCKER_RUN_BASE := docker run $(DOCKER_PLATFORM) -e UID=$(UID) -e GID=$(GID) -v $(PWD):/home/build/NanoKVM --rm
+
+# Build commands. Delegate the Go build to server/build.sh so the rpath
+# patchelf step and other post-build adjustments live in one place rather
+# than being duplicated between docker, build.sh, and the README.
+GO_BUILD_CMD := cd /home/build/NanoKVM/server && go mod tidy && ./build.sh
 SUPPORT_BUILD_CMD := . ./home/build/MaixCDK/bin/activate && cd /home/build/NanoKVM/support/sg2002 && ./build kvm_system && ./build kvm_system add_to_kvmapp
 
 .PHONY: help check-root builder-image rebuild-image check-image shell app support all clean
@@ -58,7 +65,7 @@ check-image: check-root
 builder-image: check-root
 	@if ! docker image inspect $(IMAGE_NAME) >/dev/null 2>&1; then \
 		echo "Building Docker image..."; \
-		docker build -t $(IMAGE_NAME) -f docker/Dockerfile ./; \
+		docker build $(DOCKER_PLATFORM) -t $(IMAGE_NAME) -f docker/Dockerfile ./; \
 	else \
 		echo "Docker image $(IMAGE_NAME) already exists."; \
 	fi
@@ -66,7 +73,7 @@ builder-image: check-root
 # Force rebuild Docker image
 rebuild-image: check-root
 	@echo "Force rebuilding Docker image..."
-	@docker build --no-cache -t $(IMAGE_NAME) -f docker/Dockerfile ./
+	@docker build $(DOCKER_PLATFORM) --no-cache -t $(IMAGE_NAME) -f docker/Dockerfile ./
 
 # Enter interactive shell (equivalent to build.sh with no arguments)
 shell: check-root builder-image
@@ -76,12 +83,12 @@ shell: check-root builder-image
 # Build Go application
 app: check-root builder-image
 	@echo "Building app..."
-	@$(DOCKER_RUN_BASE) -it $(IMAGE_NAME) /bin/bash -c '$(GO_BUILD_CMD)'
+	@$(DOCKER_RUN_BASE) $(IMAGE_NAME) /bin/bash -c '$(GO_BUILD_CMD)'
 
 # Build hardware support libraries
 support: check-root builder-image
 	@echo "Building support..."
-	@$(DOCKER_RUN_BASE) -it $(IMAGE_NAME) /bin/bash -c '$(SUPPORT_BUILD_CMD)'
+	@$(DOCKER_RUN_BASE) $(IMAGE_NAME) /bin/bash -c '$(SUPPORT_BUILD_CMD)'
 
 # Clean build artifacts
 clean:

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# NanoKVM dev deploy helper. Builds and uploads changed components to a
+# running NanoKVM over SSH. SSH must be enabled on the device
+# (Settings > SSH).
+#
+# Usage: NANOKVM_HOST=<host> ./deploy.sh <target> [reboot]
+#
+# See `./deploy.sh` with no args for the full target list.
+
+set -euo pipefail
+
+HOST="${NANOKVM_HOST:-london-gw-kvm.london.zelotus.com}"
+SSH_USER="${NANOKVM_SSH_USER:-root}"
+TARGET="${SSH_USER}@${HOST}"
+SSH_OPTS="${SSH_OPTS:--o StrictHostKeyChecking=accept-new}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ROOT"
+
+usage() {
+  cat <<EOF
+Usage: NANOKVM_HOST=<host> $(basename "$0") <target> [reboot]
+
+Targets:
+  script   Push kvmapp/system/init.d/S03usb{dev,hid} to /etc/init.d/ and
+           /kvmapp/system/init.d/ on the device. Pass "reboot" as 2nd arg
+           to reboot afterwards (required to rebind the USB gadget).
+  server   make app -> scp NanoKVM-Server -> restart S95nanokvm
+  web      pnpm build -> rsync dist -> restart S95nanokvm
+  all      script + server + web (no auto-reboot)
+  status   Show which init.d script is live, what /boot/usb.* flags exist,
+           and current usb_gadget function set
+  shell    Open an interactive SSH session
+
+Environment:
+  NANOKVM_HOST       target hostname (default: ${HOST})
+  NANOKVM_SSH_USER   ssh user (default: ${SSH_USER})
+  SSH_OPTS           extra ssh/scp options (default: ${SSH_OPTS})
+EOF
+  exit 1
+}
+
+# shellcheck disable=SC2086
+ssh_run() { ssh ${SSH_OPTS} "${TARGET}" "$@"; }
+# shellcheck disable=SC2086
+scp_to()  { scp ${SSH_OPTS} "$1" "${TARGET}:$2"; }
+
+target_script() {
+  echo ">>> Pushing init.d scripts to ${HOST}"
+  scp_to kvmapp/system/init.d/S03usbdev /etc/init.d/S03usbdev
+  scp_to kvmapp/system/init.d/S03usbhid /etc/init.d/S03usbhid
+  scp_to kvmapp/system/init.d/S03usbdev /kvmapp/system/init.d/S03usbdev
+  scp_to kvmapp/system/init.d/S03usbhid /kvmapp/system/init.d/S03usbhid
+  ssh_run 'chmod +x /etc/init.d/S03usb* /kvmapp/system/init.d/S03usb*'
+  if [ "${1:-}" = "reboot" ]; then
+    echo ">>> Rebooting"
+    ssh_run reboot || true
+  else
+    echo ">>> Done. Reboot required to rebind the USB gadget:"
+    echo "      ssh ${TARGET} reboot"
+  fi
+}
+
+target_server() {
+  echo ">>> Building Go server (make app)"
+  make app
+  echo ">>> Uploading server/NanoKVM-Server"
+  scp_to server/NanoKVM-Server /kvmapp/server/NanoKVM-Server
+  # The binary's rpath resolves libkvm.so from $ORIGIN/dl_lib at runtime,
+  # so the .so versions must match the binary's expected ABI. Ship dl_lib
+  # alongside the binary in case the device's installed copy is older.
+  echo ">>> Syncing server/dl_lib -> /kvmapp/server/dl_lib/"
+  # shellcheck disable=SC2086
+  rsync -avz -e "ssh ${SSH_OPTS}" server/dl_lib/ "${TARGET}:/kvmapp/server/dl_lib/"
+  ssh_run 'chmod +x /kvmapp/server/NanoKVM-Server && /etc/init.d/S95nanokvm restart'
+}
+
+target_web() {
+  if command -v pnpm >/dev/null 2>&1; then
+    echo ">>> Building frontend (pnpm)"
+    (cd web && pnpm install --frozen-lockfile && pnpm build)
+  else
+    echo ">>> pnpm not found, falling back to npm"
+    (cd web && npm install --no-fund --no-audit && ./node_modules/.bin/vite build)
+  fi
+  echo ">>> Syncing web/dist -> /kvmapp/server/web/"
+  # shellcheck disable=SC2086
+  rsync -avz --delete -e "ssh ${SSH_OPTS}" web/dist/ "${TARGET}:/kvmapp/server/web/"
+  ssh_run '/etc/init.d/S95nanokvm restart'
+}
+
+target_status() {
+  ssh_run '
+    echo "== live /etc/init.d/ ==";
+    ls -la /etc/init.d/S03usb* 2>/dev/null || echo "(none)";
+    echo;
+    echo "== kvmapp /kvmapp/system/init.d/ ==";
+    ls -la /kvmapp/system/init.d/S03usb* 2>/dev/null || echo "(none)";
+    echo;
+    echo "== /boot flags ==";
+    ls -la /boot/usb.* /boot/disable_hid /boot/BIOS 2>/dev/null || echo "(none)";
+    echo;
+    echo "== usb_gadget functions ==";
+    ls /sys/kernel/config/usb_gadget/g0/functions 2>/dev/null || echo "(gadget not bound)";
+    echo;
+    echo "== usb_gadget configs/c.1 links ==";
+    ls -la /sys/kernel/config/usb_gadget/g0/configs/c.1/ 2>/dev/null || true;
+  '
+}
+
+case "${1:-}" in
+  script) shift || true; target_script "${1:-}" ;;
+  server) target_server ;;
+  web)    target_web ;;
+  all)    target_script; target_server; target_web ;;
+  status) target_status ;;
+  # shellcheck disable=SC2086
+  shell)  exec ssh ${SSH_OPTS} "${TARGET}" ;;
+  *)      usage ;;
+esac

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:24.04 AS base_apt
 # RUN echo 'Acquire::http::Proxy "http://cache.lan:3142";' > /etc/apt/apt.conf.d/00cacher
 RUN userdel -r ubuntu
 RUN apt update \
-    && apt install wget git cmake build-essential python3 python3-venv python3-pip autoconf automake libtool gosu -y
+    && apt install wget git cmake build-essential python3 python3-venv python3-pip autoconf automake libtool gosu patchelf -y
 
 ARG DOCKER_USER=build
 RUN useradd -m "$DOCKER_USER"

--- a/kvmapp/system/init.d/S03usbhid
+++ b/kvmapp/system/init.d/S03usbhid
@@ -60,17 +60,27 @@ start_usb_dev(){
     echo -ne \\x5\\x1\\x9\\x2\\xa1\\x1\\x9\\x1\\xa1\\x0\\x5\\x9\\x19\\x1\\x29\\x3\\x15\\x0\\x25\\x1\\x95\\x3\\x75\\x1\\x81\\x2\\x95\\x1\\x75\\x5\\x81\\x3\\x5\\x1\\x9\\x30\\x9\\x31\\x9\\x38\\x15\\x81\\x25\\x7f\\x75\\x8\\x95\\x3\\x81\\x6\\xc0\\xc0 > functions/hid.GS1/report_desc
     ln -s functions/hid.GS1 configs/c.1
 
-    # touchpad
-    mkdir functions/hid.GS2
-    echo 1 > functions/hid.GS2/subclass
-    if [ ! -e /boot/usb.notwakeup ]
+    # touchpad (omitted when usb.acm is set; ACM + touchpad exceeds dwc2 FIFO budget)
+    if [ ! -e /boot/usb.acm ]
     then
-        echo 1 > functions/hid.GS2/wakeup_on_write
+        mkdir functions/hid.GS2
+        echo 1 > functions/hid.GS2/subclass
+        if [ ! -e /boot/usb.notwakeup ]
+        then
+            echo 1 > functions/hid.GS2/wakeup_on_write
+        fi
+        echo 2 > functions/hid.GS2/protocol
+        echo 6 > functions/hid.GS2/report_length
+        echo -ne \\x05\\x01\\x09\\x02\\xa1\\x01\\x09\\x01\\xa1\\x00\\x05\\x09\\x19\\x01\\x29\\x03\\x15\\x00\\x25\\x01\\x95\\x03\\x75\\x01\\x81\\x02\\x95\\x01\\x75\\x05\\x81\\x01\\x05\\x01\\x09\\x30\\x09\\x31\\x15\\x00\\x26\\xff\\x7f\\x35\\x00\\x46\\xff\\x7f\\x75\\x10\\x95\\x02\\x81\\x02\\x05\\x01\\x09\\x38\\x15\\x81\\x25\\x7f\\x35\\x00\\x45\\x00\\x75\\x08\\x95\\x01\\x81\\x06\\xc0\\xc0 > functions/hid.GS2/report_desc
+        ln -s functions/hid.GS2 configs/c.1
     fi
-    echo 2 > functions/hid.GS2/protocol
-    echo 6 > functions/hid.GS2/report_length
-    echo -ne \\x05\\x01\\x09\\x02\\xa1\\x01\\x09\\x01\\xa1\\x00\\x05\\x09\\x19\\x01\\x29\\x03\\x15\\x00\\x25\\x01\\x95\\x03\\x75\\x01\\x81\\x02\\x95\\x01\\x75\\x05\\x81\\x01\\x05\\x01\\x09\\x30\\x09\\x31\\x15\\x00\\x26\\xff\\x7f\\x35\\x00\\x46\\xff\\x7f\\x75\\x10\\x95\\x02\\x81\\x02\\x05\\x01\\x09\\x38\\x15\\x81\\x25\\x7f\\x35\\x00\\x45\\x00\\x75\\x08\\x95\\x01\\x81\\x06\\xc0\\xc0 > functions/hid.GS2/report_desc
-    ln -s functions/hid.GS2 configs/c.1
+
+    # CDC ACM virtual serial port (mutually exclusive with touchpad)
+    if [ -e /boot/usb.acm ]
+    then
+        mkdir functions/acm.GS0
+        ln -s functions/acm.GS0 configs/c.1
+    fi
 
     ls /sys/class/udc/ | cat > UDC
     echo device > /proc/cviusb/otg_role

--- a/server/proto/vm.go
+++ b/server/proto/vm.go
@@ -68,6 +68,7 @@ type GetVirtualDeviceRsp struct {
 	Network bool `json:"network"`
 	Media   bool `json:"media"`
 	Disk    bool `json:"disk"`
+	Serial  bool `json:"serial"`
 }
 
 type UpdateVirtualDeviceReq struct {

--- a/server/service/hid/status.go
+++ b/server/service/hid/status.go
@@ -132,6 +132,15 @@ func ResetUSBPHY() error {
 	return nil
 }
 
+// CopyModeFile atomically replaces /etc/init.d/S03usbdev with the contents
+// of srcScript. Exposed so callers outside this package (e.g. the USB serial
+// toggle) can force a script swap without relying on the bcdDevice-based
+// mode detection, which is not reliable on all firmware (some kernels
+// default bcdDevice to 0x0623, the hid-only marker).
+func CopyModeFile(srcScript string) error {
+	return copyModeFile(srcScript)
+}
+
 func copyModeFile(srcScript string) error {
 	// open the source file
 	srcFile, err := os.Open(srcScript)
@@ -209,4 +218,32 @@ func getHidMode() (string, error) {
 	}
 
 	return mode, nil
+}
+
+// CurrentMode reports the active HID mode ("normal" or "hid-only").
+func CurrentMode() (string, error) {
+	return getHidMode()
+}
+
+// SwitchMode swaps /etc/init.d/S03usbdev to the script for the requested mode
+// if it isn't already active. Returns true when the script was rewritten and
+// the caller must reboot for the change to take effect.
+func SwitchMode(mode string) (bool, error) {
+	if mode != ModeNormal && mode != ModeHidOnly {
+		return false, errors.New("invalid mode")
+	}
+
+	current, err := getHidMode()
+	if err == nil && current == mode {
+		return false, nil
+	}
+
+	srcScript := ModeNormalScript
+	if mode == ModeHidOnly {
+		srcScript = ModeHidOnlyScript
+	}
+	if err := copyModeFile(srcScript); err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/server/service/vm/virtual-device.go
+++ b/server/service/vm/virtual-device.go
@@ -2,8 +2,10 @@ package vm
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	log "github.com/sirupsen/logrus"
@@ -15,6 +17,7 @@ import (
 const (
 	virtualNetwork = "/boot/usb.rndis0"
 	virtualDisk    = "/boot/usb.disk0"
+	virtualSerial  = "/boot/usb.acm"
 )
 
 var (
@@ -50,10 +53,12 @@ func (s *Service) GetVirtualDevice(c *gin.Context) {
 
 	network, _ := isDeviceExist(virtualNetwork)
 	disk, _ := isDeviceExist(virtualDisk)
+	serial, _ := isDeviceExist(virtualSerial)
 
 	rsp.OkRspWithData(c, &proto.GetVirtualDeviceRsp{
 		Network: network,
 		Disk:    disk,
+		Serial:  serial,
 	})
 	log.Debugf("get virtual device success")
 }
@@ -64,6 +69,11 @@ func (s *Service) UpdateVirtualDevice(c *gin.Context) {
 
 	if err := proto.ParseFormRequest(c, &req); err != nil {
 		rsp.ErrRsp(c, -1, "invalid argument")
+		return
+	}
+
+	if req.Device == "serial" {
+		s.updateUsbSerial(c)
 		return
 	}
 
@@ -116,6 +126,67 @@ func (s *Service) UpdateVirtualDevice(c *gin.Context) {
 	})
 
 	log.Debugf("update virtual device %s success", req.Device)
+}
+
+// updateUsbSerial toggles the USB CDC ACM virtual serial port.
+//
+// Enabling implies HID-Only mode because adding the ACM endpoint to the
+// standard composite gadget exceeds the SG2002/dwc2 FIFO budget — only
+// keyboard + mouse + ACM fits. We therefore swap to the HID-only init
+// script when needed, write /boot/usb.acm, and reboot.
+//
+// Disabling removes the flag and reboots. HID-Only mode is left alone;
+// the user toggles it back to normal separately if they want
+// network/mass-storage back.
+func (s *Service) updateUsbSerial(c *gin.Context) {
+	var rsp proto.Response
+
+	exist, _ := isDeviceExist(virtualSerial)
+	enable := !exist
+
+	if enable {
+		// Always overwrite /etc/init.d/S03usbdev with the hid-only script.
+		// We can't use hid.SwitchMode here: its short-circuit relies on
+		// bcdDevice as the mode marker, and on some firmware the kernel
+		// default for bcdDevice already matches the hid-only marker, so
+		// SwitchMode incorrectly thinks no swap is needed.
+		if err := hid.CopyModeFile(hid.ModeHidOnlyScript); err != nil {
+			log.Errorf("failed to copy hid-only script: %s", err)
+			rsp.ErrRsp(c, -3, "operation failed")
+			return
+		}
+		if err := os.WriteFile(virtualSerial, []byte{}, 0o644); err != nil {
+			log.Errorf("failed to create %s: %s", virtualSerial, err)
+			rsp.ErrRsp(c, -3, "operation failed")
+			return
+		}
+		// The firmware's inittab runs a getty on ttyGS0 to expose the NanoKVM
+		// shell over serial. Remove it so the web terminal has exclusive access.
+		// Restored on disable below.
+		if err := exec.Command("sed", "-i", "/^acm::respawn/d", "/etc/inittab").Run(); err != nil {
+			log.Warnf("failed to remove acm getty from inittab: %s", err)
+		}
+	} else {
+		if err := os.Remove(virtualSerial); err != nil && !errors.Is(err, os.ErrNotExist) {
+			log.Errorf("failed to remove %s: %s", virtualSerial, err)
+			rsp.ErrRsp(c, -3, "operation failed")
+			return
+		}
+		// Restore the NanoKVM's own ttyGS0 getty if it was removed.
+		restore := "acm::respawn:/sbin/getty -L ttyGS0 0 vt100 -l /etc/ttyGS0_handler.sh"
+		cmd := fmt.Sprintf("grep -qF 'acm::respawn' /etc/inittab || echo '%s' >> /etc/inittab", restore)
+		if err := exec.Command("sh", "-c", cmd).Run(); err != nil {
+			log.Warnf("failed to restore acm getty in inittab: %s", err)
+		}
+	}
+
+	rsp.OkRspWithData(c, &proto.UpdateVirtualDeviceRsp{
+		On: enable,
+	})
+	log.Printf("usb serial %v, rebooting", enable)
+
+	time.Sleep(500 * time.Millisecond)
+	_ = exec.Command("reboot").Run()
 }
 
 func isDeviceExist(device string) (bool, error) {

--- a/web/src/i18n/locales/ca.ts
+++ b/web/src/i18n/locales/ca.ts
@@ -234,7 +234,8 @@ const ca = {
       flowControlHard: 'Maquinari',
       dataBits: 'Bits de dades',
       stopBits: 'Bits de parada',
-      confirm: "D'acord"
+      confirm: "D'acord",
+      usbSerial: '(USB CDC ACM)',
     },
     wol: {
       title: 'Wake-on-LAN',
@@ -361,6 +362,19 @@ const ca = {
         diskDesc: 'Munta un disc U virtual al dispositiu remot',
         network: 'Xarxa virtual',
         networkDesc: 'Munta una targeta de xarxa virtual al dispositiu remot',
+        usbSerial: 'USB Serial Console',
+        usbSerialDesc: 'Expose a USB CDC ACM serial port (/dev/ttyACM0) to the attached host. Implies HID-Only mode and disables the touchpad.',
+        usbSerialModal: {
+          title: 'USB Serial Console',
+          descEnable: 'Enable a CDC ACM virtual serial port so the attached host can use NanoKVM as an out-of-band serial console (e.g. OPNsense, FreeBSD, Linux).',
+          descDisable: 'Disable the USB serial console. The touchpad will be restored after reboot.',
+          tip1: 'Touchpad will be disabled (keyboard and mouse continue to work)',
+          tip2: 'Implies HID-Only mode: USB network gadget and mass storage become unavailable',
+          tip3: "NanoKVM's onboard ethernet, Wi-Fi, and web UI are unaffected",
+          tip4: 'NanoKVM will reboot to apply the change',
+          enable: 'Enable USB Serial Console',
+          disable: 'Disable USB Serial Console'
+        },
         reboot: 'Reinicia',
         rebootDesc: 'Segur que vols reiniciar el NanoKVM?',
         okBtn: 'Sí',

--- a/web/src/i18n/locales/cz.ts
+++ b/web/src/i18n/locales/cz.ts
@@ -237,7 +237,8 @@ const cz = {
       flowControlHard: 'Hardwarové',
       dataBits: 'Datové bity',
       stopBits: 'Stop bity',
-      confirm: 'OK'
+      confirm: 'OK',
+      usbSerial: '(USB CDC ACM)',
     },
     wol: {
       title: 'Wake-on-LAN',
@@ -364,6 +365,19 @@ const cz = {
         diskDesc: 'Mount virtual U-disk on the remote host',
         network: 'Virtuální síť',
         networkDesc: 'Připojit virtuální síťovou kartu na vzdáleném hostiteli',
+        usbSerial: 'USB Serial Console',
+        usbSerialDesc: 'Expose a USB CDC ACM serial port (/dev/ttyACM0) to the attached host. Implies HID-Only mode and disables the touchpad.',
+        usbSerialModal: {
+          title: 'USB Serial Console',
+          descEnable: 'Enable a CDC ACM virtual serial port so the attached host can use NanoKVM as an out-of-band serial console (e.g. OPNsense, FreeBSD, Linux).',
+          descDisable: 'Disable the USB serial console. The touchpad will be restored after reboot.',
+          tip1: 'Touchpad will be disabled (keyboard and mouse continue to work)',
+          tip2: 'Implies HID-Only mode: USB network gadget and mass storage become unavailable',
+          tip3: "NanoKVM's onboard ethernet, Wi-Fi, and web UI are unaffected",
+          tip4: 'NanoKVM will reboot to apply the change',
+          enable: 'Enable USB Serial Console',
+          disable: 'Disable USB Serial Console'
+        },
         reboot: 'Restartujte',
         rebootDesc: 'Opravdu chcete restartovat NanoKVM?',
         okBtn: 'Ano',

--- a/web/src/i18n/locales/da.ts
+++ b/web/src/i18n/locales/da.ts
@@ -235,7 +235,8 @@ const da = {
       flowControlHard: 'Hardware',
       dataBits: 'Databits',
       stopBits: 'Stopbit',
-      confirm: 'OK'
+      confirm: 'OK',
+      usbSerial: '(USB CDC ACM)',
     },
     wol: {
       title: 'Wake-on-LAN',
@@ -363,6 +364,19 @@ const da = {
         diskDesc: 'Mount virtual U-disk on the remote host',
         network: 'Virtuelt netværk',
         networkDesc: 'Monter det virtuelle netværkskort på den eksterne vært',
+        usbSerial: 'USB Serial Console',
+        usbSerialDesc: 'Expose a USB CDC ACM serial port (/dev/ttyACM0) to the attached host. Implies HID-Only mode and disables the touchpad.',
+        usbSerialModal: {
+          title: 'USB Serial Console',
+          descEnable: 'Enable a CDC ACM virtual serial port so the attached host can use NanoKVM as an out-of-band serial console (e.g. OPNsense, FreeBSD, Linux).',
+          descDisable: 'Disable the USB serial console. The touchpad will be restored after reboot.',
+          tip1: 'Touchpad will be disabled (keyboard and mouse continue to work)',
+          tip2: 'Implies HID-Only mode: USB network gadget and mass storage become unavailable',
+          tip3: "NanoKVM's onboard ethernet, Wi-Fi, and web UI are unaffected",
+          tip4: 'NanoKVM will reboot to apply the change',
+          enable: 'Enable USB Serial Console',
+          disable: 'Disable USB Serial Console'
+        },
         reboot: 'Genstart',
         rebootDesc: 'Er du sikker på, at du vil genstarte NanoKVM?',
         okBtn: 'Ja',

--- a/web/src/i18n/locales/de.ts
+++ b/web/src/i18n/locales/de.ts
@@ -239,7 +239,8 @@ const de = {
       flowControlHard: 'Hardware',
       dataBits: 'Daten bits',
       stopBits: 'Stopp bits',
-      confirm: 'Ok'
+      confirm: 'Ok',
+      usbSerial: '(USB CDC ACM)',
     },
     wol: {
       title: 'Wake-on-LAN',
@@ -368,6 +369,19 @@ const de = {
         diskDesc: 'Binde das virtuelle U-Laufwerk an den entfernten Host',
         network: 'Virtuelles Netzwerk',
         networkDesc: 'Binde die virtuelle Netzwerkkarte an den entfernten Host',
+        usbSerial: 'USB Serial Console',
+        usbSerialDesc: 'Expose a USB CDC ACM serial port (/dev/ttyACM0) to the attached host. Implies HID-Only mode and disables the touchpad.',
+        usbSerialModal: {
+          title: 'USB Serial Console',
+          descEnable: 'Enable a CDC ACM virtual serial port so the attached host can use NanoKVM as an out-of-band serial console (e.g. OPNsense, FreeBSD, Linux).',
+          descDisable: 'Disable the USB serial console. The touchpad will be restored after reboot.',
+          tip1: 'Touchpad will be disabled (keyboard and mouse continue to work)',
+          tip2: 'Implies HID-Only mode: USB network gadget and mass storage become unavailable',
+          tip3: "NanoKVM's onboard ethernet, Wi-Fi, and web UI are unaffected",
+          tip4: 'NanoKVM will reboot to apply the change',
+          enable: 'Enable USB Serial Console',
+          disable: 'Disable USB Serial Console'
+        },
         reboot: 'Neustarten',
         rebootDesc: 'Sind Sie sicher dass Sie NanoKVM neustarten möchten?',
         okBtn: 'Ja',

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -234,7 +234,8 @@ const en = {
       flowControlHard: 'Hard',
       dataBits: 'Data bits',
       stopBits: 'Stop bits',
-      confirm: 'Ok'
+      confirm: 'Ok',
+      usbSerial: '(USB CDC ACM)'
     },
     wol: {
       title: 'Wake-on-LAN',
@@ -361,6 +362,19 @@ const en = {
         diskDesc: 'Mount SD card on the remote host',
         network: 'Virtual Network',
         networkDesc: 'Mount virtual network card on the remote host',
+        usbSerial: 'USB Serial Console',
+        usbSerialDesc: 'Expose a USB CDC ACM serial port (/dev/ttyACM0) to the attached host. Implies HID-Only mode and disables the touchpad.',
+        usbSerialModal: {
+          title: 'USB Serial Console',
+          descEnable: 'Enable a CDC ACM virtual serial port so the attached host can use NanoKVM as an out-of-band serial console (e.g. OPNsense, FreeBSD, Linux).',
+          descDisable: 'Disable the USB serial console. The touchpad will be restored after reboot.',
+          tip1: 'Touchpad will be disabled (keyboard and mouse continue to work)',
+          tip2: 'Implies HID-Only mode: USB network gadget and mass storage become unavailable',
+          tip3: "NanoKVM's onboard ethernet, Wi-Fi, and web UI are unaffected",
+          tip4: 'NanoKVM will reboot to apply the change',
+          enable: 'Enable USB Serial Console',
+          disable: 'Disable USB Serial Console'
+        },
         reboot: 'Reboot',
         rebootDesc: 'Are you sure you want to reboot NanoKVM?',
         okBtn: 'Yes',

--- a/web/src/i18n/locales/es.ts
+++ b/web/src/i18n/locales/es.ts
@@ -237,7 +237,8 @@ const es = {
       flowControlHard: 'Hardware',
       dataBits: 'Bits de datos',
       stopBits: 'Bits de parada',
-      confirm: 'Confirmar'
+      confirm: 'Confirmar',
+      usbSerial: '(USB CDC ACM)',
     },
     wol: {
       title: 'Wake-on-LAN',
@@ -365,6 +366,19 @@ const es = {
         diskDesc: 'Montar disco virtual en el host remoto',
         network: 'Red Virtual',
         networkDesc: 'Montar tarjeta de red virtual en el host remoto',
+        usbSerial: 'USB Serial Console',
+        usbSerialDesc: 'Expose a USB CDC ACM serial port (/dev/ttyACM0) to the attached host. Implies HID-Only mode and disables the touchpad.',
+        usbSerialModal: {
+          title: 'USB Serial Console',
+          descEnable: 'Enable a CDC ACM virtual serial port so the attached host can use NanoKVM as an out-of-band serial console (e.g. OPNsense, FreeBSD, Linux).',
+          descDisable: 'Disable the USB serial console. The touchpad will be restored after reboot.',
+          tip1: 'Touchpad will be disabled (keyboard and mouse continue to work)',
+          tip2: 'Implies HID-Only mode: USB network gadget and mass storage become unavailable',
+          tip3: "NanoKVM's onboard ethernet, Wi-Fi, and web UI are unaffected",
+          tip4: 'NanoKVM will reboot to apply the change',
+          enable: 'Enable USB Serial Console',
+          disable: 'Disable USB Serial Console'
+        },
         reboot: 'Reiniciar',
         rebootDesc: '¿Estás seguro de que deseas reiniciar el NanoKVM?',
         okBtn: 'Sí',

--- a/web/src/i18n/locales/fr.ts
+++ b/web/src/i18n/locales/fr.ts
@@ -239,7 +239,8 @@ const fr = {
       flowControlHard: 'Matériel',
       dataBits: 'Bits de données',
       stopBits: "Bits d'arrêt",
-      confirm: 'Ok'
+      confirm: 'Ok',
+      usbSerial: '(USB CDC ACM)',
     },
     wol: {
       title: 'Wake-on-LAN',
@@ -367,6 +368,19 @@ const fr = {
         diskDesc: "Monter le disque virtuel U sur l'hôte distant",
         network: 'Réseau virtuel',
         networkDesc: "Monter la carte réseau virtuelle sur l'hôte distant",
+        usbSerial: 'USB Serial Console',
+        usbSerialDesc: 'Expose a USB CDC ACM serial port (/dev/ttyACM0) to the attached host. Implies HID-Only mode and disables the touchpad.',
+        usbSerialModal: {
+          title: 'USB Serial Console',
+          descEnable: 'Enable a CDC ACM virtual serial port so the attached host can use NanoKVM as an out-of-band serial console (e.g. OPNsense, FreeBSD, Linux).',
+          descDisable: 'Disable the USB serial console. The touchpad will be restored after reboot.',
+          tip1: 'Touchpad will be disabled (keyboard and mouse continue to work)',
+          tip2: 'Implies HID-Only mode: USB network gadget and mass storage become unavailable',
+          tip3: "NanoKVM's onboard ethernet, Wi-Fi, and web UI are unaffected",
+          tip4: 'NanoKVM will reboot to apply the change',
+          enable: 'Enable USB Serial Console',
+          disable: 'Disable USB Serial Console'
+        },
         reboot: 'Redémarrer',
         rebootDesc: 'Êtes-vous sûr de vouloir redémarrer NanoKVM?',
         okBtn: 'Oui',

--- a/web/src/i18n/locales/hu.ts
+++ b/web/src/i18n/locales/hu.ts
@@ -238,7 +238,8 @@ const hu = {
       flowControlHard: 'Hardveres',
       dataBits: 'Adatbitek',
       stopBits: 'Stop bitek',
-      confirm: 'Ok'
+      confirm: 'Ok',
+      usbSerial: '(USB CDC ACM)',
     },
     wol: {
       title: 'Wake-on-LAN',
@@ -366,6 +367,19 @@ const hu = {
         diskDesc: 'Mount virtual U-disk on the remote host',
         network: 'Virtuális hálózat',
         networkDesc: 'Virtuális hálózati kártya csatlakoztatása a távoli gazdagépen',
+        usbSerial: 'USB Serial Console',
+        usbSerialDesc: 'Expose a USB CDC ACM serial port (/dev/ttyACM0) to the attached host. Implies HID-Only mode and disables the touchpad.',
+        usbSerialModal: {
+          title: 'USB Serial Console',
+          descEnable: 'Enable a CDC ACM virtual serial port so the attached host can use NanoKVM as an out-of-band serial console (e.g. OPNsense, FreeBSD, Linux).',
+          descDisable: 'Disable the USB serial console. The touchpad will be restored after reboot.',
+          tip1: 'Touchpad will be disabled (keyboard and mouse continue to work)',
+          tip2: 'Implies HID-Only mode: USB network gadget and mass storage become unavailable',
+          tip3: "NanoKVM's onboard ethernet, Wi-Fi, and web UI are unaffected",
+          tip4: 'NanoKVM will reboot to apply the change',
+          enable: 'Enable USB Serial Console',
+          disable: 'Disable USB Serial Console'
+        },
         reboot: 'Újraindítás',
         rebootDesc: 'Biztos, hogy újra akarja indítani a NanoKVM-t?',
         okBtn: 'Igen',

--- a/web/src/i18n/locales/id.ts
+++ b/web/src/i18n/locales/id.ts
@@ -236,7 +236,8 @@ const id = {
       flowControlHard: 'Perangkat keras',
       dataBits: 'Bit data',
       stopBits: 'Hentikan bit',
-      confirm: 'Ok'
+      confirm: 'Ok',
+      usbSerial: '(USB CDC ACM)',
     },
     wol: {
       title: 'Wake-on-LAN',
@@ -363,6 +364,19 @@ const id = {
         diskDesc: 'Mount virtual U-disk on the remote host',
         network: 'Jaringan virtual',
         networkDesc: 'Pasang kartu jaringan virtual pada host jarak jauh',
+        usbSerial: 'USB Serial Console',
+        usbSerialDesc: 'Expose a USB CDC ACM serial port (/dev/ttyACM0) to the attached host. Implies HID-Only mode and disables the touchpad.',
+        usbSerialModal: {
+          title: 'USB Serial Console',
+          descEnable: 'Enable a CDC ACM virtual serial port so the attached host can use NanoKVM as an out-of-band serial console (e.g. OPNsense, FreeBSD, Linux).',
+          descDisable: 'Disable the USB serial console. The touchpad will be restored after reboot.',
+          tip1: 'Touchpad will be disabled (keyboard and mouse continue to work)',
+          tip2: 'Implies HID-Only mode: USB network gadget and mass storage become unavailable',
+          tip3: "NanoKVM's onboard ethernet, Wi-Fi, and web UI are unaffected",
+          tip4: 'NanoKVM will reboot to apply the change',
+          enable: 'Enable USB Serial Console',
+          disable: 'Disable USB Serial Console'
+        },
         reboot: 'Mulai ulang',
         rebootDesc: 'Apakah Anda yakin ingin me-reboot NanoKVM?',
         okBtn: 'Ya',

--- a/web/src/i18n/locales/it.ts
+++ b/web/src/i18n/locales/it.ts
@@ -238,7 +238,8 @@ const it = {
       flowControlHard: 'Hardware',
       dataBits: 'Bit di dati',
       stopBits: 'Bit di stop',
-      confirm: 'Ok'
+      confirm: 'Ok',
+      usbSerial: '(USB CDC ACM)',
     },
     wol: {
       title: 'Wake-on-LAN',
@@ -367,6 +368,19 @@ const it = {
         diskDesc: 'Mount virtual U-disk on the remote host',
         network: 'Rete virtuale',
         networkDesc: 'Monta la scheda di rete virtuale sull’host remoto',
+        usbSerial: 'USB Serial Console',
+        usbSerialDesc: 'Expose a USB CDC ACM serial port (/dev/ttyACM0) to the attached host. Implies HID-Only mode and disables the touchpad.',
+        usbSerialModal: {
+          title: 'USB Serial Console',
+          descEnable: 'Enable a CDC ACM virtual serial port so the attached host can use NanoKVM as an out-of-band serial console (e.g. OPNsense, FreeBSD, Linux).',
+          descDisable: 'Disable the USB serial console. The touchpad will be restored after reboot.',
+          tip1: 'Touchpad will be disabled (keyboard and mouse continue to work)',
+          tip2: 'Implies HID-Only mode: USB network gadget and mass storage become unavailable',
+          tip3: "NanoKVM's onboard ethernet, Wi-Fi, and web UI are unaffected",
+          tip4: 'NanoKVM will reboot to apply the change',
+          enable: 'Enable USB Serial Console',
+          disable: 'Disable USB Serial Console'
+        },
         reboot: 'Riavvia',
         rebootDesc: 'Sei sicuro di voler riavviare NanoKVM?',
         okBtn: 'Sì',

--- a/web/src/i18n/locales/ja.ts
+++ b/web/src/i18n/locales/ja.ts
@@ -236,7 +236,8 @@ const ja = {
       flowControlHard: 'ハードウェア',
       dataBits: 'データビット',
       stopBits: 'ストップビット',
-      confirm: 'OK'
+      confirm: 'OK',
+      usbSerial: '(USB CDC ACM)',
     },
     wol: {
       title: 'Wake-on-LAN',
@@ -365,6 +366,19 @@ const ja = {
         diskDesc: 'リモートホストに仮想 USB ドライブをマウントする',
         network: '仮想ネットワークカード',
         networkDesc: 'リモートホストに仮想ネットワークカードをマウントする',
+        usbSerial: 'USB Serial Console',
+        usbSerialDesc: 'Expose a USB CDC ACM serial port (/dev/ttyACM0) to the attached host. Implies HID-Only mode and disables the touchpad.',
+        usbSerialModal: {
+          title: 'USB Serial Console',
+          descEnable: 'Enable a CDC ACM virtual serial port so the attached host can use NanoKVM as an out-of-band serial console (e.g. OPNsense, FreeBSD, Linux).',
+          descDisable: 'Disable the USB serial console. The touchpad will be restored after reboot.',
+          tip1: 'Touchpad will be disabled (keyboard and mouse continue to work)',
+          tip2: 'Implies HID-Only mode: USB network gadget and mass storage become unavailable',
+          tip3: "NanoKVM's onboard ethernet, Wi-Fi, and web UI are unaffected",
+          tip4: 'NanoKVM will reboot to apply the change',
+          enable: 'Enable USB Serial Console',
+          disable: 'Disable USB Serial Console'
+        },
         reboot: '再起動',
         rebootDesc: 'NanoKVM を再起動してもよろしいですか?',
         okBtn: 'はい',

--- a/web/src/i18n/locales/ko.ts
+++ b/web/src/i18n/locales/ko.ts
@@ -232,7 +232,8 @@ const ko = {
       flowControlHard: '하드웨어',
       dataBits: '데이터 비트',
       stopBits: '정지 비트',
-      confirm: '확인'
+      confirm: '확인',
+      usbSerial: '(USB CDC ACM)',
     },
     wol: {
       title: 'Wake-on-LAN',
@@ -359,6 +360,19 @@ const ko = {
         diskDesc: '원격 호스트에서 가상 USB를 마운트합니다.',
         network: '가상 네트워크',
         networkDesc: '원격 호스트에서 가상 네트워크 카드를 마운트합니다.',
+        usbSerial: 'USB Serial Console',
+        usbSerialDesc: 'Expose a USB CDC ACM serial port (/dev/ttyACM0) to the attached host. Implies HID-Only mode and disables the touchpad.',
+        usbSerialModal: {
+          title: 'USB Serial Console',
+          descEnable: 'Enable a CDC ACM virtual serial port so the attached host can use NanoKVM as an out-of-band serial console (e.g. OPNsense, FreeBSD, Linux).',
+          descDisable: 'Disable the USB serial console. The touchpad will be restored after reboot.',
+          tip1: 'Touchpad will be disabled (keyboard and mouse continue to work)',
+          tip2: 'Implies HID-Only mode: USB network gadget and mass storage become unavailable',
+          tip3: "NanoKVM's onboard ethernet, Wi-Fi, and web UI are unaffected",
+          tip4: 'NanoKVM will reboot to apply the change',
+          enable: 'Enable USB Serial Console',
+          disable: 'Disable USB Serial Console'
+        },
         reboot: '재부팅',
         rebootDesc: 'NanoKVM을 재부팅하시겠습니까?',
         okBtn: '네',

--- a/web/src/i18n/locales/nb.ts
+++ b/web/src/i18n/locales/nb.ts
@@ -236,7 +236,8 @@ const nb = {
       flowControlHard: 'Maskinvare',
       dataBits: 'Databiter',
       stopBits: 'Stoppbiter',
-      confirm: 'Ok'
+      confirm: 'Ok',
+      usbSerial: '(USB CDC ACM)',
     },
     wol: {
       title: 'Wake-on-LAN',
@@ -363,6 +364,19 @@ const nb = {
         diskDesc: 'Mount virtual U-disk on the remote host',
         network: 'Virtuelt nettverk',
         networkDesc: 'Monter virtuelt nettverkskort på den eksterne verten',
+        usbSerial: 'USB Serial Console',
+        usbSerialDesc: 'Expose a USB CDC ACM serial port (/dev/ttyACM0) to the attached host. Implies HID-Only mode and disables the touchpad.',
+        usbSerialModal: {
+          title: 'USB Serial Console',
+          descEnable: 'Enable a CDC ACM virtual serial port so the attached host can use NanoKVM as an out-of-band serial console (e.g. OPNsense, FreeBSD, Linux).',
+          descDisable: 'Disable the USB serial console. The touchpad will be restored after reboot.',
+          tip1: 'Touchpad will be disabled (keyboard and mouse continue to work)',
+          tip2: 'Implies HID-Only mode: USB network gadget and mass storage become unavailable',
+          tip3: "NanoKVM's onboard ethernet, Wi-Fi, and web UI are unaffected",
+          tip4: 'NanoKVM will reboot to apply the change',
+          enable: 'Enable USB Serial Console',
+          disable: 'Disable USB Serial Console'
+        },
         reboot: 'Start på nytt',
         rebootDesc: 'Er du sikker på at du vil starte NanoKVM på nytt?',
         okBtn: 'Ja',

--- a/web/src/i18n/locales/nl.ts
+++ b/web/src/i18n/locales/nl.ts
@@ -238,7 +238,8 @@ const nl = {
       flowControlHard: 'Hardware',
       dataBits: 'Databits',
       stopBits: 'Stopbits',
-      confirm: 'Ok'
+      confirm: 'Ok',
+      usbSerial: '(USB CDC ACM)',
     },
     wol: {
       title: 'Wake-on-LAN',
@@ -367,6 +368,19 @@ const nl = {
         diskDesc: 'Koppel virtuele U-schijf aan de externe host',
         network: 'Virtueel Netwerk',
         networkDesc: 'Koppel virtueel netwerk kaart aan de externe host',
+        usbSerial: 'USB Serial Console',
+        usbSerialDesc: 'Expose a USB CDC ACM serial port (/dev/ttyACM0) to the attached host. Implies HID-Only mode and disables the touchpad.',
+        usbSerialModal: {
+          title: 'USB Serial Console',
+          descEnable: 'Enable a CDC ACM virtual serial port so the attached host can use NanoKVM as an out-of-band serial console (e.g. OPNsense, FreeBSD, Linux).',
+          descDisable: 'Disable the USB serial console. The touchpad will be restored after reboot.',
+          tip1: 'Touchpad will be disabled (keyboard and mouse continue to work)',
+          tip2: 'Implies HID-Only mode: USB network gadget and mass storage become unavailable',
+          tip3: "NanoKVM's onboard ethernet, Wi-Fi, and web UI are unaffected",
+          tip4: 'NanoKVM will reboot to apply the change',
+          enable: 'Enable USB Serial Console',
+          disable: 'Disable USB Serial Console'
+        },
         reboot: 'Opnieuw opstarten',
         rebootDesc: 'Weet u zeker dat u NanoKVM opnieuw wilt opstarten?',
         okBtn: 'Ja',

--- a/web/src/i18n/locales/pl.ts
+++ b/web/src/i18n/locales/pl.ts
@@ -237,7 +237,8 @@ const pl = {
       flowControlHard: 'Sprzętowe',
       dataBits: 'Bity danych',
       stopBits: 'Bity stopu',
-      confirm: 'Ok'
+      confirm: 'Ok',
+      usbSerial: '(USB CDC ACM)',
     },
     wol: {
       title: 'Wake-on-LAN',
@@ -366,6 +367,19 @@ const pl = {
         diskDesc: 'Mount virtual U-disk on the remote host',
         network: 'Sieć wirtualna',
         networkDesc: 'Zamontuj wirtualną kartę sieciową na zdalnym hoście',
+        usbSerial: 'USB Serial Console',
+        usbSerialDesc: 'Expose a USB CDC ACM serial port (/dev/ttyACM0) to the attached host. Implies HID-Only mode and disables the touchpad.',
+        usbSerialModal: {
+          title: 'USB Serial Console',
+          descEnable: 'Enable a CDC ACM virtual serial port so the attached host can use NanoKVM as an out-of-band serial console (e.g. OPNsense, FreeBSD, Linux).',
+          descDisable: 'Disable the USB serial console. The touchpad will be restored after reboot.',
+          tip1: 'Touchpad will be disabled (keyboard and mouse continue to work)',
+          tip2: 'Implies HID-Only mode: USB network gadget and mass storage become unavailable',
+          tip3: "NanoKVM's onboard ethernet, Wi-Fi, and web UI are unaffected",
+          tip4: 'NanoKVM will reboot to apply the change',
+          enable: 'Enable USB Serial Console',
+          disable: 'Disable USB Serial Console'
+        },
         reboot: 'Uruchom ponownie',
         rebootDesc: 'Czy na pewno chcesz ponownie uruchomić NanoKVM?',
         okBtn: 'Tak',

--- a/web/src/i18n/locales/pt_br.ts
+++ b/web/src/i18n/locales/pt_br.ts
@@ -236,7 +236,8 @@ const pt_br = {
       flowControlHard: 'Hardware',
       dataBits: 'Bits de dados',
       stopBits: 'Bits de parada',
-      confirm: 'Ok'
+      confirm: 'Ok',
+      usbSerial: '(USB CDC ACM)',
     },
     wol: {
       title: 'Wake-on-LAN',
@@ -364,6 +365,19 @@ const pt_br = {
         diskDesc: 'Montar U-disk virtual no host remoto',
         network: 'Rede Virtual',
         networkDesc: 'Montar placa de rede virtual no host remoto',
+        usbSerial: 'USB Serial Console',
+        usbSerialDesc: 'Expose a USB CDC ACM serial port (/dev/ttyACM0) to the attached host. Implies HID-Only mode and disables the touchpad.',
+        usbSerialModal: {
+          title: 'USB Serial Console',
+          descEnable: 'Enable a CDC ACM virtual serial port so the attached host can use NanoKVM as an out-of-band serial console (e.g. OPNsense, FreeBSD, Linux).',
+          descDisable: 'Disable the USB serial console. The touchpad will be restored after reboot.',
+          tip1: 'Touchpad will be disabled (keyboard and mouse continue to work)',
+          tip2: 'Implies HID-Only mode: USB network gadget and mass storage become unavailable',
+          tip3: "NanoKVM's onboard ethernet, Wi-Fi, and web UI are unaffected",
+          tip4: 'NanoKVM will reboot to apply the change',
+          enable: 'Enable USB Serial Console',
+          disable: 'Disable USB Serial Console'
+        },
         reboot: 'Reiniciar',
         rebootDesc: 'Tem certeza de que deseja reiniciar o NanoKVM?',
         okBtn: 'Sim',

--- a/web/src/i18n/locales/ru.ts
+++ b/web/src/i18n/locales/ru.ts
@@ -236,7 +236,8 @@ const ru = {
       flowControlHard: 'Аппаратное',
       dataBits: 'Бит данных',
       stopBits: 'Стоп-бит',
-      confirm: 'ОК'
+      confirm: 'ОК',
+      usbSerial: '(USB CDC ACM)',
     },
     wol: {
       title: 'Wake-on-LAN',
@@ -366,6 +367,19 @@ const ru = {
         diskDesc: 'Смонтировать виртуальный USB диск на удаленном хосте',
         network: 'Виртуальная сеть',
         networkDesc: 'Смонтировать виртуальное сетевое устройство на удаленном хосте',
+        usbSerial: 'USB Serial Console',
+        usbSerialDesc: 'Expose a USB CDC ACM serial port (/dev/ttyACM0) to the attached host. Implies HID-Only mode and disables the touchpad.',
+        usbSerialModal: {
+          title: 'USB Serial Console',
+          descEnable: 'Enable a CDC ACM virtual serial port so the attached host can use NanoKVM as an out-of-band serial console (e.g. OPNsense, FreeBSD, Linux).',
+          descDisable: 'Disable the USB serial console. The touchpad will be restored after reboot.',
+          tip1: 'Touchpad will be disabled (keyboard and mouse continue to work)',
+          tip2: 'Implies HID-Only mode: USB network gadget and mass storage become unavailable',
+          tip3: "NanoKVM's onboard ethernet, Wi-Fi, and web UI are unaffected",
+          tip4: 'NanoKVM will reboot to apply the change',
+          enable: 'Enable USB Serial Console',
+          disable: 'Disable USB Serial Console'
+        },
         reboot: 'Перезагрузка',
         rebootDesc: 'Вы уверены, что хотите перезагрузить NanoKVM?',
         okBtn: 'Да',

--- a/web/src/i18n/locales/se.ts
+++ b/web/src/i18n/locales/se.ts
@@ -233,7 +233,8 @@ const se = {
       flowControlHard: 'Hårdvara',
       dataBits: 'Databitar',
       stopBits: 'Stoppbitar',
-      confirm: 'Ok'
+      confirm: 'Ok',
+      usbSerial: '(USB CDC ACM)',
     },
     wol: {
       title: 'Wake-on-LAN',
@@ -360,6 +361,19 @@ const se = {
         diskDesc: 'Montera virtuell U-disk på fjärrvärden',
         network: 'Virtuellt nätverk',
         networkDesc: 'Montera virtuell nätverkskort på fjärrvärden',
+        usbSerial: 'USB Serial Console',
+        usbSerialDesc: 'Expose a USB CDC ACM serial port (/dev/ttyACM0) to the attached host. Implies HID-Only mode and disables the touchpad.',
+        usbSerialModal: {
+          title: 'USB Serial Console',
+          descEnable: 'Enable a CDC ACM virtual serial port so the attached host can use NanoKVM as an out-of-band serial console (e.g. OPNsense, FreeBSD, Linux).',
+          descDisable: 'Disable the USB serial console. The touchpad will be restored after reboot.',
+          tip1: 'Touchpad will be disabled (keyboard and mouse continue to work)',
+          tip2: 'Implies HID-Only mode: USB network gadget and mass storage become unavailable',
+          tip3: "NanoKVM's onboard ethernet, Wi-Fi, and web UI are unaffected",
+          tip4: 'NanoKVM will reboot to apply the change',
+          enable: 'Enable USB Serial Console',
+          disable: 'Disable USB Serial Console'
+        },
         reboot: 'Starta om',
         rebootDesc: 'Är du säker på att du vill starta om NanoKVM?',
         okBtn: 'Ja',

--- a/web/src/i18n/locales/th.ts
+++ b/web/src/i18n/locales/th.ts
@@ -230,7 +230,8 @@ const th = {
       flowControlHard: 'ฮาร์ดแวร์',
       dataBits: 'บิตข้อมูล',
       stopBits: 'บิตหยุด',
-      confirm: 'ยืนยัน'
+      confirm: 'ยืนยัน',
+      usbSerial: '(USB CDC ACM)',
     },
     wol: {
       title: 'Wake-on-LAN',
@@ -357,6 +358,19 @@ const th = {
         diskDesc: 'เปิดใช้งาน U-disk จำลอง',
         network: 'เครือข่ายจำลอง',
         networkDesc: 'เปิดใช้งานอุปกรณ์เครือข่ายจำลอง',
+        usbSerial: 'USB Serial Console',
+        usbSerialDesc: 'Expose a USB CDC ACM serial port (/dev/ttyACM0) to the attached host. Implies HID-Only mode and disables the touchpad.',
+        usbSerialModal: {
+          title: 'USB Serial Console',
+          descEnable: 'Enable a CDC ACM virtual serial port so the attached host can use NanoKVM as an out-of-band serial console (e.g. OPNsense, FreeBSD, Linux).',
+          descDisable: 'Disable the USB serial console. The touchpad will be restored after reboot.',
+          tip1: 'Touchpad will be disabled (keyboard and mouse continue to work)',
+          tip2: 'Implies HID-Only mode: USB network gadget and mass storage become unavailable',
+          tip3: "NanoKVM's onboard ethernet, Wi-Fi, and web UI are unaffected",
+          tip4: 'NanoKVM will reboot to apply the change',
+          enable: 'Enable USB Serial Console',
+          disable: 'Disable USB Serial Console'
+        },
         reboot: 'รีบูต',
         rebootDesc: 'คุณแน่ใจหรือไม่ว่าต้องการรีบูต NanoKVM',
         okBtn: 'ใช่',

--- a/web/src/i18n/locales/tr.ts
+++ b/web/src/i18n/locales/tr.ts
@@ -235,7 +235,8 @@ const tr = {
       flowControlHard: 'Donanımsal',
       dataBits: 'Veri bitleri',
       stopBits: 'Dur bitleri',
-      confirm: 'Tamam'
+      confirm: 'Tamam',
+      usbSerial: '(USB CDC ACM)',
     },
     wol: {
       title: 'Ağ Üzerinden Uyandırma (WOL)',
@@ -364,6 +365,19 @@ const tr = {
         diskDesc: "Sanal U-disk'i uzak ana bilgisayara bağla",
         network: 'Sanal Ağ',
         networkDesc: 'Sanal ağ kartını uzak ana bilgisayara bağla',
+        usbSerial: 'USB Serial Console',
+        usbSerialDesc: 'Expose a USB CDC ACM serial port (/dev/ttyACM0) to the attached host. Implies HID-Only mode and disables the touchpad.',
+        usbSerialModal: {
+          title: 'USB Serial Console',
+          descEnable: 'Enable a CDC ACM virtual serial port so the attached host can use NanoKVM as an out-of-band serial console (e.g. OPNsense, FreeBSD, Linux).',
+          descDisable: 'Disable the USB serial console. The touchpad will be restored after reboot.',
+          tip1: 'Touchpad will be disabled (keyboard and mouse continue to work)',
+          tip2: 'Implies HID-Only mode: USB network gadget and mass storage become unavailable',
+          tip3: "NanoKVM's onboard ethernet, Wi-Fi, and web UI are unaffected",
+          tip4: 'NanoKVM will reboot to apply the change',
+          enable: 'Enable USB Serial Console',
+          disable: 'Disable USB Serial Console'
+        },
         reboot: 'Yeniden Başlat',
         rebootDesc: "NanoKVM'i yeniden başlatmak istediğinizden emin misiniz?",
         okBtn: 'Evet',

--- a/web/src/i18n/locales/uk.ts
+++ b/web/src/i18n/locales/uk.ts
@@ -237,7 +237,8 @@ const uk = {
       flowControlHard: 'Апаратне',
       dataBits: 'Біти даних',
       stopBits: 'Стопові біти',
-      confirm: 'Ок'
+      confirm: 'Ок',
+      usbSerial: '(USB CDC ACM)',
     },
     wol: {
       title: 'Wake-on-LAN',
@@ -364,6 +365,19 @@ const uk = {
         diskDesc: 'Монтувати віртуальний U-диск на віддаленому хості',
         network: 'Віртуальна мережа',
         networkDesc: 'Встановити віртуальну мережеву карту на віддаленому хості',
+        usbSerial: 'USB Serial Console',
+        usbSerialDesc: 'Expose a USB CDC ACM serial port (/dev/ttyACM0) to the attached host. Implies HID-Only mode and disables the touchpad.',
+        usbSerialModal: {
+          title: 'USB Serial Console',
+          descEnable: 'Enable a CDC ACM virtual serial port so the attached host can use NanoKVM as an out-of-band serial console (e.g. OPNsense, FreeBSD, Linux).',
+          descDisable: 'Disable the USB serial console. The touchpad will be restored after reboot.',
+          tip1: 'Touchpad will be disabled (keyboard and mouse continue to work)',
+          tip2: 'Implies HID-Only mode: USB network gadget and mass storage become unavailable',
+          tip3: "NanoKVM's onboard ethernet, Wi-Fi, and web UI are unaffected",
+          tip4: 'NanoKVM will reboot to apply the change',
+          enable: 'Enable USB Serial Console',
+          disable: 'Disable USB Serial Console'
+        },
         reboot: 'Перезавантажити',
         rebootDesc: 'Ви впевнені, що хочете перезавантажити NanoKVM?',
         okBtn: 'Так',

--- a/web/src/i18n/locales/vi.ts
+++ b/web/src/i18n/locales/vi.ts
@@ -234,7 +234,8 @@ const vi = {
       flowControlHard: 'Phần cứng',
       dataBits: 'Bit dữ liệu',
       stopBits: 'Bit dừng',
-      confirm: 'OK'
+      confirm: 'OK',
+      usbSerial: '(USB CDC ACM)',
     },
     wol: {
       title: 'Wake-on-LAN',
@@ -361,6 +362,19 @@ const vi = {
         diskDesc: 'Mount virtual U-disk on the remote host',
         network: 'Mạng ảo',
         networkDesc: 'Gắn card mạng ảo trên máy chủ từ xa',
+        usbSerial: 'USB Serial Console',
+        usbSerialDesc: 'Expose a USB CDC ACM serial port (/dev/ttyACM0) to the attached host. Implies HID-Only mode and disables the touchpad.',
+        usbSerialModal: {
+          title: 'USB Serial Console',
+          descEnable: 'Enable a CDC ACM virtual serial port so the attached host can use NanoKVM as an out-of-band serial console (e.g. OPNsense, FreeBSD, Linux).',
+          descDisable: 'Disable the USB serial console. The touchpad will be restored after reboot.',
+          tip1: 'Touchpad will be disabled (keyboard and mouse continue to work)',
+          tip2: 'Implies HID-Only mode: USB network gadget and mass storage become unavailable',
+          tip3: "NanoKVM's onboard ethernet, Wi-Fi, and web UI are unaffected",
+          tip4: 'NanoKVM will reboot to apply the change',
+          enable: 'Enable USB Serial Console',
+          disable: 'Disable USB Serial Console'
+        },
         reboot: 'Khởi động lại',
         rebootDesc: 'Bạn có chắc chắn muốn khởi động lại NanoKVM không?',
         okBtn: 'Có',

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -226,7 +226,8 @@ const zh = {
       flowControlHard: '硬件',
       dataBits: '数据位',
       stopBits: '停止位',
-      confirm: '确定'
+      confirm: '确定',
+      usbSerial: '(USB CDC ACM)',
     },
     wol: {
       title: 'Wake-on-LAN',
@@ -353,6 +354,19 @@ const zh = {
         diskDesc: '在远程主机中挂载虚拟U盘',
         network: '虚拟网卡',
         networkDesc: '在远程主机中挂载虚拟网卡',
+        usbSerial: 'USB Serial Console',
+        usbSerialDesc: 'Expose a USB CDC ACM serial port (/dev/ttyACM0) to the attached host. Implies HID-Only mode and disables the touchpad.',
+        usbSerialModal: {
+          title: 'USB Serial Console',
+          descEnable: 'Enable a CDC ACM virtual serial port so the attached host can use NanoKVM as an out-of-band serial console (e.g. OPNsense, FreeBSD, Linux).',
+          descDisable: 'Disable the USB serial console. The touchpad will be restored after reboot.',
+          tip1: 'Touchpad will be disabled (keyboard and mouse continue to work)',
+          tip2: 'Implies HID-Only mode: USB network gadget and mass storage become unavailable',
+          tip3: "NanoKVM's onboard ethernet, Wi-Fi, and web UI are unaffected",
+          tip4: 'NanoKVM will reboot to apply the change',
+          enable: 'Enable USB Serial Console',
+          disable: 'Disable USB Serial Console'
+        },
         reboot: '重新启动',
         rebootDesc: '您确定要重新启动 NanoKVM 吗？',
         okBtn: '是',

--- a/web/src/i18n/locales/zh_tw.ts
+++ b/web/src/i18n/locales/zh_tw.ts
@@ -226,7 +226,8 @@ const zh_tw = {
       flowControlHard: '硬體',
       dataBits: '資料位元',
       stopBits: '停止位元',
-      confirm: '確定'
+      confirm: '確定',
+      usbSerial: '(USB CDC ACM)',
     },
     wol: {
       title: 'Wake-on-LAN',
@@ -353,6 +354,19 @@ const zh_tw = {
         diskDesc: '在遠端主機上連接虛擬隨身碟',
         network: '虛擬網卡',
         networkDesc: '在遠端主機上新增虛擬網卡',
+        usbSerial: 'USB Serial Console',
+        usbSerialDesc: 'Expose a USB CDC ACM serial port (/dev/ttyACM0) to the attached host. Implies HID-Only mode and disables the touchpad.',
+        usbSerialModal: {
+          title: 'USB Serial Console',
+          descEnable: 'Enable a CDC ACM virtual serial port so the attached host can use NanoKVM as an out-of-band serial console (e.g. OPNsense, FreeBSD, Linux).',
+          descDisable: 'Disable the USB serial console. The touchpad will be restored after reboot.',
+          tip1: 'Touchpad will be disabled (keyboard and mouse continue to work)',
+          tip2: 'Implies HID-Only mode: USB network gadget and mass storage become unavailable',
+          tip3: "NanoKVM's onboard ethernet, Wi-Fi, and web UI are unaffected",
+          tip4: 'NanoKVM will reboot to apply the change',
+          enable: 'Enable USB Serial Console',
+          disable: 'Disable USB Serial Console'
+        },
         reboot: '重新啟動',
         rebootDesc: '您確定要重新啟動 NanoKVM?',
         okBtn: '確定',

--- a/web/src/pages/desktop/menu/settings/device/virtual-devices.tsx
+++ b/web/src/pages/desktop/menu/settings/device/virtual-devices.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react';
-import { Switch } from 'antd';
+import { Button, Divider, Modal, Switch, Typography } from 'antd';
 import { useTranslation } from 'react-i18next';
 
 import { getHidMode } from '@/api/hid.ts';
 import * as api from '@/api/virtual-device.ts';
+
+const { Paragraph } = Typography;
 
 export const VirtualDevices = () => {
   const { t } = useTranslation();
@@ -11,7 +13,11 @@ export const VirtualDevices = () => {
   const [isHidOnlyMode, setIsHidOnlyMode] = useState(false);
   const [isDiskEnabled, setIsDiskEnabled] = useState(false);
   const [isNetworkEnabled, setIsNetworkEnabled] = useState(false);
-  const [loading, setLoading] = useState<'' | 'disk' | 'network'>('');
+  const [isSerialEnabled, setIsSerialEnabled] = useState(false);
+  const [loading, setLoading] = useState<'' | 'disk' | 'network' | 'serial'>('');
+
+  const [isSerialModalOpen, setIsSerialModalOpen] = useState(false);
+  const [serialErrMsg, setSerialErrMsg] = useState('');
 
   useEffect(() => {
     getHidOnlyMode();
@@ -41,6 +47,7 @@ export const VirtualDevices = () => {
 
       setIsDiskEnabled(rsp.data.disk);
       setIsNetworkEnabled(rsp.data.network);
+      setIsSerialEnabled(!!rsp.data.serial);
     } catch (err) {
       console.log(err);
     }
@@ -65,16 +72,107 @@ export const VirtualDevices = () => {
     }
   }
 
+  function updateSerial() {
+    if (loading) return;
+    setLoading('serial');
+    setSerialErrMsg('');
+
+    const timeoutId = setTimeout(() => {
+      window.location.reload();
+    }, 30000);
+
+    api
+      .updateVirtualDevice('serial')
+      .then((rsp) => {
+        if (rsp.code !== 0) {
+          setSerialErrMsg(rsp.msg);
+          setLoading('');
+          clearTimeout(timeoutId);
+        }
+      })
+      .catch((err) => {
+        console.log(err);
+        setLoading('');
+        clearTimeout(timeoutId);
+      });
+  }
+
+  const serialRow = (
+    <div className="flex items-center justify-between">
+      <div className="flex flex-col space-y-1">
+        <span>{t('settings.device.usbSerial')}</span>
+        <span className="text-xs text-neutral-500">{t('settings.device.usbSerialDesc')}</span>
+      </div>
+
+      <Switch
+        checked={isSerialEnabled}
+        loading={loading === 'serial'}
+        onChange={() => setIsSerialModalOpen(true)}
+      />
+    </div>
+  );
+
+  const serialModal = (
+    <Modal
+      open={isSerialModalOpen}
+      title={t('settings.device.usbSerialModal.title')}
+      width={580}
+      centered={false}
+      footer={false}
+      onCancel={() => setIsSerialModalOpen(false)}
+    >
+      <Divider />
+
+      <Paragraph>
+        {isSerialEnabled
+          ? t('settings.device.usbSerialModal.descDisable')
+          : t('settings.device.usbSerialModal.descEnable')}
+      </Paragraph>
+
+      <Paragraph type="secondary">
+        <ul>
+          <li>{t('settings.device.usbSerialModal.tip1')}</li>
+          <li>{t('settings.device.usbSerialModal.tip2')}</li>
+          <li>{t('settings.device.usbSerialModal.tip3')}</li>
+          <li>{t('settings.device.usbSerialModal.tip4')}</li>
+        </ul>
+      </Paragraph>
+
+      {serialErrMsg && <div className="pt-1 text-sm text-red-500">{serialErrMsg}</div>}
+
+      <div className="flex justify-center pt-5">
+        <Button
+          danger
+          type="primary"
+          loading={loading === 'serial'}
+          onClick={() => {
+            setIsSerialModalOpen(false);
+            updateSerial();
+          }}
+        >
+          {isSerialEnabled
+            ? t('settings.device.usbSerialModal.disable')
+            : t('settings.device.usbSerialModal.enable')}
+        </Button>
+      </div>
+    </Modal>
+  );
+
   if (isHidOnlyMode) {
     return (
-      <div className="flex items-center justify-between space-x-10">
-        <div className="flex flex-col space-y-1">
-          <span>{t('settings.device.hidOnly')}</span>
-          <span className="text-xs text-neutral-500">{t('settings.device.hidOnlyDesc')}</span>
+      <>
+        <div className="flex items-center justify-between space-x-10">
+          <div className="flex flex-col space-y-1">
+            <span>{t('settings.device.hidOnly')}</span>
+            <span className="text-xs text-neutral-500">{t('settings.device.hidOnlyDesc')}</span>
+          </div>
+
+          <Switch checked={true} disabled={true} />
         </div>
 
-        <Switch checked={true} disabled={true} />
-      </div>
+        {serialRow}
+        {serialModal}
+      </>
     );
   }
 
@@ -107,6 +205,9 @@ export const VirtualDevices = () => {
           onChange={() => update('network')}
         />
       </div>
+
+      {serialRow}
+      {serialModal}
     </>
   );
 };

--- a/web/src/pages/desktop/menu/terminal/serial-port.tsx
+++ b/web/src/pages/desktop/menu/terminal/serial-port.tsx
@@ -4,6 +4,7 @@ import { useSetAtom } from 'jotai';
 import { SquareTerminalIcon } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
+import { getVirtualDevice } from '@/api/virtual-device.ts';
 import { isKeyboardEnableAtom } from '@/jotai/keyboard.ts';
 
 export const SerialPort = () => {
@@ -17,9 +18,22 @@ export const SerialPort = () => {
   const [flowControl, setFlowControl] = useState<string>('none');
   const [dataBits, setDataBits] = useState(8);
   const [stopBits, setStopBits] = useState(1);
+  const [isUsbSerialEnabled, setIsUsbSerialEnabled] = useState(false);
 
   function openModal() {
     setIsKeyboardEnable(false);
+
+    // Refresh USB serial availability each time the modal opens so the
+    // /dev/ttyGS0 option appears/disappears in step with the device toggle.
+    getVirtualDevice()
+      .then((rsp) => {
+        if (rsp.code === 0) {
+          setIsUsbSerialEnabled(!!rsp.data.serial);
+        }
+      })
+      .catch(() => {
+        // Treat the failure as "USB serial unavailable" — don't block opening.
+      });
 
     setIsModalOpen(true);
   }
@@ -83,6 +97,11 @@ export const SerialPort = () => {
             <Radio value="/dev/ttyS2">
               <code>/dev/ttyS2</code>
             </Radio>
+            {isUsbSerialEnabled && (
+              <Radio value="/dev/ttyGS0">
+                <code>/dev/ttyGS0</code> <span className="text-xs text-neutral-500">{t('terminal.usbSerial')}</span>
+              </Radio>
+            )}
           </Radio.Group>
         </div>
 

--- a/web/src/pages/terminal/index.tsx
+++ b/web/src/pages/terminal/index.tsx
@@ -63,7 +63,7 @@ export const Terminal = () => {
       }
 
       ws.send(
-        `picocom ${port} --baud ${baud} --parity ${parity} --flow ${flowControl} --databits ${dataBits} --stopbits ${stopBits}\r`
+        `picocom ${port} --baud ${baud} --parity ${parity} --flow ${flowControl} --databits ${dataBits} --stopbits ${stopBits} --imap lfcrlf --noreset\r`
       );
 
       isPicocomRunning = true;


### PR DESCRIPTION
This PR adds support for exposing a virtual serial port to the host, that can be used as a serial console tty. This was done as a POC as it seemed like it should be possible and it was interesting.

**It is 100% written by Claude.** please bear that in mind. 

It includes some things that Claude used to run the development process, like the deploy.sh script.

Therefore I am not suggesting this is merged directly, I am providing it as a POC to prove it is possible as this would be a nice feature to add.


----------------------------------------------------------------------

Exposes a CDC ACM virtual serial port to the attached host via a /boot/usb.acm boot flag, providing an out-of-band text console for OPNsense/FreeBSD/Linux servers over the existing NanoKVM USB cable. Host enumerates /dev/ttyACM0 (Linux) or /dev/cuaU0 (FreeBSD).

The SG2002/dwc2 USB controller's FIFO budget only fits keyboard + mouse + ACM simultaneously. The toggle therefore implies HID-Only mode and additionally suppresses the touchpad. The UI warns of the trade-off and reboots to apply.

Components:
- kvmapp/system/init.d/S03usbhid: when /boot/usb.acm exists, skip hid.GS2 (touchpad) and link functions/acm.GS0 into configs/c.1/. Standard-mode S03usbdev is untouched.
- server/service/vm/virtual-device.go: USB Serial toggle dispatched via existing POST /api/vm/device/virtual (device:"serial"). Enable forces the hid-only script over /etc/init.d/S03usbdev, writes /boot/usb.acm, removes firmware's acm::respawn getty from /etc/inittab (so web terminal has exclusive ttyGS0 access), and reboots. Disable removes the flag, restores the getty line, and reboots.
- server/service/hid/status.go: exports CopyModeFile so vm package can force the script swap, bypassing the bcdDevice-based short-circuit in SwitchMode.
- server/proto/vm.go: GetVirtualDeviceRsp gains Serial bool.
- web Settings -> Device: third Switch + warning modal.
- web Terminal -> Serial Port: /dev/ttyGS0 radio option when enabled.
- web Terminal -> terminal/index.tsx: picocom with --imap lfcrlf (fixes diagonal output) and --noreset (avoids ENOTTY on exit).
- Makefile + docker/Dockerfile: fix make app on Apple Silicon / arm64 Linux.
- deploy.sh: dev workflow helper (build + deploy over SSH).
- i18n: real English strings; placeholder stubs in 23 other locales.

Tested on NanoKVM Lite (SG2002) against OPNsense/FreeBSD.