### PR TITLE
fix(usb): stable gadget MAC so the host NIC keeps one MAC across reboots

### DIFF
--- a/kvmapp/system/init.d/S03usbdev
+++ b/kvmapp/system/init.d/S03usbdev
@@ -39,15 +39,30 @@ start_usb_dev(){
     mkdir configs/c.1/strings/0x409
     echo "NanoKVM" >  configs/c.1/strings/0x409/configuration
 
+    # Deterministic gadget MACs from the chip UID so the host-side RNDIS/NCM
+    # interface keeps a STABLE MAC across re-enumeration/reboot. Without this
+    # the kernel assigns a random dev_addr/host_addr on every bind, so the
+    # attached PC sees a brand-new network adapter (and MAC) each time.
+    usb_uid=$(sha512sum /sys/class/cvi-base/base_uid | head -c 4)
+    if [ -n "$usb_uid" ]
+    then
+        usb_dev_mac="48:da:35:6e:${usb_uid%??}:${usb_uid#??}"
+        usb_host_mac="48:da:35:6d:${usb_uid%??}:${usb_uid#??}"
+    fi
+
     if [ -e /boot/usb.ncm ]
     then
         mkdir functions/ncm.usb0
+        [ -n "$usb_dev_mac" ]  && echo "$usb_dev_mac"  > functions/ncm.usb0/dev_addr
+        [ -n "$usb_host_mac" ] && echo "$usb_host_mac" > functions/ncm.usb0/host_addr
         echo WINNCM > functions/ncm.usb0/os_desc/interface.ncm/compatible_id
         ln -s functions/ncm.usb0 configs/c.1/
     else
         if [ -e /boot/usb.rndis0 ]
         then
                 mkdir functions/rndis.usb0
+                [ -n "$usb_dev_mac" ]  && echo "$usb_dev_mac"  > functions/rndis.usb0/dev_addr
+                [ -n "$usb_host_mac" ] && echo "$usb_host_mac" > functions/rndis.usb0/host_addr
                 echo e0 > functions/rndis.usb0/class
                 echo 01 > functions/rndis.usb0/subclass
                 echo 03 > functions/rndis.usb0/protocol


### PR DESCRIPTION
## Problem

Plugging one NanoKVM (Cube) into a PC over USB ends up creating **many** network adapters / MAC addresses on the host — ~10 after a few reboots.

Root cause: the USB network gadget `rndis.usb0` / `ncm.usb0` is created in `S03usbdev` **without setting `dev_addr` or `host_addr`**, so the kernel assigns a *random* MAC to both the device side and the host side on every bind. `S10uuid` later pins the device-side `usb0` with `ip link set`, but the **`host_addr`** — the MAC the attached PC's RNDIS/NCM adapter uses — stays random and changes on every re-enumeration/reboot. Windows then registers a brand-new adapter each time, piling up stale adapters/MACs and breaking anything that keys off the MAC (DHCP reservations, WoL, firewall rules…).

## Fix

Derive both MACs deterministically from the chip UID (the same `sha512sum /sys/class/cvi-base/base_uid` scheme `S10uuid` already uses for `eth0`/`usb0`), set **before** binding the gadget:

```
dev_addr  = 48:da:35:6e:<uid>
host_addr = 48:da:35:6d:<uid>
```

Guarded on a non-empty UID; falls back to the old random behaviour if `base_uid` is unavailable. Applies to both the `ncm` and `rndis` paths.

## Verified on hardware (NanoKVM Cube)

| | host_addr (MAC the PC sees) |
|---|---|
| before | `a6:3f:5d:8a:7d:52` (random, changes every boot) |
| after, reboot #1 | `48:da:35:6d:26:62` |
| after, reboot #2 | `48:da:35:6d:26:62` (stable) |

Fixes #740