### PR TITLE
修复UID问题导致的容器进入缓慢

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,17 @@
 # Makefile for NanoKVM Project
 
 # Configuration
-IMAGE_NAME := nanokvm-builder
 UID := $(shell id -u)
 GID := $(shell id -g)
+IMAGE_NAME := nanokvm-builder-local-$(UID)-$(GID)
 PWD := $(shell pwd)
 
 # Docker run common parameters
 DOCKER_RUN_BASE := docker run -e UID=$(UID) -e GID=$(GID) -v $(PWD):/home/build/NanoKVM --rm
+
+# Build the image with the host user's identity so entrypoint does not need
+# to recursively rewrite the MaixCDK home directory at container startup.
+DOCKER_BUILD_ARGS := --build-arg DOCKER_UID=$(UID) --build-arg DOCKER_GID=$(GID)
 
 # Build commands
 GO_BUILD_CMD := cd /home/build/NanoKVM/server && go mod tidy && CGO_ENABLED=1 GOOS=linux GOARCH=riscv64 CC=riscv64-unknown-linux-musl-gcc CGO_CFLAGS="-mcpu=c906fdv -march=rv64imafdcv0p7xthead -mcmodel=medany -mabi=lp64d" go build
@@ -58,7 +62,7 @@ check-image: check-root
 builder-image: check-root
 	@if ! docker image inspect $(IMAGE_NAME) >/dev/null 2>&1; then \
 		echo "Building Docker image..."; \
-		docker build -t $(IMAGE_NAME) -f docker/Dockerfile ./; \
+		docker build $(DOCKER_BUILD_ARGS) -t $(IMAGE_NAME) -f docker/Dockerfile ./; \
 	else \
 		echo "Docker image $(IMAGE_NAME) already exists."; \
 	fi
@@ -66,7 +70,7 @@ builder-image: check-root
 # Force rebuild Docker image
 rebuild-image: check-root
 	@echo "Force rebuilding Docker image..."
-	@docker build --no-cache -t $(IMAGE_NAME) -f docker/Dockerfile ./
+	@docker build --no-cache $(DOCKER_BUILD_ARGS) -t $(IMAGE_NAME) -f docker/Dockerfile ./
 
 # Enter interactive shell (equivalent to build.sh with no arguments)
 shell: check-root builder-image

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,10 @@ RUN apt update \
     && apt install wget git cmake build-essential python3 python3-venv python3-pip autoconf automake libtool gosu -y
 
 ARG DOCKER_USER=build
-RUN useradd -m "$DOCKER_USER"
+ARG DOCKER_UID=1000
+ARG DOCKER_GID=1000
+RUN groupadd --gid "$DOCKER_GID" "$DOCKER_USER" \
+    && useradd --uid "$DOCKER_UID" --gid "$DOCKER_GID" --create-home --shell /bin/bash "$DOCKER_USER"
 USER $DOCKER_USER
 
 FROM base_apt AS host_tools

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,9 +8,19 @@ RUN apt update \
 ARG DOCKER_USER=build
 ARG DOCKER_UID=1000
 ARG DOCKER_GID=1000
-RUN groupadd --gid "$DOCKER_GID" "$DOCKER_USER" \
-    && useradd --uid "$DOCKER_UID" --gid "$DOCKER_GID" --create-home --shell /bin/bash "$DOCKER_USER"
-USER $DOCKER_USER
+# Reuse existing accounts for numeric IDs that are already present in the
+# base image. All later ownership and user switches use numeric IDs, so a
+# dedicated build user/group is only needed when the ID does not exist.
+RUN set -eux; \
+    if ! getent group "$DOCKER_GID" >/dev/null; then \
+        groupadd --gid "$DOCKER_GID" "$DOCKER_USER"; \
+    fi; \
+    if ! getent passwd "$DOCKER_UID" >/dev/null; then \
+        useradd --uid "$DOCKER_UID" --gid "$DOCKER_GID" --no-create-home \
+            --home-dir "/home/$DOCKER_USER" --shell /bin/bash "$DOCKER_USER"; \
+    fi; \
+    install -d -o "$DOCKER_UID" -g "$DOCKER_GID" "/home/$DOCKER_USER"
+USER $DOCKER_UID:$DOCKER_GID
 
 FROM base_apt AS host_tools
 
@@ -42,6 +52,8 @@ RUN cd /tmp/go_cache \
 
 FROM base_apt AS sdk
 
+ENV HOME="/home/$DOCKER_USER"
+
 RUN cd ~ \
     && git clone https://github.com/Sipeed/MaixCDK \
     && cd MaixCDK \
@@ -49,7 +61,7 @@ RUN cd ~ \
     && . ./bin/activate \
     && pip install -U -r requirements.txt 
 
-COPY --chown=$DOCKER_USER . /home/$DOCKER_USER/NanoKVM
+COPY --chown=$DOCKER_UID:$DOCKER_GID . /home/$DOCKER_USER/NanoKVM
 
 RUN cd ~/MaixCDK \
     && . ./bin/activate \
@@ -60,7 +72,7 @@ FROM base_apt
 
 # Install golang
 COPY --from=golang /usr/local/go /usr/local/go
-COPY --chown=$DOCKER_USER --from=golang /root/go /home/$DOCKER_USER/go
+COPY --chown=$DOCKER_UID:$DOCKER_GID --from=golang /root/go /home/$DOCKER_USER/go
 ENV PATH="$PATH:/usr/local/go/bin"
 
 # Install host tools
@@ -68,7 +80,7 @@ COPY --from=host_tools /usr/local/host-tools /usr/local/host-tools
 ENV PATH="$PATH:/usr/local/host-tools/gcc/riscv64-linux-musl-x86_64/bin"
 
 # Install SDK
-COPY --from=sdk /home/$DOCKER_USER/MaixCDK /home/$DOCKER_USER/MaixCDK
+COPY --chown=$DOCKER_UID:$DOCKER_GID --from=sdk /home/$DOCKER_USER/MaixCDK /home/$DOCKER_USER/MaixCDK
 COPY --chmod=+x docker/entrypoint /entrypoint
 
 RUN echo "Verify build tools" \

--- a/docker/entrypoint
+++ b/docker/entrypoint
@@ -12,19 +12,9 @@ fi
 
 if [ "$UID" != 0 ]
 then
-        current_uid="$(id -u "$DOCKER_USER")"
-        current_gid="$(id -g "$DOCKER_USER")"
-
-        if [ "$current_uid" != "$UID" ]; then
-                usermod -u "$UID" "$DOCKER_USER"
-        fi
-
-        if [ "$current_gid" != "$GID" ]; then
-                groupmod -g "$GID" "$DOCKER_USER" 2>/dev/null ||
-                usermod -a -G "$GID" "$DOCKER_USER"
-        fi
-
-        set -- gosu "${UID}:${GID}" "${@}"
+        set -- gosu "${UID}:${GID}" env HOME="/home/$DOCKER_USER" "${@}"
+else
+        export HOME=/root
 fi
 
 exec "$@"

--- a/docker/entrypoint
+++ b/docker/entrypoint
@@ -12,10 +12,18 @@ fi
 
 if [ "$UID" != 0 ]
 then
-        usermod -u "$UID" "$DOCKER_USER" 2>/dev/null && {
+        current_uid="$(id -u "$DOCKER_USER")"
+        current_gid="$(id -g "$DOCKER_USER")"
+
+        if [ "$current_uid" != "$UID" ]; then
+                usermod -u "$UID" "$DOCKER_USER"
+        fi
+
+        if [ "$current_gid" != "$GID" ]; then
                 groupmod -g "$GID" "$DOCKER_USER" 2>/dev/null ||
                 usermod -a -G "$GID" "$DOCKER_USER"
-        }
+        fi
+
         set -- gosu "${UID}:${GID}" "${@}"
 fi
 


### PR DESCRIPTION
原先进入容器时，若用户UID不为1000，则会在进入时对home目录下所有文件执行usermod，造成缓慢。
现在令镜像创建时即使用当前用户的UID。