### PR TITLE
Add a novision build tag so the server can be built and tested off-device

### DIFF
--- a/server/common/kvm_vision.go
+++ b/server/common/kvm_vision.go
@@ -1,3 +1,5 @@
+//go:build !novision
+
 package common
 
 /*

--- a/server/common/kvm_vision_stub.go
+++ b/server/common/kvm_vision_stub.go
@@ -1,0 +1,56 @@
+//go:build novision
+
+package common
+
+import (
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// This stub replaces the cgo capture bindings when the "novision" build tag is
+// set. The real implementation links against libkvm in dl_lib through cgo, so
+// building it needs CGO_ENABLED=1 and the riscv64 cross-compiler. Without this
+// stub, every package that reaches common is therefore out of reach of go vet
+// and go test on a workstation. It is never used in a device build.
+
+var (
+	kvmVision     *KvmVision
+	kvmVisionOnce sync.Once
+)
+
+type KvmVision struct{}
+
+func GetKvmVision() *KvmVision {
+	kvmVisionOnce.Do(func() {
+		kvmVision = &KvmVision{}
+		log.Debugf("kvm vision stub initialized")
+	})
+
+	return kvmVision
+}
+
+func (k *KvmVision) ReadMjpeg(width uint16, height uint16, quality uint16) (data []byte, result int) {
+	return nil, -1
+}
+
+func (k *KvmVision) ReadH264(width uint16, height uint16, bitRate uint16) (data []byte, result int) {
+	return nil, -1
+}
+
+func (k *KvmVision) SetHDMI(enable bool) int {
+	return 0
+}
+
+// HasHDMISignal reports no signal, which is what the real binding also returns
+// when the library is closed. A caller that polls it therefore sees a valid
+// state rather than a build without an input.
+func (k *KvmVision) HasHDMISignal() bool {
+	return false
+}
+
+func (k *KvmVision) SetGop(gop uint8) {}
+
+func (k *KvmVision) SetFrameDetect(frame uint8) {}
+
+func (k *KvmVision) Close() {}


### PR DESCRIPTION
common/kvm_vision.go links against libkvm through cgo, so any package that reaches it can only be built with the cross-compiler and the device libraries present. That is most of the server, which means none of it can be type checked or tested on a workstation or in CI.

This adds a `novision` tag that swaps that one file for a pure Go stub with the same surface:

```
go vet -tags novision ./...
go test -tags novision ./...
go build -tags novision ./...
```

The device build is untouched. Without the tag the real bindings are used exactly as before, and `common/kvm_vision.go` only gains a `//go:build !novision` line.

I opened this first because several other fixes I am proposing come with tests, and without something like this there is no way to run them anywhere but on hardware.

### One thing worth knowing

With the tag in place the existing suite runs, and it is not quite green under load. `service/controlmode` and `service/picoclaw` have tests with one-second timing budgets that fail when the whole suite runs in parallel on a slow filesystem, and pass consistently when run alone:

```
go test -tags novision -count=1 ./service/controlmode/   ok (3/3 runs)
go test -tags novision -count=1 ./service/picoclaw/      ok (2/2 runs)
go test -tags novision -count=1 -p 1 ./...               intermittent
```

Those are pre-existing and nothing to do with this change, but if you wire this into CI you will meet them. `-p 1` makes it reliable in my testing.

Verified: `go build`, `go vet`, and `GOOS=linux GOARCH=riscv64 go build` all clean with and without the tag.