### PR TITLE
Hold the whole API to the same origin, not only the websocket upgrades

### DIFF
--- a/server/middleware/jwt.go
+++ b/server/middleware/jwt.go
@@ -34,6 +34,11 @@ type Token struct {
 
 func CheckToken() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		if !allowByOrigin(c.Request) {
+			abortForbiddenOrigin(c)
+			return
+		}
+
 		principal, token, ok := authenticate(c)
 		if !ok {
 			abortUnauthorized(c)
@@ -119,6 +124,11 @@ func CheckLoopbackInternalToken() gin.HandlerFunc {
 
 func CheckTokenOrLoopbackInternalToken() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		if !allowByOrigin(c.Request) {
+			abortForbiddenOrigin(c)
+			return
+		}
+
 		if allowByLoopbackInternalToken(c.Request) {
 			c.Next()
 			return
@@ -159,6 +169,13 @@ func authenticate(c *gin.Context) (Principal, *Token, bool) {
 
 func abortUnauthorized(c *gin.Context) {
 	c.JSON(http.StatusUnauthorized, "unauthorized")
+	c.Abort()
+}
+
+func abortForbiddenOrigin(c *gin.Context) {
+	log.Debugf("rejected request from origin %s to host %s", c.Request.Header.Get("Origin"), c.Request.Host)
+
+	c.JSON(http.StatusForbidden, "forbidden origin")
 	c.Abort()
 }
 

--- a/server/middleware/jwt_test.go
+++ b/server/middleware/jwt_test.go
@@ -177,29 +177,65 @@ func TestWatchWebSocketClosesRevokedConnection(t *testing.T) {
 	}
 }
 
-func TestCheckWebSocketOrigin(t *testing.T) {
-	tests := []struct {
-		origin string
-		host   string
-		want   bool
-	}{
-		{"", "kvm.local", true},
-		{"http://kvm.local", "kvm.local", true},
-		{"http://KVM.local", "kvm.local", true},
-		{"http://kvm.local:8080", "kvm.local:8080", true},
-		{"http://kvm.local:8081", "kvm.local:8080", false},
-		{"http://evil.example", "kvm.local", false},
+// The origin rule this fork applies is its own: it guards every authenticated
+// request, not only the websocket upgrades, because the session travels in a
+// cookie and a page the operator has open can POST to any endpoint without an
+// upgrade. It compares the hostname alone, because the device serves the same
+// UI over http and https, and it stands down when authentication is switched
+// off. See middleware/origin.go.
+func TestCheckTokenAcceptsValidTokenFromSameOrigin(t *testing.T) {
+	if status := requestWithOriginHeader(t, "https://nanokvm.local"); status != http.StatusNoContent {
+		t.Fatalf("same-origin request with a valid token = %d, want %d", status, http.StatusNoContent)
 	}
-	for _, test := range tests {
-		request := httptest.NewRequest(http.MethodGet, "http://"+test.host+"/api/ws", nil)
-		request.Host = test.host
-		if test.origin != "" {
-			request.Header.Set("Origin", test.origin)
-		}
-		if got := CheckWebSocketOrigin(request); got != test.want {
-			t.Fatalf("origin %q host %q = %v, want %v", test.origin, test.host, got, test.want)
-		}
+}
+
+func TestCheckTokenRejectsValidTokenFromForeignOrigin(t *testing.T) {
+	// The cookie is valid; only the Origin differs. This is the CSRF and
+	// cross-site websocket hijacking case.
+	if status := requestWithOriginHeader(t, "https://evil.example.com"); status != http.StatusForbidden {
+		t.Fatalf("cross-site request = %d, want %d", status, http.StatusForbidden)
 	}
+}
+
+func TestCheckTokenAcceptsValidTokenWithoutOrigin(t *testing.T) {
+	// A non-browser client sends no Origin, and cannot be driven by a web page.
+	if status := requestWithOriginHeader(t, ""); status != http.StatusNoContent {
+		t.Fatalf("request without an origin = %d, want %d", status, http.StatusNoContent)
+	}
+}
+
+func requestWithOriginHeader(t *testing.T, origin string) int {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	store := authn.NewStore(filepath.Join(t.TempDir(), "pwd"))
+	admin, ok, err := store.Authenticate("admin", "admin")
+	if err != nil || !ok {
+		t.Fatalf("default login: ok=%v err=%v", ok, err)
+	}
+	restore := useTestAuthStore(t, store)
+	defer restore()
+
+	token, err := GenerateJWT(admin.Username, admin.TokenVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	router := gin.New()
+	router.POST("/api/vm/system/reboot", CheckToken(), func(c *gin.Context) {
+		c.Status(http.StatusNoContent)
+	})
+
+	request := httptest.NewRequest(http.MethodPost, "/api/vm/system/reboot", nil)
+	request.Host = "nanokvm.local"
+	request.AddCookie(&http.Cookie{Name: CookieName, Value: token})
+	if origin != "" {
+		request.Header.Set("Origin", origin)
+	}
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, request)
+	return recorder.Code
 }
 
 func requestWithToken(handler http.Handler, path, token string) int {

--- a/server/middleware/origin.go
+++ b/server/middleware/origin.go
@@ -1,0 +1,56 @@
+package middleware
+
+import (
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"NanoKVM-Server/config"
+)
+
+// SameOrigin reports whether the request may act on the device.
+//
+// Browsers always attach an Origin header to cross-site POST requests and to
+// websocket handshakes, so comparing it against the host the request was sent
+// to is what stops a hostile page from riding the session cookie (CSRF and
+// cross-site websocket hijacking). Requests without an Origin header come from
+// non-browser clients, which cannot be driven by a web page, and are allowed.
+// Only the hostname is compared: the device serves the same UI over both http
+// and https, so an origin arriving on the other port is still the same device.
+func SameOrigin(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true
+	}
+
+	u, err := url.Parse(origin)
+	if err != nil || u.Host == "" {
+		return false
+	}
+
+	return strings.EqualFold(u.Hostname(), hostname(r.Host))
+}
+
+// allowByOrigin applies SameOrigin unless authentication is switched off, a
+// mode in which the API is deliberately open (main.go also enables permissive
+// CORS there) and origin enforcement would contradict the operator's choice.
+func allowByOrigin(r *http.Request) bool {
+	if config.GetInstance().Authentication == "disable" {
+		return true
+	}
+
+	return SameOrigin(r)
+}
+
+func hostname(hostport string) string {
+	if host, _, err := net.SplitHostPort(hostport); err == nil {
+		return strings.Trim(host, "[]")
+	}
+
+	return strings.Trim(hostport, "[]")
+}

--- a/server/middleware/origin_test.go
+++ b/server/middleware/origin_test.go
@@ -1,0 +1,82 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func requestWithOrigin(host string, origin string) *http.Request {
+	r := httptest.NewRequest(http.MethodPost, "/api/vm/script/run", nil)
+	r.Host = host
+	if origin != "" {
+		r.Header.Set("Origin", origin)
+	}
+	return r
+}
+
+func TestSameOriginAllowsRequestWithoutOriginHeader(t *testing.T) {
+	// Non-browser clients (curl, scripts, the picoclaw agent) send no Origin.
+	// Browsers always send one on cross-site POSTs and websocket handshakes,
+	// so absence cannot be forged by a page and must stay allowed.
+	if !SameOrigin(requestWithOrigin("nanokvm.local", "")) {
+		t.Fatal("request without an Origin header must be allowed")
+	}
+}
+
+func TestSameOriginAllowsMatchingHost(t *testing.T) {
+	if !SameOrigin(requestWithOrigin("nanokvm.local", "http://nanokvm.local")) {
+		t.Fatal("same-host origin must be allowed")
+	}
+}
+
+func TestSameOriginAllowsMatchingHostAndPort(t *testing.T) {
+	if !SameOrigin(requestWithOrigin("nanokvm.local:8080", "http://nanokvm.local:8080")) {
+		t.Fatal("same host:port origin must be allowed")
+	}
+}
+
+func TestSameOriginAllowsHttpsOriginOnHttpHost(t *testing.T) {
+	// The device serves the same UI over both http:80 and https:443, so a
+	// request from one to the other is still the same device.
+	if !SameOrigin(requestWithOrigin("nanokvm.local", "https://nanokvm.local")) {
+		t.Fatal("https origin on the same host must be allowed")
+	}
+}
+
+func TestSameOriginAllowsIPv6Host(t *testing.T) {
+	if !SameOrigin(requestWithOrigin("[fe80::1]:443", "https://[fe80::1]")) {
+		t.Fatal("matching IPv6 origin must be allowed")
+	}
+}
+
+func TestSameOriginRejectsForeignHost(t *testing.T) {
+	if SameOrigin(requestWithOrigin("nanokvm.local", "https://evil.example.com")) {
+		t.Fatal("cross-site origin must be rejected")
+	}
+}
+
+func TestSameOriginRejectsForeignHostSharingSuffix(t *testing.T) {
+	if SameOrigin(requestWithOrigin("nanokvm.local", "https://evilnanokvm.local")) {
+		t.Fatal("origin that merely shares a suffix must be rejected")
+	}
+}
+
+func TestSameOriginRejectsNullOrigin(t *testing.T) {
+	// Sandboxed iframes and some redirects produce "null".
+	if SameOrigin(requestWithOrigin("nanokvm.local", "null")) {
+		t.Fatal("null origin must be rejected")
+	}
+}
+
+func TestSameOriginRejectsUnparsableOrigin(t *testing.T) {
+	if SameOrigin(requestWithOrigin("nanokvm.local", "://not a url")) {
+		t.Fatal("unparsable origin must be rejected")
+	}
+}
+
+func TestSameOriginRejectsOriginWithoutHost(t *testing.T) {
+	if SameOrigin(requestWithOrigin("nanokvm.local", "file://")) {
+		t.Fatal("origin without a host must be rejected")
+	}
+}

--- a/server/middleware/session.go
+++ b/server/middleware/session.go
@@ -2,10 +2,6 @@ package middleware
 
 import (
 	"context"
-	"net"
-	"net/http"
-	"net/url"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -69,55 +65,4 @@ func WatchWebSocket(ctx context.Context, connection *websocket.Conn) func() {
 		}
 	}()
 	return func() { stopOnce.Do(func() { close(stopped) }) }
-}
-
-func CheckWebSocketOrigin(request *http.Request) bool {
-	origin := strings.TrimSpace(request.Header.Get("Origin"))
-	if origin == "" {
-		return true
-	}
-	parsed, err := url.Parse(origin)
-	if err != nil || parsed.Host == "" {
-		return false
-	}
-	requestScheme := "http"
-	if request.TLS != nil {
-		requestScheme = "https"
-	}
-	if forwarded := strings.TrimSpace(strings.Split(request.Header.Get("X-Forwarded-Proto"), ",")[0]); forwarded != "" {
-		requestScheme = strings.ToLower(forwarded)
-	}
-	return equalOrigin(parsed, request.Host, requestScheme)
-}
-
-func equalOrigin(origin *url.URL, requestHost, requestScheme string) bool {
-	originHost, originPort := splitHostPort(origin.Host)
-	host, port := splitHostPort(requestHost)
-	if !strings.EqualFold(originHost, host) {
-		return false
-	}
-	if originPort == "" {
-		originPort = defaultPort(origin.Scheme)
-	}
-	if port == "" {
-		port = defaultPort(requestScheme)
-	}
-	return originPort == port
-}
-
-func splitHostPort(value string) (string, string) {
-	host, port, err := net.SplitHostPort(value)
-	if err == nil {
-		return host, port
-	}
-	return strings.Trim(value, "[]"), ""
-}
-
-func defaultPort(scheme string) string {
-	switch strings.ToLower(scheme) {
-	case "https", "wss":
-		return "443"
-	default:
-		return "80"
-	}
 }

--- a/server/service/picoclaw/gateway_proxy.go
+++ b/server/service/picoclaw/gateway_proxy.go
@@ -20,7 +20,7 @@ import (
 var gatewayUpgrader = websocket.Upgrader{
 	ReadBufferSize:  4096,
 	WriteBufferSize: 4096,
-	CheckOrigin:     middleware.CheckWebSocketOrigin,
+	CheckOrigin:     middleware.SameOrigin,
 }
 
 type relayResult struct {

--- a/server/service/stream/direct/h264.go
+++ b/server/service/stream/direct/h264.go
@@ -17,7 +17,7 @@ var (
 	streamer = newStreamer()
 	upgrader = websocket.Upgrader{
 		WriteBufferSize: 256 * 1024,
-		CheckOrigin:     middleware.CheckWebSocketOrigin,
+		CheckOrigin:     middleware.SameOrigin,
 	}
 )
 

--- a/server/service/stream/webrtc/h264.go
+++ b/server/service/stream/webrtc/h264.go
@@ -17,7 +17,7 @@ import (
 var (
 	upgrader = websocket.Upgrader{
 		WriteBufferSize: 256 * 1024,
-		CheckOrigin:     middleware.CheckWebSocketOrigin,
+		CheckOrigin:     middleware.SameOrigin,
 	}
 	globalManager *WebRTCManager
 	managerOnce   sync.Once

--- a/server/service/vm/terminal.go
+++ b/server/service/vm/terminal.go
@@ -26,7 +26,7 @@ type WinSize struct {
 var upgrader = websocket.Upgrader{
 	ReadBufferSize:  maxMessageSize,
 	WriteBufferSize: maxMessageSize,
-	CheckOrigin:     middleware.CheckWebSocketOrigin,
+	CheckOrigin:     middleware.SameOrigin,
 }
 
 func (s *Service) Terminal(c *gin.Context) {

--- a/server/service/ws/service.go
+++ b/server/service/ws/service.go
@@ -13,7 +13,7 @@ type Service struct{}
 var upgrader = websocket.Upgrader{
 	ReadBufferSize:  1024,
 	WriteBufferSize: 1024,
-	CheckOrigin:     middleware.CheckWebSocketOrigin,
+	CheckOrigin:     middleware.SameOrigin,
 }
 
 func NewService() *Service {


### PR DESCRIPTION
`#876` added an origin check to the five websocket upgraders. The API around them still takes any origin, and the session is a cookie, so a page the operator has open can POST to any endpoint on the device: change a setting, mount an image, reboot the board. Only the browser's SameSite default stands in the way, and it is a default rather than a rule.

This applies the same check in `CheckToken`, `CheckSession` and `CheckTokenOrLoopbackInternalToken`, and points the upgraders at that one implementation.

Two differences from the check it replaces, both deliberate:

**Only the hostname is compared.** The device serves the same UI over http and https, and it can be reached on either while a certificate is being set up, so an origin that arrives on the other scheme or port is still the same device. Comparing the port refuses a request that is not cross-site.

**The rule stands down when `authentication: disable` is set.** That mode exists for frontend development against a real board, where the page is served by Vite on another origin, and `main.go` already turns on permissive CORS for it. A rule that contradicts the operator's own setting is a rule they will work around.

A request with no `Origin` header is allowed: non-browser clients do not send one, and they are not what this defends against.

The cookie hardening this branch used to carry is gone, because `#876` does it better: the server sets the session cookie itself with `SameSite=Strict`, `Secure` on https and `HttpOnly`.

Tests: `middleware/origin_test.go` covers the comparison, and `middleware/jwt_test.go` covers a valid session used cross-site, same-site, and with no `Origin` at all.
