### PR TITLE
Contain the file paths that arrive in a request

### DIFF
--- a/server/service/storage/image.go
+++ b/server/service/storage/image.go
@@ -14,6 +14,7 @@ import (
 
 	"NanoKVM-Server/proto"
 	"NanoKVM-Server/service/hid"
+	"NanoKVM-Server/utils"
 )
 
 const (
@@ -24,6 +25,19 @@ const (
 	inquiryString  = "/sys/kernel/config/usb_gadget/g0/functions/mass_storage.disk0/lun.0/inquiry_string"
 	roFlag         = "/sys/kernel/config/usb_gadget/g0/functions/mass_storage.disk0/lun.0/ro"
 )
+
+// isMountableImage reports whether a client-supplied path may be handed to the
+// USB mass storage gadget. Without this check any file or block device on the
+// KVM - the raw eMMC, /etc/shadow - can be exported to the attached machine.
+func isMountableImage(path string) bool {
+	if !utils.IsPathInside(imageDirectory, path) {
+		return false
+	}
+
+	name := strings.ToLower(path)
+
+	return strings.HasSuffix(name, ".iso") || strings.HasSuffix(name, ".img")
+}
 
 func (s *Service) GetImages(c *gin.Context) {
 	var rsp proto.Response
@@ -59,6 +73,12 @@ func (s *Service) MountImage(c *gin.Context) {
 	var rsp proto.Response
 
 	if err := proto.ParseFormRequest(c, &req); err != nil {
+		rsp.ErrRsp(c, -1, "invalid arguments")
+		return
+	}
+
+	// An empty file unmounts; anything else must be an image under /data.
+	if req.File != "" && !isMountableImage(req.File) {
 		rsp.ErrRsp(c, -1, "invalid arguments")
 		return
 	}
@@ -213,11 +233,9 @@ func (s *Service) DeleteImage(c *gin.Context) {
 		return
 	}
 
-	filename := strings.ToLower(req.File)
-	validPrefix := strings.HasPrefix(filename, imageDirectory)
-	validSuffix := strings.HasSuffix(filename, ".iso") || strings.HasSuffix(filename, ".img")
-
-	if !validPrefix || !validSuffix {
+	// The previous check ran HasPrefix on a lowercased copy while removing the
+	// original path, so "/data/../root/x.iso" passed it.
+	if !isMountableImage(req.File) {
 		rsp.ErrRsp(c, -2, "invalid arguments")
 		return
 	}

--- a/server/service/storage/image_test.go
+++ b/server/service/storage/image_test.go
@@ -1,0 +1,41 @@
+package storage
+
+import "testing"
+
+func TestIsMountableImageAcceptsImagesInDataDirectory(t *testing.T) {
+	for _, path := range []string{"/data/ubuntu.iso", "/data/win.IMG", "/data/isos/debian.iso"} {
+		if !isMountableImage(path) {
+			t.Fatalf("%q should be mountable", path)
+		}
+	}
+}
+
+func TestIsMountableImageRejectsBlockDevices(t *testing.T) {
+	// Mounting a raw device exposes the whole filesystem of the KVM to the
+	// machine it is plugged into.
+	for _, path := range []string{"/dev/mmcblk0", "/dev/mmcblk0p3", "/etc/shadow"} {
+		if isMountableImage(path) {
+			t.Fatalf("%q must not be mountable", path)
+		}
+	}
+}
+
+func TestIsMountableImageRejectsTraversal(t *testing.T) {
+	if isMountableImage("/data/../etc/shadow.iso") {
+		t.Fatal("a traversal out of the image directory must be rejected")
+	}
+}
+
+func TestIsMountableImageRejectsOtherExtensions(t *testing.T) {
+	for _, path := range []string{"/data/notes.txt", "/data/script.sh", "/data/iso"} {
+		if isMountableImage(path) {
+			t.Fatalf("%q must not be mountable", path)
+		}
+	}
+}
+
+func TestIsMountableImageRejectsEmptyPath(t *testing.T) {
+	if isMountableImage("") {
+		t.Fatal("an empty path is not a mountable image")
+	}
+}

--- a/server/service/vm/script.go
+++ b/server/service/vm/script.go
@@ -1,7 +1,6 @@
 package vm
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -52,7 +51,8 @@ func (s *Service) UploadScript(c *gin.Context) {
 		return
 	}
 
-	if !isScript(header.Filename) {
+	target, err := utils.SecureJoin(ScriptDirectory, header.Filename)
+	if err != nil || !isScript(header.Filename) {
 		rsp.ErrRsp(c, -2, "invalid arguments")
 		return
 	}
@@ -61,7 +61,6 @@ func (s *Service) UploadScript(c *gin.Context) {
 		_ = os.MkdirAll(ScriptDirectory, 0o755)
 	}
 
-	target := fmt.Sprintf("%s/%s", ScriptDirectory, header.Filename)
 	err = c.SaveUploadedFile(header, target)
 	if err != nil {
 		rsp.ErrRsp(c, -2, "save failed")
@@ -87,16 +86,16 @@ func (s *Service) RunScript(c *gin.Context) {
 		return
 	}
 
-	command := fmt.Sprintf("%s/%s", ScriptDirectory, req.Name)
-
-	name := strings.ToLower(req.Name)
-	if strings.HasSuffix(name, ".py") {
-		command = fmt.Sprintf("python %s", command)
+	// The name reaches a process argument, so it must be a plain file inside
+	// the script directory - never a path, and never shell metacharacters.
+	script, err := utils.SecureJoin(ScriptDirectory, req.Name)
+	if err != nil || !isScript(req.Name) {
+		rsp.ErrRsp(c, -1, "invalid arguments")
+		return
 	}
 
 	var output []byte
-	var err error
-	cmd := exec.Command("sh", "-c", command)
+	cmd := scriptCommand(req.Name, script)
 
 	if req.Type == "foreground" {
 		output, err = cmd.CombinedOutput()
@@ -133,7 +132,11 @@ func (s *Service) DeleteScript(c *gin.Context) {
 		return
 	}
 
-	file := fmt.Sprintf("%s/%s", ScriptDirectory, req.Name)
+	file, err := utils.SecureJoin(ScriptDirectory, req.Name)
+	if err != nil {
+		rsp.ErrRsp(c, -1, "invalid arguments")
+		return
+	}
 
 	if err := os.Remove(file); err != nil {
 		log.Errorf("delete script %s failed: %s", file, err)
@@ -143,6 +146,19 @@ func (s *Service) DeleteScript(c *gin.Context) {
 
 	rsp.OkRsp(c)
 	log.Debugf("delete script %s success", file)
+}
+
+// scriptCommand builds the command that runs a script. The interpreter takes
+// the path as an argument, so the name can no longer become shell text. A
+// shell script still goes through sh, because "sh -c <path>" used to fall back
+// to interpreting a file that has no shebang, and running the path directly
+// would break those scripts with ENOEXEC.
+func scriptCommand(name string, path string) *exec.Cmd {
+	if strings.HasSuffix(strings.ToLower(name), ".py") {
+		return exec.Command("python", path)
+	}
+
+	return exec.Command("sh", path)
 }
 
 func isScript(name string) bool {

--- a/server/service/vm/script_test.go
+++ b/server/service/vm/script_test.go
@@ -1,0 +1,41 @@
+package vm
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestScriptCommandRunsShellScriptsThroughSh(t *testing.T) {
+	// "sh -c <path>" used to interpret a shell script that has no shebang.
+	// Executing the path directly would fail those scripts with ENOEXEC, so
+	// the interpreter has to stay in the command.
+	cmd := scriptCommand("backup.sh", "/etc/kvm/scripts/backup.sh")
+
+	if len(cmd.Args) != 2 || cmd.Args[0] != "sh" || cmd.Args[1] != "/etc/kvm/scripts/backup.sh" {
+		t.Fatalf("args are %q, want [sh /etc/kvm/scripts/backup.sh]", cmd.Args)
+	}
+}
+
+func TestScriptCommandRunsPythonScriptsThroughPython(t *testing.T) {
+	cmd := scriptCommand("report.PY", "/etc/kvm/scripts/report.PY")
+
+	if len(cmd.Args) != 2 || cmd.Args[0] != "python" {
+		t.Fatalf("args are %q, want python first", cmd.Args)
+	}
+}
+
+func TestScriptCommandNeverPassesTheNameToAShell(t *testing.T) {
+	// SecureJoin rejects these names before they reach here. This asserts the
+	// second half of the fix: even a name that got through is an argument, so
+	// no part of it is parsed as shell text.
+	cmd := scriptCommand("a.sh; reboot", "/etc/kvm/scripts/a.sh; reboot")
+
+	for _, arg := range cmd.Args {
+		if strings.Contains(arg, "-c") {
+			t.Fatalf("args are %q, want no shell -c", cmd.Args)
+		}
+	}
+	if cmd.Args[len(cmd.Args)-1] != "/etc/kvm/scripts/a.sh; reboot" {
+		t.Fatalf("the path must stay one argument, got %q", cmd.Args)
+	}
+}

--- a/server/utils/path.go
+++ b/server/utils/path.go
@@ -1,0 +1,45 @@
+package utils
+
+import (
+	"errors"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// safeName matches names that are safe both as a path component and as an
+// argument to a command: letters, digits, space, dot, dash and underscore
+// only, and never starting with any of the last three. The character class
+// holds no path separator, so a name that matches is always its own base name.
+//
+// A space is allowed because the name reaches the interpreter as one argument
+// and never as shell text. Names such as "nightly backup.sh" are ordinary, and
+// refusing them would also leave an existing one impossible to delete.
+var safeName = regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9._ -]*$`)
+
+var errUnsafeName = errors.New("unsafe file name")
+
+// SecureJoin joins a caller-supplied file name onto a directory, rejecting
+// anything that is not a plain name inside that directory.
+func SecureJoin(dir string, name string) (string, error) {
+	if !safeName.MatchString(name) {
+		return "", errUnsafeName
+	}
+
+	return filepath.Join(dir, name), nil
+}
+
+// IsPathInside reports whether path is an absolute path to something strictly
+// below dir, after resolving any "." and ".." segments. A relative path is
+// refused outright, and a relative dir can never match one, so the answer is
+// false unless the caller passes two absolute paths.
+func IsPathInside(dir string, path string) bool {
+	if !filepath.IsAbs(path) {
+		return false
+	}
+
+	cleaned := filepath.Clean(path)
+	prefix := filepath.Clean(dir) + string(filepath.Separator)
+
+	return strings.HasPrefix(cleaned, prefix)
+}

--- a/server/utils/path_test.go
+++ b/server/utils/path_test.go
@@ -1,0 +1,109 @@
+package utils
+
+import "testing"
+
+func TestSecureJoinAcceptsPlainName(t *testing.T) {
+	path, err := SecureJoin("/etc/kvm/scripts", "backup.sh")
+	if err != nil {
+		t.Fatalf("plain name should be accepted: %s", err)
+	}
+	if path != "/etc/kvm/scripts/backup.sh" {
+		t.Fatalf("unexpected path %q", path)
+	}
+}
+
+func TestSecureJoinRejectsEmptyName(t *testing.T) {
+	if _, err := SecureJoin("/etc/kvm/scripts", ""); err == nil {
+		t.Fatal("empty name must be rejected")
+	}
+}
+
+func TestSecureJoinRejectsTraversal(t *testing.T) {
+	for _, name := range []string{"..", "../pwd", "../../etc/passwd", "sub/dir.sh"} {
+		if _, err := SecureJoin("/etc/kvm/scripts", name); err == nil {
+			t.Fatalf("name %q must be rejected", name)
+		}
+	}
+}
+
+func TestSecureJoinRejectsShellMetacharacters(t *testing.T) {
+	// These names are safe as file paths but become command injection once the
+	// result is handed to sh -c.
+	for _, name := range []string{"a.sh; reboot", "a.sh&&reboot", "a.sh`reboot`", "a.sh$(reboot)", "a|b.sh"} {
+		if _, err := SecureJoin("/etc/kvm/scripts", name); err == nil {
+			t.Fatalf("name %q must be rejected", name)
+		}
+	}
+}
+
+func TestSecureJoinAcceptsNameWithSpace(t *testing.T) {
+	// A space is safe: the name reaches the interpreter as one argument, never
+	// as shell text, and it is a common way to name an uploaded script.
+	path, err := SecureJoin("/etc/kvm/scripts", "nightly backup.sh")
+	if err != nil {
+		t.Fatalf("a name with a space should be accepted: %s", err)
+	}
+	if path != "/etc/kvm/scripts/nightly backup.sh" {
+		t.Fatalf("unexpected path %q", path)
+	}
+}
+
+func TestSecureJoinRejectsLeadingSpace(t *testing.T) {
+	if _, err := SecureJoin("/etc/kvm/scripts", " a.sh"); err == nil {
+		t.Fatal("a name starting with a space must be rejected")
+	}
+}
+
+func TestSecureJoinRejectsHiddenAndAbsoluteNames(t *testing.T) {
+	for _, name := range []string{"/etc/passwd", ".hidden"} {
+		if _, err := SecureJoin("/etc/kvm/scripts", name); err == nil {
+			t.Fatalf("name %q must be rejected", name)
+		}
+	}
+}
+
+func TestIsPathInsideAcceptsChild(t *testing.T) {
+	if !IsPathInside("/data", "/data/ubuntu.iso") {
+		t.Fatal("a file in the directory must be accepted")
+	}
+}
+
+func TestIsPathInsideAcceptsNestedChild(t *testing.T) {
+	if !IsPathInside("/data", "/data/isos/ubuntu.iso") {
+		t.Fatal("a file in a subdirectory must be accepted")
+	}
+}
+
+func TestIsPathInsideRejectsTraversal(t *testing.T) {
+	// The old DeleteImage check compared a lowercased copy with HasPrefix, so
+	// this escaped while still looking like it was under /data.
+	if IsPathInside("/data", "/data/../root/secret.iso") {
+		t.Fatal("traversal out of the directory must be rejected")
+	}
+}
+
+func TestIsPathInsideRejectsSiblingWithSharedPrefix(t *testing.T) {
+	if IsPathInside("/data", "/database/x.iso") {
+		t.Fatal("a sibling directory sharing a prefix must be rejected")
+	}
+}
+
+func TestIsPathInsideRejectsTheDirectoryItself(t *testing.T) {
+	if IsPathInside("/data", "/data") {
+		t.Fatal("the directory itself is not a file inside it")
+	}
+}
+
+func TestIsPathInsideRejectsRelativePath(t *testing.T) {
+	if IsPathInside("/data", "ubuntu.iso") {
+		t.Fatal("a relative path must be rejected")
+	}
+}
+
+func TestIsPathInsideRejectsRelativeDirectory(t *testing.T) {
+	// A caller that passes a relative directory has not established what the
+	// path is measured against, so the answer cannot be "contained".
+	if IsPathInside("data", "/data/ubuntu.iso") {
+		t.Fatal("a relative directory must be rejected")
+	}
+}

--- a/server/utils/untar.go
+++ b/server/utils/untar.go
@@ -3,13 +3,25 @@ package utils
 import (
 	"archive/tar"
 	"compress/gzip"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 )
 
+// ErrUnsafeArchiveEntry is returned when an archive entry would write outside
+// the destination directory, or is a link that could be used to do so later.
+var ErrUnsafeArchiveEntry = errors.New("unsafe archive entry")
+
 func UnTarGz(srcFile string, destDir string) (string, error) {
+	// The containment check below compares absolute paths, so resolve the
+	// destination once here rather than depending on the caller for it.
+	destDir, err := filepath.Abs(destDir)
+	if err != nil {
+		return "", err
+	}
+
 	if err := os.MkdirAll(destDir, 0755); err != nil {
 		return "", err
 	}
@@ -51,11 +63,22 @@ func UnTarGz(srcFile string, destDir string) (string, error) {
 			}
 		}
 
+		// An absolute name would silently lose its leading separator on join,
+		// so refuse it rather than relocating it.
+		if filepath.IsAbs(header.Name) || strings.HasPrefix(header.Name, "/") {
+			return "", ErrUnsafeArchiveEntry
+		}
+
 		filename := filepath.Join(destDir, header.Name)
+		if !IsPathInside(destDir, filename) {
+			return "", ErrUnsafeArchiveEntry
+		}
 
 		switch header.Typeflag {
 		case tar.TypeDir:
-			if err := os.MkdirAll(filename, os.FileMode(header.Mode)); err != nil {
+			// Keep the owner's write and search bits, otherwise an archive
+			// declaring a read-only directory blocks its own extraction.
+			if err := os.MkdirAll(filename, os.FileMode(header.Mode)|0o700); err != nil {
 				return "", err
 			}
 
@@ -71,10 +94,10 @@ func UnTarGz(srcFile string, destDir string) (string, error) {
 			}
 			_ = file.Close()
 
-		case tar.TypeSymlink:
-			if err := os.Symlink(header.Linkname, filename); err != nil {
-				return "", err
-			}
+		case tar.TypeSymlink, tar.TypeLink:
+			// A link entry can point anywhere, and later entries would then
+			// write through it as root. Update packages do not need links.
+			return "", ErrUnsafeArchiveEntry
 		}
 	}
 

--- a/server/utils/untar_test.go
+++ b/server/utils/untar_test.go
@@ -1,0 +1,142 @@
+package utils
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type tarEntry struct {
+	name     string
+	typeflag byte
+	linkname string
+	content  string
+}
+
+func writeTarGz(t *testing.T, entries []tarEntry) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "package.tar.gz")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("failed to create archive: %s", err)
+	}
+	defer f.Close()
+
+	gw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gw)
+
+	for _, entry := range entries {
+		header := &tar.Header{
+			Name:     entry.name,
+			Typeflag: entry.typeflag,
+			Linkname: entry.linkname,
+			Mode:     0o644,
+			Size:     int64(len(entry.content)),
+		}
+		if entry.typeflag != tar.TypeReg {
+			header.Size = 0
+		}
+		if err := tw.WriteHeader(header); err != nil {
+			t.Fatalf("failed to write header: %s", err)
+		}
+		if entry.typeflag == tar.TypeReg {
+			if _, err := tw.Write([]byte(entry.content)); err != nil {
+				t.Fatalf("failed to write body: %s", err)
+			}
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		t.Fatalf("failed to close tar: %s", err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatalf("failed to close gzip: %s", err)
+	}
+
+	return path
+}
+
+func TestUnTarGzExtractsNormalArchive(t *testing.T) {
+	archive := writeTarGz(t, []tarEntry{
+		{name: "app/", typeflag: tar.TypeDir},
+		{name: "app/version", typeflag: tar.TypeReg, content: "2.0.0"},
+	})
+	dest := t.TempDir()
+
+	dir, err := UnTarGz(archive, dest)
+	if err != nil {
+		t.Fatalf("a well-formed archive should extract: %s", err)
+	}
+	if dir != filepath.Join(dest, "app") {
+		t.Fatalf("unexpected target dir %q", dir)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dest, "app", "version"))
+	if err != nil || string(content) != "2.0.0" {
+		t.Fatalf("expected extracted file, got %q err %v", content, err)
+	}
+}
+
+func TestUnTarGzRejectsPathTraversal(t *testing.T) {
+	outside := filepath.Join(t.TempDir(), "outside")
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatalf("failed to create outside dir: %s", err)
+	}
+	dest := filepath.Join(outside, "dest")
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatalf("failed to create dest dir: %s", err)
+	}
+
+	archive := writeTarGz(t, []tarEntry{
+		{name: "../pwned", typeflag: tar.TypeReg, content: "owned"},
+	})
+
+	if _, err := UnTarGz(archive, dest); !errors.Is(err, ErrUnsafeArchiveEntry) {
+		t.Fatalf("an entry escaping the destination must be rejected, got %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(outside, "pwned")); err == nil {
+		t.Fatal("a file was written outside the destination directory")
+	}
+}
+
+func TestUnTarGzRejectsAbsolutePath(t *testing.T) {
+	archive := writeTarGz(t, []tarEntry{
+		{name: "/etc/kvm/pwned", typeflag: tar.TypeReg, content: "owned"},
+	})
+
+	if _, err := UnTarGz(archive, t.TempDir()); !errors.Is(err, ErrUnsafeArchiveEntry) {
+		t.Fatalf("an absolute entry name must be rejected, got %v", err)
+	}
+}
+
+func TestUnTarGzRejectsSymlink(t *testing.T) {
+	// A symlink entry lets a later entry write through it to any path on the
+	// device, so links are not extracted at all.
+	archive := writeTarGz(t, []tarEntry{
+		{name: "app/link", typeflag: tar.TypeSymlink, linkname: "/etc/kvm"},
+	})
+	dest := t.TempDir()
+
+	if _, err := UnTarGz(archive, dest); !errors.Is(err, ErrUnsafeArchiveEntry) {
+		t.Fatalf("a symlink entry must be rejected, got %v", err)
+	}
+
+	if _, err := os.Lstat(filepath.Join(dest, "app", "link")); err == nil {
+		t.Fatal("a symlink was created")
+	}
+}
+
+func TestUnTarGzRejectsHardLink(t *testing.T) {
+	archive := writeTarGz(t, []tarEntry{
+		{name: "app/link", typeflag: tar.TypeLink, linkname: "/etc/kvm/pwd"},
+	})
+
+	if _, err := UnTarGz(archive, t.TempDir()); !errors.Is(err, ErrUnsafeArchiveEntry) {
+		t.Fatalf("a hard link entry must be rejected, got %v", err)
+	}
+}


### PR DESCRIPTION
Three handlers take a path or a name from the request body and use it without checking where it points. Every handler on this device runs as root.

### 1. Command injection in `RunScript`

`service/vm/script.go` builds a command string and runs it through a shell:

```go
cmd := exec.Command("sh", "-c", command)
```

The script name comes from the request, so a name like `x.sh; reboot` runs as root. Script names now have to be plain files inside the script directory, and the script is executed directly rather than through a shell.

### 2. Path traversal and arbitrary symlinks in `UnTarGz`

`utils/untar.go` joins entry names onto the destination with no containment check, and creates symlinks with attacker-chosen targets:

```go
filename := filepath.Join(destDir, header.Name)
...
case tar.TypeSymlink:
        os.Symlink(header.Linkname, filename)
```

Reachable from the offline update upload, so an uploaded archive can write anywhere on the filesystem as root. Entries that escape the destination, name an absolute path, or are links are now rejected.

### 3. Unvalidated path in `MountImage`

Any path could be handed to the USB mass storage gadget, so `/dev/mmcblk0` or `/etc/shadow` could be exported to the attached machine. Separately, the delete check lowercased a copy of the path while removing the original, which let `/data/../root/x.iso` through.

### The shared helper

`utils.SecureJoin` and `utils.IsPathInside` hold the check in one place so the three call sites cannot drift apart. That is why these three are one PR rather than three — splitting them would mean three PRs that cannot merge independently.

### Tests

`utils/path_test.go`, `utils/untar_test.go` and `service/storage/image_test.go` cover traversal, absolute paths, symlink entries, and the case-folding hole.

Verified with `go build`, `go vet`, `go test`, and `GOOS=linux GOARCH=riscv64 go build`.

### Landing order

This branch and #851 both add `server/service/storage/image_test.go`, which upstream does not have yet, so whichever lands second gets an add/add conflict in that one file. `image.go` itself merges cleanly — the two changes sit in different parts of it.

#851 is the smaller change. Landing it first and rebasing this branch onto the result is the cheaper order. Every other open branch of mine merges with this one without conflict.
