### PR TITLE
Refuse a guessable JWT signing key, and test the algorithm pin

### DIFF
--- a/server/config/default.go
+++ b/server/config/default.go
@@ -1,5 +1,7 @@
 package config
 
+import "log"
+
 var defaultConfig = &Config{
 	Proto: "http",
 	Host:  "",
@@ -35,7 +37,14 @@ var defaultConfig = &Config{
 
 func checkDefaultValue() {
 	if instance.JWT.SecretKey == "" {
-		instance.JWT.SecretKey = generateRandomSecretKey()
+		key, err := generateSecretKey(secretKeyReader)
+		if err != nil {
+			// Every session on the device is signed with this. Running with a
+			// key we could not generate properly is not an option.
+			log.Fatalf("failed to generate a jwt secret key: %s", err)
+		}
+
+		instance.JWT.SecretKey = key
 		instance.JWT.RevokeTokensOnLogout = true
 	}
 

--- a/server/config/jwt.go
+++ b/server/config/jwt.go
@@ -4,18 +4,29 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
-	"time"
+	"io"
 )
 
-// Generate random string for secret key.
-func generateRandomSecretKey() string {
+// secretKeyReader is the entropy source. nil means crypto/rand; tests replace
+// it to exercise the failure path.
+var secretKeyReader io.Reader
+
+func generateSecretKey(reader io.Reader) (string, error) {
 	b := make([]byte, 64)
-	_, err := rand.Read(b)
-	if err != nil {
-		currentTime := time.Now().UnixNano()
-		timeString := fmt.Sprintf("%d", currentTime)
-		return fmt.Sprintf("%064s", timeString)
+
+	var err error
+	if reader == nil {
+		_, err = rand.Read(b)
+	} else {
+		_, err = io.ReadFull(reader, b)
 	}
 
-	return base64.URLEncoding.EncodeToString(b)
+	if err != nil {
+		// There is no safe fallback. Anything derived from the clock is a key
+		// an attacker can search, because they know roughly when the device
+		// booted, so this has to fail instead.
+		return "", fmt.Errorf("failed to read random bytes for the secret key: %w", err)
+	}
+
+	return base64.URLEncoding.EncodeToString(b), nil
 }

--- a/server/config/jwt_test.go
+++ b/server/config/jwt_test.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+type failingReader struct{}
+
+func (failingReader) Read([]byte) (int, error) {
+	return 0, errors.New("no entropy")
+}
+
+// Falling back to anything derived from the clock would hand an attacker a
+// signing key they can search: the device boots, and the key is the nanosecond
+// it happened to boot at.
+func TestGenerateSecretKeyFailsRatherThanReturningAPredictableValue(t *testing.T) {
+	key, err := generateSecretKey(failingReader{})
+
+	if err == nil {
+		t.Fatalf("expected an error, got key %q", key)
+	}
+	if key != "" {
+		t.Fatalf("expected no key on failure, got %q", key)
+	}
+}
+
+func TestGenerateSecretKeyReturnsADifferentKeyEachTime(t *testing.T) {
+	first, err := generateSecretKey(nil)
+	if err != nil {
+		t.Fatalf("failed to generate key: %s", err)
+	}
+
+	second, err := generateSecretKey(nil)
+	if err != nil {
+		t.Fatalf("failed to generate key: %s", err)
+	}
+
+	if first == second {
+		t.Fatal("two generated keys are identical")
+	}
+	if strings.TrimSpace(first) == "" {
+		t.Fatal("generated key is blank")
+	}
+}

--- a/server/config/picoclaw_internal.go
+++ b/server/config/picoclaw_internal.go
@@ -34,7 +34,11 @@ func GetPicoclawInternalToken() (string, error) {
 		return "", err
 	}
 
-	token := generateRandomSecretKey()
+	token, err := generateSecretKey(secretKeyReader)
+	if err != nil {
+		return "", err
+	}
+
 	if err := os.MkdirAll(filepath.Dir(picoclawInternalTokenFile), 0o755); err != nil {
 		return "", err
 	}

--- a/server/middleware/jwt_alg_test.go
+++ b/server/middleware/jwt_alg_test.go
@@ -1,0 +1,69 @@
+package middleware
+
+import (
+	"testing"
+	"time"
+
+	"NanoKVM-Server/config"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// signWith mints a token for the device's own secret using a chosen algorithm,
+// which is what an attacker holding a leaked or guessed secret would do.
+func signWith(t *testing.T, method jwt.SigningMethod) string {
+	t.Helper()
+
+	claims := Token{
+		Username:     "admin",
+		TokenVersion: 1,
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   "admin",
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+	}
+
+	signed, err := jwt.NewWithClaims(method, claims).
+		SignedString([]byte(config.GetInstance().JWT.SecretKey))
+	if err != nil {
+		t.Fatalf("failed to sign token: %s", err)
+	}
+
+	return signed
+}
+
+func TestParseJWTAcceptsHS256(t *testing.T) {
+	if _, err := ParseJWT(signWith(t, jwt.SigningMethodHS256)); err != nil {
+		t.Fatalf("HS256 token should be accepted: %s", err)
+	}
+}
+
+// The parser must accept only the algorithm the server issues. Taking whatever
+// the token's own header asks for is how algorithm-confusion attacks start.
+func TestParseJWTRejectsOtherHMACAlgorithms(t *testing.T) {
+	for _, method := range []jwt.SigningMethod{jwt.SigningMethodHS384, jwt.SigningMethodHS512} {
+		if _, err := ParseJWT(signWith(t, method)); err == nil {
+			t.Fatalf("%s token should be rejected", method.Alg())
+		}
+	}
+}
+
+// An unsigned token is the case the algorithm list exists for: a parser that
+// takes the header at its word accepts a token nobody signed.
+func TestParseJWTRejectsUnsignedToken(t *testing.T) {
+	unsigned, err := jwt.NewWithClaims(jwt.SigningMethodNone, Token{
+		Username:     "admin",
+		TokenVersion: 1,
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   "admin",
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+	}).SignedString(jwt.UnsafeAllowNoneSignatureType)
+	if err != nil {
+		t.Fatalf("failed to build unsigned token: %s", err)
+	}
+
+	if _, err := ParseJWT(unsigned); err == nil {
+		t.Fatal("a token with alg=none should be rejected")
+	}
+}


### PR DESCRIPTION
Two problems were in this branch. `#876` fixed one of them, so only the other is left, plus the test for the part that is now fixed.

**The signing key had a guessable fallback.** When the random source errors, `generateRandomSecretKey` returns a space-padded nanosecond timestamp. Every session on the device is signed with that key, and `config/picoclaw_internal.go` draws the internal token from the same function, so the fallback produces a secret an attacker can search: they know roughly when the device booted.

There is no safe fallback, so generation now reports the failure and each caller decides. Startup refuses to run without a key, which is the right answer for a device whose sessions all depend on it, and the internal token is not written at all.

**The algorithm pin is already in.** `ParseJWT` checks the method and passes an explicit list, both added by `#876`. Only the case that is still untested remains here: `alg=none`. A parser that takes the header at its word accepts a token nobody signed, and that is the case the list exists for. `middleware/jwt_alg_test.go` covers HS256, the other HMAC methods, and `alg=none` together.
