### PR TITLE
Keep the frame rate counter off the SD card

### DIFF
--- a/kvmapp/system/init.d/S95nanokvm
+++ b/kvmapp/system/init.d/S95nanokvm
@@ -44,7 +44,28 @@ stop_services() {
     rm -rf /tmp/kvm_system /tmp/server
 }
 
+# now_fps is rewritten whenever the measured frame rate changes, so a
+# streaming session rewrites it for as long as it runs. The value means
+# nothing across a reboot, and the card it lands on is the one the device
+# boots from, so point the path at tmpfs and leave a symlink behind. Both
+# readers keep the path they already use and neither needs rebuilding.
+#
+# kvm_system does not check the result of fopen before seeking on it, so a
+# missing file crashes it. The target is created here, before anything reads
+# it, and refreshed on restart in case tmpfs was cleared underneath us.
+prepare_runtime_state() {
+    mkdir -p /tmp/kvm
+    [ -e /tmp/kvm/now_fps ] || echo 0 > /tmp/kvm/now_fps
+
+    if [ ! -L /kvmapp/kvm/now_fps ]; then
+        rm -f /kvmapp/kvm/now_fps
+        ln -s /tmp/kvm/now_fps /kvmapp/kvm/now_fps
+    fi
+}
+
 start_services() {
+    prepare_runtime_state
+
     cp -r /kvmapp/kvm_system /tmp/
     if [ -f /kvmapp/kvm_new_app ]; then
         touch /tmp/.nanokvm_migrating


### PR DESCRIPTION
Fixes #701.

`now_fps` is rewritten every time the measured frame rate changes, so a streaming session keeps rewriting it for as long as it runs. The file lives on the card the device boots from. The reporter's point in #701 is the one that matters: a NanoKVM is deployed for remote access, so a worn card is a drive out to the site to replace it.

### Why not just change the path

That is what #708 and #751 do, and it cannot ship in this package alone.

The FPS shown on the OLED does not come from the Go server. `kvm_system` reads `/kvmapp/kvm/now_fps` itself, in `kvm_update_stream_fps`. Change only the server and the OLED reads a file nothing writes any more. So the path change has to land in the Go server *and* in the C++ firmware, and both have to be deployed together — which is why #751 also has to touch `kvm_system`, `kvm_vision` and the sophgo middleware, and why it is currently conflicting.

### What this does instead

`S95nanokvm` creates `/tmp/kvm/now_fps` and leaves a symlink at `/kvmapp/kvm/now_fps` pointing at it.

Both readers keep the path they already use. The server writes the same path, `kvm_system` reads the same path, and neither binary is rebuilt. The writes land on tmpfs.

This is the pattern the script already uses elsewhere — `kvm_system` and `server` are copied to `/tmp` before they start, for the same reason.

### One detail worth stating

`kvm_update_stream_fps` calls `fopen` and then seeks on the result without checking it:

```c
fp = fopen("/kvmapp/kvm/now_fps", "r");
fseek(fp, 0, SEEK_END);
```

A missing file is therefore a crash, not a zero reading. The target is created before anything starts, and again on `restart`, in case tmpfs was cleared underneath us. The symlink is only replaced when it is not already a symlink, so a restart does not churn the card either.

### Scope

Only `now_fps` moves. `state`, `wifi_state`, `width` and `height` are written when something actually changes — a cable is plugged, a resolution is negotiated — not on a timer, so they do not carry the same exposure. Moving them would mean the same cross-binary coupling described above for no comparable gain.

### Standalone

One file, 23 lines, applies directly to `main`. No dependency on my other open PRs and can be merged in any order.

### Verification

`busybox sh -n` on the modified script. Behaviour checked on a Cube: `/kvmapp/kvm/now_fps` resolves to `/tmp/kvm/now_fps`, the Web UI still reports the frame rate, and the OLED still shows it.
