### PR TITLE
feat(oled): add safer sleep and idle status carousel

### DIFF
--- a/kvmapp/system/init.d/S95nanokvm
+++ b/kvmapp/system/init.d/S95nanokvm
@@ -41,10 +41,13 @@ stop_services() {
     # The server owns VI/VPSS. Let it release MMF before stopping kvm_system.
     stop_process NanoKVM-Server
     stop_process kvm_system
+    # Runtime viewer state belongs to tmpfs and is safe to discard on restart.
+    rm -f /run/nanokvm/oled_viewers
     rm -rf /tmp/kvm_system /tmp/server
 }
 
 start_services() {
+    mkdir -p /run/nanokvm
     cp -r /kvmapp/kvm_system /tmp/
     if [ -f /kvmapp/kvm_new_app ]; then
         touch /tmp/.nanokvm_migrating

--- a/server/main.go
+++ b/server/main.go
@@ -45,6 +45,7 @@ func initialize() {
 		vm.EnableHdmiCapture()
 	}
 	vm.SetHdmiViewerCount(0)
+	vm.StartOLEDViewerPublisher()
 
 	// run mouse jiggler
 	jiggler.GetJiggler().Run()
@@ -123,5 +124,6 @@ func run() {
 }
 
 func dispose() {
+	vm.StopOLEDViewerPublisher()
 	common.GetKvmVision().Close()
 }

--- a/server/proto/vm.go
+++ b/server/proto/vm.go
@@ -89,7 +89,7 @@ type GetMemoryLimitRsp struct {
 }
 
 type SetOledReq struct {
-	Sleep int `validate:"omitempty"`
+	Sleep *int `json:"sleep"`
 }
 
 type GetOLEDRsp struct {

--- a/server/service/vm/hdmi.go
+++ b/server/service/vm/hdmi.go
@@ -133,6 +133,14 @@ func SetHdmiViewerCount(count int) {
 	SetHdmiViewerCountForSource("legacy", count)
 }
 
+// OLEDViewerCount returns only long-lived streaming viewers. It intentionally
+// excludes capture leases used by screenshots and other short-lived jobs.
+func OLEDViewerCount() int {
+	hdmiMutex.Lock()
+	defer hdmiMutex.Unlock()
+	return hdmiDemand.ViewerCount()
+}
+
 // SetHdmiViewerCountForSource is retained for callers that cannot provide a
 // source revision. Streamers should use UpdateHdmiViewerSnapshot instead.
 func SetHdmiViewerCountForSource(source string, count int) {

--- a/server/service/vm/oled.go
+++ b/server/service/vm/oled.go
@@ -2,8 +2,9 @@ package vm
 
 import (
 	"NanoKVM-Server/proto"
-	"fmt"
+	"errors"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -12,61 +13,82 @@ import (
 )
 
 const (
-	OLEDExistFile = "/etc/kvm/oled_exist"
-	OLEDSleepFile = "/etc/kvm/oled_sleep"
+	OLEDExistFile    = "/etc/kvm/oled_exist"
+	OLEDSleepFile    = "/etc/kvm/oled_sleep"
+	defaultOLEDSleep = 60
 )
+
+func validOLEDSleep(sleep int) bool {
+	return sleep == 0 || (sleep >= 10 && sleep <= 3600)
+}
+
+func readOLEDSleep() (int, error) {
+	data, err := os.ReadFile(OLEDSleepFile)
+	if errors.Is(err, os.ErrNotExist) {
+		return defaultOLEDSleep, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	sleep, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || !validOLEDSleep(sleep) {
+		return 0, errors.New("invalid OLED sleep setting")
+	}
+	return sleep, nil
+}
+
+func writeFileAtomic(path string, data []byte) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".oled-sleep-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err = tmp.Chmod(0o644); err == nil {
+		_, err = tmp.Write(data)
+	}
+	if err == nil {
+		err = tmp.Sync()
+	}
+	if closeErr := tmp.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
 
 func (s *Service) SetOLED(c *gin.Context) {
 	var req proto.SetOledReq
 	var rsp proto.Response
-
-	if err := proto.ParseFormRequest(c, &req); err != nil {
+	if err := proto.ParseFormRequest(c, &req); err != nil || req.Sleep == nil {
 		rsp.ErrRsp(c, -1, "invalid arguments")
 		return
 	}
-
-	data := []byte(fmt.Sprintf("%d", req.Sleep))
-	err := os.WriteFile(OLEDSleepFile, data, 0o644)
-	if err != nil {
-		rsp.ErrRsp(c, -2, "failed to write data")
+	if !validOLEDSleep(*req.Sleep) {
+		rsp.ErrRsp(c, -1, "sleep must be 0 or between 10 and 3600 seconds")
 		return
 	}
-
+	if err := writeFileAtomic(OLEDSleepFile, []byte(strconv.Itoa(*req.Sleep)+"\n")); err != nil {
+		rsp.ErrRsp(c, -2, "failed to write OLED sleep setting")
+		return
+	}
 	rsp.OkRsp(c)
-	log.Debugf("set OLED sleep: %d", req.Sleep)
+	log.Debugf("set OLED sleep: %d", *req.Sleep)
 }
 
 func (s *Service) GetOLED(c *gin.Context) {
 	var rsp proto.Response
-
 	if _, err := os.Stat(OLEDExistFile); err != nil {
-		rsp.OkRspWithData(c, &proto.GetOLEDRsp{
-			Exist: false,
-			Sleep: 0,
-		})
+		rsp.OkRspWithData(c, &proto.GetOLEDRsp{Exist: false})
 		return
 	}
-
-	data, err := os.ReadFile(OLEDSleepFile)
+	sleep, err := readOLEDSleep()
 	if err != nil {
-		rsp.OkRspWithData(c, &proto.GetOLEDRsp{
-			Exist: true,
-			Sleep: 0,
-		})
+		log.Errorf("failed to parse OLED sleep setting: %s", err)
+		rsp.ErrRsp(c, -1, "failed to parse OLED sleep setting")
 		return
 	}
-
-	content := strings.TrimSpace(string(data))
-	sleep, err := strconv.Atoi(content)
-	if err != nil {
-		log.Errorf("failed to parse OLED: %s", err)
-		rsp.ErrRsp(c, -1, "failed to parse OLED config")
-		return
-	}
-
-	rsp.OkRspWithData(c, &proto.GetOLEDRsp{
-		Exist: true,
-		Sleep: sleep,
-	})
-	log.Debugf("get OLED config successful, sleep %d", sleep)
+	rsp.OkRspWithData(c, &proto.GetOLEDRsp{Exist: true, Sleep: sleep})
 }

--- a/server/service/vm/oled_viewers.go
+++ b/server/service/vm/oled_viewers.go
@@ -1,0 +1,98 @@
+package vm
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const oledViewersFile = "/run/nanokvm/oled_viewers"
+
+var (
+	oledPublisherMu     sync.Mutex
+	oledPublisherCancel context.CancelFunc
+	oledPublisherDone   chan struct{}
+)
+
+func publishOLEDViewerCount(count int) error {
+	if count < 0 {
+		count = 0
+	}
+	if err := os.MkdirAll(filepath.Dir(oledViewersFile), 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(oledViewersFile), ".oled_viewers-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err = tmp.Chmod(0o644); err == nil {
+		_, err = fmt.Fprintf(tmp, "%d\n", count)
+	}
+	if err == nil {
+		err = tmp.Sync()
+	}
+	if closeErr := tmp.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, oledViewersFile)
+}
+
+// StartOLEDViewerPublisher periodically publishes a heartbeat on tmpfs. The
+// OLED process treats an absent or stale file as zero so either process can be
+// upgraded or restarted independently.
+func StartOLEDViewerPublisher() {
+	oledPublisherMu.Lock()
+	defer oledPublisherMu.Unlock()
+	if oledPublisherCancel != nil {
+		return
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	oledPublisherCancel = cancel
+	done := make(chan struct{})
+	oledPublisherDone = done
+	if err := publishOLEDViewerCount(OLEDViewerCount()); err != nil {
+		log.Warnf("failed to publish OLED viewers: %s", err)
+	}
+	go func(done chan struct{}) {
+		defer close(done)
+		ticker := time.NewTicker(2 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if err := publishOLEDViewerCount(OLEDViewerCount()); err != nil {
+					log.Warnf("failed to publish OLED viewers: %s", err)
+				}
+			}
+		}
+	}(done)
+}
+
+func StopOLEDViewerPublisher() {
+	oledPublisherMu.Lock()
+	done := oledPublisherDone
+	if oledPublisherCancel != nil {
+		oledPublisherCancel()
+		oledPublisherCancel = nil
+		oledPublisherDone = nil
+	}
+	oledPublisherMu.Unlock()
+	if done != nil {
+		<-done
+	}
+	if err := os.Remove(oledViewersFile); err != nil && !os.IsNotExist(err) {
+		log.Warnf("failed to remove OLED viewer state: %s", err)
+	}
+}

--- a/support/sg2002/kvm_system/main/include/config.h
+++ b/support/sg2002/kvm_system/main/include/config.h
@@ -35,7 +35,15 @@
 #define KEY_LONGLONG_PRESS 			9000
 #define WIFI_CONNECTION_DELAY 		5000
 #define OLED_SLEEP_DELAY_MIN 		10
-#define OLED_SLEEP_DELAY_DEFAULT 	30
+#define OLED_SLEEP_DELAY_DEFAULT 	60
+#define OLED_WIFI_SLEEP_DELAY      300
+#define OLED_EVENT_WAKE_DELAY      15
+#define OLED_EVENT_WAKE_MAX        60
+#define OLED_CAROUSEL_DELAY        6
+#define OLED_CAROUSEL_START_DELAY  900
+#define OLED_PIXEL_SHIFT_DELAY     60
+#define OLED_PIXEL_SHIFT_X         3
+#define OLED_PIXEL_SHIFT_Y         3
 #define KVM_WD_COUNT_MAX			10
 #define RM_Watchdog_times			60
 
@@ -68,6 +76,11 @@ typedef struct {
 	int8_t wifi_config_process = -1;	// 1:QR;2:Test;3:IP;
 	char wifi_ap_pass[9] = {0};
     uint8_t oled_sleep_state = 0;	// 0:wakeup; 1:sleep;
+	// Key/system threads only publish these intents. OLED I2C remains owned by
+	// the OLED thread.
+	volatile uint8_t oled_manual_off = 0;
+	volatile uint64_t oled_local_activity_ms = 0;
+	volatile uint64_t oled_wifi_activity_ms = 0;
 	int8_t reconvery_update = 0;	// 0:Undetected; 1:Needs Update; 2:Update finish; -1:not need to update
 	uint8_t ping_allow = 1;
 } kvm_sys_state_t;
@@ -95,9 +108,26 @@ typedef struct {
 	int8_t type = -1;				// cat /kvmapp/kvm/type
 	int8_t now_fps = -1;			// cat /kvmapp/kvm/now_fps
 	int16_t qlty = -1;				// cat /kvmapp/kvm/qlty
-    uint16_t oled_sleep_param = 0;
+    uint16_t oled_sleep_param = OLED_SLEEP_DELAY_DEFAULT;
     uint8_t oled_sleep_state = 0;	// 0:wakeup; 1:sleep;
 	uint64_t oled_sleep_start = 0;
+	uint64_t event_wake_deadline_ms = 0;
+	uint64_t event_wake_started_ms = 0;
+	uint64_t event_wake_last_ms = 0;
+	uint64_t next_page_switch_ms = 0;
+	uint64_t next_pixel_shift_ms = 0;
+	uint64_t wifi_context_started_ms = 0;
+	uint64_t viewer_file_seen_ms = 0;
+	uint8_t main_page = 0;
+	uint8_t pixel_shift_x = 0;
+	uint8_t pixel_shift_y = 0;
+	int8_t pixel_shift_dx = 1;
+	int8_t pixel_shift_dy = 1;
+	uint8_t power_state = 0; // 0: off, 1: on
+	uint8_t wake_pending = 0;
+	uint8_t force_full_redraw = 1;
+	uint8_t viewers = 0;
+	uint64_t render_signature = 0;
 	uint64_t ue_patch_state = 0;
 } kvm_oled_state_t;
 

--- a/support/sg2002/kvm_system/main/lib/oled_ctrl/oled_ctrl.cpp
+++ b/support/sg2002/kvm_system/main/lib/oled_ctrl/oled_ctrl.cpp
@@ -8,6 +8,7 @@ i2c::I2C oled_beta(5, i2c::Mode::MASTER);
 
 uint8_t OLED_state = 0;
 uint8_t kvm_hw_ver = 0;
+static int8_t oled_layout_offset = 0;
 
 /* mode = OLED_CMD
  * 		= OLED_DATA         */
@@ -81,13 +82,32 @@ void OLED_Set_Pos(uint8_t x, uint8_t y)
 	// oled_write_register(OLED_CMD, 0xb0+y);
 	// oled_write_register(OLED_CMD, ((x&0xf0)>>4)|0x10);
 	// oled_write_register(OLED_CMD, (x&0x0f));
+	uint16_t adjusted_x = x;
+	if(kvm_hw_ver != 2 && oled_layout_offset > 0){
+		adjusted_x += oled_layout_offset;
+		if(adjusted_x > 127) adjusted_x = 127;
+	}
 	if(kvm_hw_ver == 2){
-		x += 32;
+		adjusted_x += 32;
 		y += 8;
 	}
 	oled_write_register(OLED_CMD, 0xb0+y);
-	oled_write_register(OLED_CMD, ((x&0xf0)>>4)|0x10);
-	oled_write_register(OLED_CMD, (x&0x0f));
+	oled_write_register(OLED_CMD, ((adjusted_x&0xf0)>>4)|0x10);
+	oled_write_register(OLED_CMD, (adjusted_x&0x0f));
+}
+
+void OLED_SetLayoutOffset(int8_t offset)
+{
+	oled_layout_offset = (kvm_hw_ver == 2 || offset < 0) ? 0 : offset;
+}
+
+void OLED_SetVerticalOffset(uint8_t offset)
+{
+	// SSD1306 display offset is expressed in physical pixels, allowing a
+	// vertical swim without rewriting the page-oriented text renderer.
+	if(kvm_hw_ver == 2) return;
+	oled_write_register(OLED_CMD, 0xD3);
+	oled_write_register(OLED_CMD, offset & 0x3F);
 }
 
 //开启OLED显示    
@@ -101,9 +121,35 @@ void OLED_Display_On()
 //关闭OLED显示     
 void OLED_Display_Off()
 {
+	oled_write_register(OLED_CMD, 0XAE);
 	oled_write_register(OLED_CMD, 0X8D);
 	oled_write_register(OLED_CMD, 0X10);
-	oled_write_register(OLED_CMD, 0XAE);
+}
+
+bool OLED_PrepareFrame()
+{
+	if(!OLED_state) return false;
+	oled_write_register(OLED_CMD, 0xAE);
+	return true;
+}
+
+bool OLED_EnterSleep()
+{
+	if(!OLED_state) return false;
+	OLED_PrepareFrame();
+	OLED_Clear();
+	oled_write_register(OLED_CMD, 0x8D);
+	oled_write_register(OLED_CMD, 0x10);
+	return true;
+}
+
+bool OLED_CommitAndWake()
+{
+	if(!OLED_state) return false;
+	oled_write_register(OLED_CMD, 0x8D);
+	oled_write_register(OLED_CMD, 0x14);
+	oled_write_register(OLED_CMD, 0xAF);
+	return true;
 }
 
 //清屏函数,清完屏,整个屏幕是黑色的!和没点亮一样!!!	  
@@ -217,7 +263,7 @@ void OLED_ShowNum(uint8_t x, uint8_t y, uint8_t num, uint8_t len, uint8_t sizey)
 }
 
 //显示一个字符号串
-void OLED_ShowString(uint8_t x, uint8_t y, char *chr, uint8_t sizey)
+void OLED_ShowString(uint8_t x, uint8_t y, const char *chr, uint8_t sizey)
 {
 	uint8_t j=0;
 	while (chr[j]!='\0')
@@ -229,7 +275,7 @@ void OLED_ShowString(uint8_t x, uint8_t y, char *chr, uint8_t sizey)
 	}
 }
 //反显一个字符号串
-void OLED_ShowStringTurn(uint8_t x, uint8_t y, char *chr, uint8_t sizey)
+void OLED_ShowStringTurn(uint8_t x, uint8_t y, const char *chr, uint8_t sizey)
 {
 	uint8_t j=0;
 	while (chr[j]!='\0')
@@ -282,7 +328,9 @@ void OLED_Init(void)
 	oled_write_register(OLED_CMD, 0x10);//---set high column address
 	oled_write_register(OLED_CMD, 0x40);//--set start line address  Set Mapping RAM Display Start Line (0x00~0x3F)
 	oled_write_register(OLED_CMD, 0x81);//--set contrast control register
-	oled_write_register(OLED_CMD, 0xCF);// Set SEG Output Current Brightness
+	// Keep the hardware's established controller contrast. Cube panels do not
+	// reliably expose a usable brightness range through this register.
+	oled_write_register(OLED_CMD, 0xCF);
 	oled_write_register(OLED_CMD, 0xA1);//--Set SEG/Column Mapping     0xa0左右反置 0xa1正常
 	oled_write_register(OLED_CMD, 0xC8);//Set COM/Row Scan Direction   0xc0上下反置 0xc8正常
 	oled_write_register(OLED_CMD, 0xA6);//--set normal display
@@ -304,11 +352,12 @@ void OLED_Init(void)
 	oled_write_register(OLED_CMD, 0x14);//--set(0x10) disable
 	oled_write_register(OLED_CMD, 0xA4);// Disable Entire Display On (0xa4/0xa5)
 	oled_write_register(OLED_CMD, 0xA6);// Disable Inverse Display On (0xa6/a7) 
+	// Do not expose an old frame during boot. The OLED thread draws a complete
+	// frame first and then calls OLED_CommitAndWake().
 	OLED_Clear();
-	oled_write_register(OLED_CMD, 0xAF); /*display ON*/ 
 }
 
-void OLED_ShowStringtoend(uint8_t x, uint8_t y, char *chr, uint8_t sizey, uint8_t end)
+void OLED_ShowStringtoend(uint8_t x, uint8_t y, const char *chr, uint8_t sizey, uint8_t end)
 {
 	uint8_t j=0;
 	while (chr[j] != end)
@@ -442,7 +491,7 @@ void OLED_Showline()
     }
 }
 
-void OLED_ShowString_AlignRight(uint8_t x_end, uint8_t y, char *chr, uint8_t size)
+void OLED_ShowString_AlignRight(uint8_t x_end, uint8_t y, const char *chr, uint8_t size)
 {
 	uint8_t j = 0;
 	uint8_t x = x_end;

--- a/support/sg2002/kvm_system/main/lib/oled_ctrl/oled_ctrl.h
+++ b/support/sg2002/kvm_system/main/lib/oled_ctrl/oled_ctrl.h
@@ -341,6 +341,13 @@ const uint8_t oled_sipeed_logo[32] = {
 0x66,0x66,0x66,0x66,0x66,0x70,0xfe,0x78,0xfe,0x7d,0xfc,0x3f,0xf8,0x1f,0x00,0x00
 };
 int oled_exist(void);
+void OLED_Display_On();
+void OLED_Display_Off();
+bool OLED_PrepareFrame();
+bool OLED_EnterSleep();
+bool OLED_CommitAndWake();
+void OLED_SetLayoutOffset(int8_t offset);
+void OLED_SetVerticalOffset(uint8_t offset);
 void OLED_Clear(void);
 void OLED_Fill(void);
 void OLED_Init(void);
@@ -351,10 +358,10 @@ void OLED_ColorTurn(uint8_t i);
 void OLED_ShowError(uint8_t x,uint8_t y,uint8_t _state);
 void OLED_ShowCharTurn(uint8_t x,uint8_t y,char chr,uint8_t sizey);
 void OLED_ShowNum(uint8_t x, uint8_t y, uint8_t num, uint8_t len, uint8_t sizey);
-void OLED_ShowString(uint8_t x, uint8_t y, char *chr, uint8_t sizey);
-void OLED_ShowStringTurn(uint8_t x, uint8_t y, char *chr, uint8_t sizey);
-void OLED_ShowStringtoend(uint8_t x, uint8_t y, char *chr, uint8_t sizey, uint8_t end);
-void OLED_ShowString_AlignRight(uint8_t x_end, uint8_t y, char *chr, uint8_t size);
+void OLED_ShowString(uint8_t x, uint8_t y, const char *chr, uint8_t sizey);
+void OLED_ShowStringTurn(uint8_t x, uint8_t y, const char *chr, uint8_t sizey);
+void OLED_ShowStringtoend(uint8_t x, uint8_t y, const char *chr, uint8_t sizey, uint8_t end);
+void OLED_ShowString_AlignRight(uint8_t x_end, uint8_t y, const char *chr, uint8_t size);
 void OLED_ROW(uint8_t _EN);
 void OLED_ShowKVMLogo();
 void OLED_ShowLogo();

--- a/support/sg2002/kvm_system/main/lib/oled_ui/oled_ui.cpp
+++ b/support/sg2002/kvm_system/main/lib/oled_ui/oled_ui.cpp
@@ -1,559 +1,493 @@
 #include "oled_ui.h"
 
+#include <ctype.h>
+#include <errno.h>
+#include <sys/stat.h>
+
 using namespace maix;
 using namespace maix::sys;
 
 extern kvm_sys_state_t kvm_sys_state;
 extern kvm_oled_state_t kvm_oled_state;
 
-void kvm_init_cube_ui(void)
-{
-	uint8_t temp;
-	char* str_temp = "192.168.1.243";
+namespace {
+const char *const OLED_SLEEP_FILE = "/etc/kvm/oled_sleep";
+const char *const OLED_VIEWERS_FILE = "/run/nanokvm/oled_viewers";
 
-	OLED_Clear();
-	// OLED_Revolve();
-	OLED_ShowKVMLogo();
-	OLED_ShowLogo();
-	OLED_ShowKVMState(HDMI_STATE, 	0);
-	OLED_ShowKVMState(HID_STATE, 	0);
-	OLED_ShowKVMState(ETH_STATE, 	0);
-	OLED_ShowKVMState(WIFI_STATE, 	0);
-	OLED_Showline();
-	OLED_ShowKVMStreamState(KVM_INIT, &temp);
-	temp = 0;
-	OLED_ShowKVMStreamState(KVM_ETH_IP, &temp);
-	temp = KVM_RES_none;
-	OLED_ShowKVMStreamState(KVM_HDMI_RES, &temp);
-	temp = KVM_TYPE_none;
-	OLED_ShowKVMStreamState(KVM_STEAM_TYPE, &temp);
-	temp = 0;
-	OLED_ShowKVMStreamState(KVM_STEAM_FPS, &temp);
-	temp = 80;
-	OLED_ShowKVMStreamState(KVM_JPG_QLTY, &temp);
+uint64_t hash_bytes(uint64_t value, const void *data, size_t size)
+{
+	const uint8_t *bytes = static_cast<const uint8_t *>(data);
+	for(size_t i = 0; i < size; ++i) value = (value ^ bytes[i]) * 1099511628211ULL;
+	return value;
 }
 
-void kvm_init_pcie_ui(void)
+uint64_t render_signature()
 {
+	uint64_t value = 1469598103934665603ULL;
+	value = hash_bytes(value, &kvm_sys_state.eth_state, sizeof(kvm_sys_state.eth_state));
+	value = hash_bytes(value, &kvm_sys_state.wifi_state, sizeof(kvm_sys_state.wifi_state));
+	value = hash_bytes(value, &kvm_sys_state.usb_state, sizeof(kvm_sys_state.usb_state));
+	value = hash_bytes(value, &kvm_sys_state.hdmi_state, sizeof(kvm_sys_state.hdmi_state));
+	value = hash_bytes(value, &kvm_sys_state.hdmi_width, sizeof(kvm_sys_state.hdmi_width));
+	value = hash_bytes(value, &kvm_sys_state.hdmi_height, sizeof(kvm_sys_state.hdmi_height));
+	value = hash_bytes(value, &kvm_sys_state.type, sizeof(kvm_sys_state.type));
+	value = hash_bytes(value, &kvm_sys_state.now_fps, sizeof(kvm_sys_state.now_fps));
+	value = hash_bytes(value, &kvm_sys_state.qlty, sizeof(kvm_sys_state.qlty));
+	value = hash_bytes(value, kvm_sys_state.eth_addr, sizeof(kvm_sys_state.eth_addr));
+	value = hash_bytes(value, kvm_sys_state.wifi_addr, sizeof(kvm_sys_state.wifi_addr));
+	value = hash_bytes(value, &kvm_oled_state.main_page, sizeof(kvm_oled_state.main_page));
+	value = hash_bytes(value, &kvm_oled_state.pixel_shift_x, sizeof(kvm_oled_state.pixel_shift_x));
+	value = hash_bytes(value, &kvm_oled_state.pixel_shift_y, sizeof(kvm_oled_state.pixel_shift_y));
+	value = hash_bytes(value, &kvm_oled_state.viewers, sizeof(kvm_oled_state.viewers));
+	return value;
+}
+
+bool parse_number(const char *text, long *value)
+{
+	if(text == NULL || *text == '\0') return false;
+	char *end = NULL;
+	errno = 0;
+	long parsed = strtol(text, &end, 10);
+	while(end != NULL && isspace(static_cast<unsigned char>(*end))) ++end;
+	if(errno != 0 || end == text || (end != NULL && *end != '\0')) return false;
+	*value = parsed;
+	return true;
+}
+
+bool read_text_file(const char *path, char *buffer, size_t size)
+{
+	if(size == 0) return false;
+	FILE *file = fopen(path, "r");
+	if(file == NULL) return false;
+	size_t count = fread(buffer, 1, size - 1, file);
+	bool complete = !ferror(file);
+	fclose(file);
+	buffer[count] = '\0';
+	return complete;
+}
+
+void note_local_activity(uint64_t now)
+{
+	kvm_sys_state.oled_local_activity_ms = now;
+	kvm_oled_state.oled_sleep_start = now;
+}
+
+void reset_idle_policy(uint64_t now)
+{
+	note_local_activity(now);
+	kvm_oled_state.main_page = 0;
+	kvm_oled_state.pixel_shift_x = 0;
+	kvm_oled_state.pixel_shift_y = 0;
+	kvm_oled_state.pixel_shift_dx = 1;
+	kvm_oled_state.pixel_shift_dy = 1;
+	kvm_oled_state.next_page_switch_ms = 0;
+	kvm_oled_state.next_pixel_shift_ms = 0;
+	kvm_oled_state.force_full_redraw = 1;
+}
+
+void reload_oled_config(uint64_t now)
+{
+	struct stat info;
+	static time_t sleep_mtime = -1;
+	static ino_t sleep_ino = 0;
+	if(stat(OLED_SLEEP_FILE, &info) == 0){
+		if(info.st_mtime != sleep_mtime || info.st_ino != sleep_ino){
+			sleep_mtime = info.st_mtime;
+			sleep_ino = info.st_ino;
+			char sleep_buffer[32] = {0};
+			long sleep = OLED_SLEEP_DELAY_DEFAULT;
+			if(read_text_file(OLED_SLEEP_FILE, sleep_buffer, sizeof(sleep_buffer))){
+				long parsed = 0;
+				if(parse_number(sleep_buffer, &parsed) && (parsed == 0 || (parsed >= OLED_SLEEP_DELAY_MIN && parsed <= 3600))) sleep = parsed;
+				else {
+					printf("[kvms] invalid OLED sleep setting; keeping last valid setting\n");
+					sleep = kvm_oled_state.oled_sleep_param;
+				}
+			} else sleep = kvm_oled_state.oled_sleep_param;
+			if(kvm_oled_state.oled_sleep_param != sleep){
+				kvm_oled_state.oled_sleep_param = static_cast<uint16_t>(sleep);
+				reset_idle_policy(now);
+			}
+		}
+	} else if(sleep_mtime != 0) {
+		sleep_mtime = 0;
+		sleep_ino = 0;
+		if(kvm_oled_state.oled_sleep_param != OLED_SLEEP_DELAY_DEFAULT){
+			kvm_oled_state.oled_sleep_param = OLED_SLEEP_DELAY_DEFAULT;
+			reset_idle_policy(now);
+		}
+	}
+}
+
+void refresh_viewers(uint64_t now)
+{
+	static time_t mtime = -1;
+	static ino_t inode = 0;
+	struct stat info;
+	if(stat(OLED_VIEWERS_FILE, &info) == 0){
+		if(info.st_mtime != mtime || info.st_ino != inode){
+			mtime = info.st_mtime;
+			inode = info.st_ino;
+			char buffer[32] = {0};
+			long viewers = 0;
+			if(read_text_file(OLED_VIEWERS_FILE, buffer, sizeof(buffer)) && parse_number(buffer, &viewers) && viewers >= 0){
+				if(viewers > 99) viewers = 99;
+				kvm_oled_state.viewers = static_cast<uint8_t>(viewers);
+				kvm_oled_state.viewer_file_seen_ms = now;
+			}
+		}
+	}
+	if(kvm_oled_state.viewer_file_seen_ms == 0 || now - kvm_oled_state.viewer_file_seen_ms > 5000) kvm_oled_state.viewers = 0;
+}
+
+bool passive_state_changed()
+{
+	static uint64_t previous = 0;
+	uint64_t value = 1469598103934665603ULL;
+	value = hash_bytes(value, &kvm_sys_state.eth_state, sizeof(kvm_sys_state.eth_state));
+	value = hash_bytes(value, &kvm_sys_state.wifi_state, sizeof(kvm_sys_state.wifi_state));
+	value = hash_bytes(value, &kvm_sys_state.usb_state, sizeof(kvm_sys_state.usb_state));
+	value = hash_bytes(value, &kvm_sys_state.hdmi_state, sizeof(kvm_sys_state.hdmi_state));
+	value = hash_bytes(value, &kvm_sys_state.hdmi_width, sizeof(kvm_sys_state.hdmi_width));
+	value = hash_bytes(value, &kvm_sys_state.hdmi_height, sizeof(kvm_sys_state.hdmi_height));
+	value = hash_bytes(value, kvm_sys_state.eth_addr, sizeof(kvm_sys_state.eth_addr));
+	value = hash_bytes(value, kvm_sys_state.wifi_addr, sizeof(kvm_sys_state.wifi_addr));
+	bool changed = previous != 0 && previous != value;
+	previous = value;
+	return changed;
+}
+
+void address_or_off(char *output, size_t size, const char *label, int8_t state, const uint8_t *address)
+{
+	if(state > 0 && address[0] != 0) snprintf(output, size, "%s %s", label, reinterpret_cast<const char *>(address));
+	else snprintf(output, size, "%s OFF", label);
+}
+
+void draw_cube_network()
+{
+	char line[22] = {0};
+	address_or_off(line, sizeof(line), "ETH", kvm_sys_state.eth_state, kvm_sys_state.eth_addr);
+	OLED_ShowString(0, 1, line, 8);
+	address_or_off(line, sizeof(line), "WIFI", kvm_sys_state.wifi_state, kvm_sys_state.wifi_addr);
+	OLED_ShowString(0, 2, line, 8);
+	snprintf(line, sizeof(line), "USB %s HDMI %s", kvm_sys_state.usb_state > 0 ? "ON" : "OFF", kvm_sys_state.hdmi_state > 0 ? "ON" : "OFF");
+	OLED_ShowString(0, 3, line, 8);
+	OLED_ShowString(0, 4, "NETWORK", 8);
+}
+
+void draw_cube_video()
+{
+	char line[22] = {0};
+	OLED_ShowString(0, 1, kvm_sys_state.hdmi_state > 0 ? "HDMI ON" : "NO SIGNAL", 8);
+	if(kvm_sys_state.hdmi_state > 0) snprintf(line, sizeof(line), "RES %dx%d", kvm_sys_state.hdmi_width, kvm_sys_state.hdmi_height);
+	else snprintf(line, sizeof(line), "RES --");
+	OLED_ShowString(0, 2, line, 8);
+	snprintf(line, sizeof(line), "%s %d FPS", kvm_sys_state.type == KVM_TYPE_H264 ? "H264" : "MJPG", kvm_sys_state.now_fps);
+	OLED_ShowString(0, 3, line, 8);
+	snprintf(line, sizeof(line), "QUALITY %d", kvm_sys_state.qlty);
+	OLED_ShowString(0, 4, line, 8);
+}
+
+void draw_cube_session()
+{
+	char line[22] = {0};
+	snprintf(line, sizeof(line), "VIEWERS %u", kvm_oled_state.viewers);
+	OLED_ShowString(0, 1, line, 8);
+	snprintf(line, sizeof(line), "USB %s HID %s", kvm_sys_state.usb_state > 0 ? "ON" : "OFF", kvm_sys_state.hid_state > 0 ? "ON" : "OFF");
+	OLED_ShowString(0, 2, line, 8);
+	snprintf(line, sizeof(line), "QUALITY %d", kvm_sys_state.qlty);
+	OLED_ShowString(0, 3, line, 8);
+	address_or_off(line, sizeof(line), "ETH", kvm_sys_state.eth_state, kvm_sys_state.eth_addr);
+	OLED_ShowString(0, 4, line, 8);
+}
+
+void draw_cube_main()
+{
+	OLED_SetLayoutOffset(kvm_oled_state.pixel_shift_x);
+	OLED_SetVerticalOffset(kvm_oled_state.pixel_shift_y);
+	OLED_Clear();
+	switch(kvm_oled_state.main_page){
+		case 0: draw_cube_network(); break;
+		case 1: draw_cube_video(); break;
+		default: draw_cube_session(); break;
+	}
+	OLED_SetLayoutOffset(0);
+}
+
+bool carousel_enabled()
+{
+	// Preserve the original Cube dashboard through the 10-minute option.
+	// Never-off, 30-minute, and one-hour modes opt into anti-burn carousel.
+	return kvm_oled_state.oled_sleep_param == 0 || kvm_oled_state.oled_sleep_param > 600;
+}
+
+bool carousel_active(uint64_t local_idle)
+{
+	return carousel_enabled() && local_idle >= OLED_CAROUSEL_START_DELAY * 1000ULL;
+}
+
+void draw_cube_legacy()
+{
+	OLED_SetLayoutOffset(0);
+	OLED_SetVerticalOffset(0);
+	OLED_Clear();
+	OLED_ShowKVMLogo();
+	OLED_ShowLogo();
+	OLED_ShowKVMState(HDMI_STATE, kvm_sys_state.hdmi_state > 0 ? 1 : 0);
+	OLED_ShowKVMState(HID_STATE, kvm_sys_state.usb_state > 0 ? 1 : 0);
+	OLED_ShowKVMState(ETH_STATE, kvm_sys_state.eth_state > 0 ? 1 : 0);
+	OLED_ShowKVMState(WIFI_STATE, kvm_sys_state.wifi_state > 0 ? 1 : 0);
+	OLED_Showline();
+	uint8_t empty = 0;
+	OLED_ShowKVMStreamState(KVM_INIT, &empty);
+	if(kvm_sys_state.eth_state > 0 && kvm_sys_state.eth_addr[0] != 0)
+		OLED_ShowKVMStreamState(KVM_ETH_IP, kvm_sys_state.eth_addr);
+	else if(kvm_sys_state.wifi_state > 0 && kvm_sys_state.wifi_addr[0] != 0)
+		OLED_ShowKVMStreamState(KVM_WIFI_IP, kvm_sys_state.wifi_addr);
+	else
+		OLED_ShowKVMStreamState(KVM_ETH_IP, &empty);
+	OLED_Show_Res(kvm_sys_state.hdmi_width, kvm_sys_state.hdmi_height);
+	OLED_ShowKVMStreamState(KVM_STEAM_TYPE, &kvm_sys_state.type);
+	OLED_ShowKVMStreamState(KVM_STEAM_FPS, &kvm_sys_state.now_fps);
+	OLED_ShowKVMStreamState(KVM_JPG_QLTY, &kvm_sys_state.qlty);
+}
+
+void draw_pcie_legacy()
+{
+	OLED_SetLayoutOffset(0);
+	OLED_SetVerticalOffset(0);
+	OLED_Clear();
 	OLED_Revolve();
 	OLED_Showline_1();
 	OLED_ShowLogo();
-	OLED_ShowKVMState(HDMI_STATE, 	0);
-	OLED_ShowKVMState(HID_STATE, 	0);
-	OLED_ShowKVMState(ETH_STATE, 	0);
-	OLED_ShowKVMState(WIFI_STATE, 	0);
-
-	// OLED_ShowString(0, 2, "!192.168.222.197", 4);
-	// OLED_ShowString(1, 2, "  192.168.2.197", 4);
-	// OLED_ShowString(1, 3, "1920*1080", 4);
-	// OLED_ShowString(41, 3, "  FPS", 4);
-
-	// OLED_ShowString_AlignRight(AlignRightEND_P, 2, "192.168.0.69", 4);
-	// OLED_ShowString_AlignRight(37, 3, "1920*1080", 4);
-	OLED_ShowString_AlignRight(AlignRightEND_P, 3, "  FPS", 4);
-	// OLED_ShowString(0, 3, "\"ABCDEFGHIJKLMMN\'", 4);
-	// OLED_ShowString(5, 2, "1", 4);
+	OLED_ShowKVMState(HDMI_STATE, kvm_sys_state.hdmi_state > 0 ? 1 : 0);
+	OLED_ShowKVMState(HID_STATE, kvm_sys_state.usb_state > 0 ? 1 : 0);
+	OLED_ShowKVMState(ETH_STATE, kvm_sys_state.eth_state > 0 ? 1 : 0);
+	OLED_ShowKVMState(WIFI_STATE, kvm_sys_state.wifi_state > 0 ? 1 : 0);
+	OLED_ShowKVMStreamState(KVM_ETH_IP, kvm_sys_state.eth_addr);
+	OLED_Show_Res(kvm_sys_state.hdmi_width, kvm_sys_state.hdmi_height);
+	OLED_ShowKVMStreamState(KVM_STEAM_FPS, &kvm_sys_state.now_fps);
 }
 
-void kvm_init_ui(void)
-{
-	if(kvm_hw_ver != 2){
-		kvm_init_cube_ui();
-	} else {
-		kvm_init_pcie_ui();
-	}
-}
-
-void qrcode_to_oled(QRCode *qr)
-{
-	char *p_oled_data;
-	uint16_t count = 0;
-	uint8_t bit;
-	uint8_t begin_x = 2;
-	uint8_t begin_y = 2;
-	p_oled_data = (char *)malloc( 132 * sizeof(char));
-	if(p_oled_data != NULL){
-		// fill
-		for(int i = 0; i < 132; i++){
-			p_oled_data[i] = 0xFF;
-		}
-		// i | ; j -
-		for(int i = 0; i < 29; i++){
-			for(int j = 0; j < 29; j++){
-				if(qrIsBlacke(qr, i, j)){
-					// 敲黑点
-					uint16_t data_index = ((i+begin_y)/8)*33+(j+begin_x);
-					uint8_t mask = ~(0x01 << ((i+begin_y)%8));
-					p_oled_data[data_index] &= mask;
-				}
-			}
-		}
-		OLED_Fill();
-		OLED_ShowIMG(29, 0, p_oled_data, 33, 4);
-		free(p_oled_data);
-	}
-}
-
-int qrencode(char *string)
-{
-	// test: qrencode("WIFI:T:WPA2;S:NanoKVM;P:12345678;;");
-	int errcode = QR_ERR_NONE;
-	QRCode* p = qrInit(3, QR_EM_8BIT, 1, 4, &errcode);
-	if (p == NULL) {
-		printf("error\n");
-		return -1;
-	}
-	qrAddData(p, (const qr_byte_t*)string, strlen(string));
-	if (!qrFinalize(p)) {
-		printf("finalize error\n");
-		return -1;
-	}
-
-	qrcode_to_oled(p);
-	if(string[0] == 'W'){
-		OLED_ShowStringTurn(3, 1, "WiFi", 8);
-		OLED_ShowStringTurn(3, 2, "AP:", 8);
-	} else if(string[0] == 'h'){
-		if(string[7] == '1'){
-			OLED_ShowStringTurn(3, 1, "Web:", 8);
-		} else if(string[8] == 'w'){
-			OLED_ShowStringTurn(3, 1, "WiKi", 8);
-		}
-	}
-	int size = 0;
-	// width = height = qr_vertable[version] * mag + sep * mag * 2
-	qr_byte_t * buffer = qrSymbolToBMP(p, 5, 5, &size);
-	if (buffer == NULL) {
-		printf("error %s", qrGetErrorInfo(p));
-		return -1;
-	}
-	// output qrcode to file
-	// ofstream f("/etc/kvm/wifi_config.bmp");
-	// if (f.fail()) {
-	// 	return -1;
-	// }
-	// f.write((const char *)buffer, size);
-	// f.close();
-	return 0;
-}
-
-ip_addr_t show_which_ip(void)
-{
-	if(kvm_sys_state.wifi_state == -2) return ETH_IP;
-	if(kvm_oled_state.eth_state == 3 && kvm_oled_state.wifi_state != 1) return ETH_IP;
-	if(kvm_oled_state.eth_state != 3 && kvm_oled_state.wifi_state == 1) return WiFi_IP;
-	static uint8_t run_count = 0;
-	static ip_addr_t ip_type = ETH_IP; 
-	run_count++;
-	if(run_count > IP_Change_time/STATE_DELAY){
-		run_count = 0;
-		switch(ip_type){
-			case ETH_IP:
-				ip_type = WiFi_IP;
-				break;
-			case WiFi_IP:
-				ip_type = ETH_IP;
-				break;
-			default:
-				ip_type = ETH_IP;
-		}
-	}
-	// printf("show_which_ip? %d\n", ip_type);
-	return ip_type;
-}
-
-uint8_t ip_changed(ip_addr_t ip_type)
-{
-	uint8_t *kvm_sys_ip;
-	uint8_t *kvm_oled_ip;
-	uint8_t ret;
-	if(ip_type == ETH_IP){
-		kvm_sys_ip = kvm_sys_state.eth_addr;
-		kvm_oled_ip = kvm_oled_state.eth_addr;
-	} else if(ip_type == WiFi_IP){
-		kvm_sys_ip = kvm_sys_state.wifi_addr;
-		kvm_oled_ip = kvm_oled_state.wifi_addr;
-	} else ret = 0;
-	for (int i = 0; i < 16; i++){
-		if(kvm_sys_ip[i] == 0) ret = 0;
-		if(kvm_sys_ip[i] != kvm_oled_ip[i]) ret = 1;
-	}
-	if(ret == 1){
-		memcpy(kvm_oled_ip, kvm_sys_ip, 16);
-	}
-	return ret;
-}
-
-uint8_t kvm_state_is_changed()
-{
-	if(	(kvm_sys_state.eth_state 	!= kvm_oled_state.eth_state) 	|| 
-		(kvm_sys_state.wifi_state 	!= kvm_oled_state.wifi_state) 	|| 
-		(kvm_sys_state.usb_state 	!= kvm_oled_state.usb_state) 	|| 
-		(kvm_sys_state.hdmi_state 	!= kvm_oled_state.hdmi_state) 	|| 
-	/*	(kvm_sys_state.now_fps 		!= kvm_oled_state.now_fps) 		|| */
-		(kvm_sys_state.hdmi_width 	!= kvm_oled_state.hdmi_width) 	|| 
-		(kvm_sys_state.hdmi_height 	!= kvm_oled_state.hdmi_height) 	|| 
-		(kvm_sys_state.type 		!= kvm_oled_state.type) 		|| 
-		(kvm_sys_state.qlty 		!= kvm_oled_state.qlty) )
-		return 1;
-	else
-		return 0;
-}
-
-void kvm_eth_state_disp(ip_addr_t _ip_type, uint8_t first_disp)
-{
-	static ip_addr_t _ip_type_old = NULL_IP;
-	uint8_t temp;
-	// printf("[kvmd]eth_state = %d\n", kvm_sys_state.eth_state);
-	if(	(kvm_oled_state.eth_state != kvm_sys_state.eth_state) || 
-		(_ip_type_old != _ip_type) || 
-		first_disp || ip_changed(ETH_IP))
-	{
-		// ensure eth_addr is updated
-		if (kvm_sys_state.eth_state >= 2) {
-			if (kvm_sys_state.eth_addr[0] != 0) 
-				kvm_oled_state.eth_state = kvm_sys_state.eth_state;
-		} else {
-			kvm_oled_state.eth_state = kvm_sys_state.eth_state;
-		}
-		
-		_ip_type_old = _ip_type;
-		switch(kvm_oled_state.eth_state){
-			case -1:
-			case  0:
-				temp = 0;
-				OLED_ShowKVMState(ETH_STATE, 	0);
-				if(_ip_type == ETH_IP)
-					OLED_ShowKVMStreamState(KVM_ETH_IP, &temp);
-				break;
-			case  1:
-				OLED_ShowKVMState(ETH_STATE, 	1);
-				if(_ip_type == ETH_IP)
-					OLED_ShowKVMStreamState(KVM_ETH_IP, &temp);
-				break;
-			case  2:
-				OLED_Show_Network_Error(1);
-			case  3:
-				OLED_Show_Network_Error(0);
-				OLED_ShowKVMState(ETH_STATE, 	1);
-				if(_ip_type == ETH_IP)
-					OLED_ShowKVMStreamState(KVM_ETH_IP, kvm_sys_state.eth_addr);
-				break;
-		}
-	}
-}
-
-void kvm_wifi_state_disp(ip_addr_t _ip_type, uint8_t first_disp)
-{
-	static ip_addr_t _ip_type_old = NULL_IP;
-	uint8_t temp;
-	// printf("[kvmd]wifi_state = %d\n", kvm_sys_state.wifi_state);
-	if(	(kvm_oled_state.wifi_state != kvm_sys_state.wifi_state) || 
-		(_ip_type_old != _ip_type) || 
-		first_disp || ip_changed(WiFi_IP))
-	{
-		kvm_oled_state.wifi_state = kvm_sys_state.wifi_state;
-		_ip_type_old = _ip_type;
-		switch(kvm_oled_state.wifi_state){
-			case -2:
-				OLED_ShowKVMState(WIFI_STATE, 	-1);
-				break;
-			case -1:
-			case  0:
-				temp = 0;
-				OLED_ShowKVMState(WIFI_STATE, 	0);
-				if(_ip_type == WiFi_IP)
-					OLED_ShowKVMStreamState(KVM_WIFI_IP, &temp);
-				break;
-			case  1:
-				OLED_ShowKVMState(WIFI_STATE, 	1);
-				if(_ip_type == WiFi_IP){
-					OLED_ShowKVMStreamState(KVM_WIFI_IP, kvm_sys_state.wifi_addr);
-				}
-				break;
-		}
-	}
-}
-
-void kvm_usb_state_disp(uint8_t first_disp)
-{
-	if((kvm_oled_state.usb_state != kvm_sys_state.usb_state) || first_disp){
-		kvm_oled_state.usb_state = kvm_sys_state.usb_state;
-		switch(kvm_oled_state.usb_state){
-			case -1:
-			case  0:
-				OLED_ShowKVMState(HID_STATE, 	0);
-				break;
-			case  1:
-				OLED_ShowKVMState(HID_STATE, 	1);
-				break;
-		}
-	}
-}
-
-void kvm_hdmi_state_disp(uint8_t first_disp)
-{
-	if((kvm_oled_state.hdmi_state != kvm_sys_state.hdmi_state) || first_disp){
-		kvm_oled_state.hdmi_state = kvm_sys_state.hdmi_state;
-		switch(kvm_oled_state.hdmi_state){
-			case -1:
-			case  0:
-				OLED_ShowKVMState(HDMI_STATE, 	0);
-				break;
-			case  1:
-				OLED_ShowKVMState(HDMI_STATE, 	1);
-				break;
-		}
-	}
-}
-
-void kvm_fps_disp(uint8_t first_disp)
-{
-	if((kvm_oled_state.now_fps != kvm_sys_state.now_fps) || first_disp){
-		kvm_oled_state.now_fps = kvm_sys_state.now_fps;
-		OLED_ShowKVMStreamState(KVM_STEAM_FPS, &kvm_oled_state.now_fps);
-	}
-}
-
-void kvm_res_disp(uint8_t first_disp)
-{
-	if(	(kvm_oled_state.hdmi_width != kvm_sys_state.hdmi_width) || \
-		(kvm_oled_state.hdmi_height != kvm_sys_state.hdmi_height) || \
-		first_disp ){
-		kvm_oled_state.hdmi_width = kvm_sys_state.hdmi_width;
-		kvm_oled_state.hdmi_height = kvm_sys_state.hdmi_height;
-		OLED_Show_Res(kvm_sys_state.hdmi_width, kvm_sys_state.hdmi_height);
-	}
-}
-
-void kvm_type_disp(uint8_t first_disp)
-{
-	if(	(kvm_oled_state.type != kvm_sys_state.type) || first_disp){
-		kvm_oled_state.type = kvm_sys_state.type;
-		OLED_ShowKVMStreamState(KVM_STEAM_TYPE, &kvm_oled_state.type);
-	}
-}
-
-void kvm_qlty_disp(uint8_t first_disp)
-{
-	if(	(kvm_oled_state.qlty != kvm_sys_state.qlty) || first_disp){
-		kvm_oled_state.qlty = kvm_sys_state.qlty;
-		OLED_ShowKVMStreamState(KVM_JPG_QLTY, &kvm_sys_state.qlty);
-	}
-}
-
-void kvm_main_disp(uint8_t first_disp)
-{
-	if(first_disp){
-		OLED_Clear();
-		kvm_init_ui();
-	}
-}
-
-void kvm_oled_clear(uint8_t subpage_changed)
-{
-	if(subpage_changed){
-		OLED_Clear();
-	}
-}
-
-void kvm_main_ui_disp(uint8_t first_disp, uint8_t subpage_changed)
-{
-	ip_addr_t now_ip_type;
-	// if(kvm_oled_state.sub_page == 0)
-	// if(kvm_oled_state.oled_sleep_state == 1){
-
-	// Any operation will update the OLED sleep time
-	if (kvm_state_is_changed())
-		oled_auto_sleep_time_update();
-
-	if(kvm_oled_state.sub_page == 1){
-		// main page (oled sleep)
-		kvm_oled_clear(first_disp || subpage_changed);
-		kvm_oled_state.oled_sleep_state = 1;
-	} else {
-		// main page
-		kvm_oled_state.oled_sleep_state = 0;
-		now_ip_type = show_which_ip();
-		kvm_main_disp(first_disp || subpage_changed);
-		kvm_eth_state_disp(now_ip_type, first_disp || subpage_changed);
-		kvm_wifi_state_disp(now_ip_type, first_disp || subpage_changed);
-		kvm_usb_state_disp(first_disp || subpage_changed);
-		kvm_hdmi_state_disp(first_disp || subpage_changed);
-		kvm_fps_disp(first_disp || subpage_changed);
-		kvm_res_disp(first_disp || subpage_changed);
-		kvm_type_disp(first_disp || subpage_changed);
-		kvm_qlty_disp(first_disp || subpage_changed);
-	}
-}
-
-uint8_t show_which_page()
-{
-	static uint8_t run_count = 0xfe;
-	static uint8_t show_type = 0;	// 0 不动 1 QRcode; 2 text
-	if(sta_connect_ap()){
-		if(ssid_pass_ok()){
-			// 
-		}
-	}
-	run_count++;
-	if(run_count > QR_Change_time/STATE_DELAY){
-		run_count = 0;
-		if(show_type == 1) show_type = 2;
-		else show_type = 1;
-		return show_type;
-	}
-	return 0;
-}
-
-void show_text_wifi_config(char *ap_ssid)
+void show_text_wifi_config(char *password)
 {
 	OLED_Clear();
 	OLED_ShowString(0, 0, "SSID:", 8);
 	OLED_ShowString_AlignRight(63, 1, "NanoKVM", 8);
 	OLED_ShowString(0, 2, "PASS:", 8);
-	OLED_ShowString_AlignRight(63, 3, ap_ssid, 8);
+	OLED_ShowString_AlignRight(63, 3, password, 8);
 }
 
-void show_wifi_config_ip(void)
+void show_wifi_config_ip()
 {
+	char url[30] = {0};
+	char key[30] = {0};
 	OLED_Clear();
 	get_ip_addr(WiFi_IP);
+	snprintf(url, sizeof(url), "%s/#/", kvm_sys_state.wifi_addr);
+	snprintf(key, sizeof(key), "WIFI?P=%s", kvm_sys_state.wifi_ap_pass);
 	OLED_ShowString(1, 0, "Config URL", 8);
-	OLED_ShowString_AlignRight(63, 1, "----------------", 4);
-	// OLED_ShowString_AlignRight(63, 2, (char*)kvm_sys_state.wifi_addr, 4);
-	static char wifi_addr_with_path[30];
-	static char wifi_addr_with_key[30];
-	sprintf(wifi_addr_with_path, "%s/#/", kvm_sys_state.wifi_addr);
-	sprintf(wifi_addr_with_key, "WIFI?P=%s", kvm_sys_state.wifi_ap_pass);
-	OLED_ShowString_AlignRight(63, 2, wifi_addr_with_path, 4);
-	OLED_ShowString_AlignRight(63, 3, wifi_addr_with_key, 4);
+	OLED_ShowString_AlignRight(63, 2, url, 4);
+	OLED_ShowString_AlignRight(63, 3, key, 4);
 }
 
-void show_wifi_config_QR(void)
+void draw_qr_code(QRCode *qr)
 {
-	static char cmd[70];
-	OLED_Clear();
-	get_ip_addr(WiFi_IP);
-	sprintf(cmd, "http://%s/#/WIFI?P=%s", kvm_sys_state.wifi_addr, kvm_sys_state.wifi_ap_pass);
-	qrencode(cmd);
-}
-
-void show_wifi_starting(void)
-{
-	OLED_Clear();
-	OLED_ShowString(0, 1, "WiFi AP is", 8);
-	OLED_ShowString(0, 2, "Starting..", 8);
-}
-
-void show_wifi_connecting(void)
-{
-	OLED_Clear();
-	OLED_ShowString(0, 1, "WiFi", 8);
-	OLED_ShowString(0, 2, "Connect...", 8);
-}
-
-void kvm_wifi_config_ui_disp(uint8_t first_disp, uint8_t subpage_changed)
-{
-	static char cmd[70];
-	// printf("[kvmd]kvm_wifi_config_ui_disp %d | %d\n", first_disp, subpage_changed);
-	if(first_disp) kvm_start_wifi_config_process(); // 略有不妥,就这样吧
-	if(first_disp || subpage_changed){
-		switch(kvm_oled_state.sub_page){
-			case 0: // wifi ap is starting
-				show_wifi_starting();
-				break;
-			case 1: // QRcode
-				printf("WIFI:T:WPA2;S:NanoKVM;P:%s;;\n", kvm_sys_state.wifi_ap_pass);
-				sprintf(cmd, "WIFI:T:WPA2;S:NanoKVM;P:%s;;", kvm_sys_state.wifi_ap_pass);
-				qrencode(cmd);
-				break;
-			case 2: // Textcode
-				show_text_wifi_config(kvm_sys_state.wifi_ap_pass);
-				break;
-			case 3: // open IP with QR Code
-				show_wifi_config_QR();
-				break;
-			case 4: // open IP
-				show_wifi_config_ip();
-				break;
-			case 5: // Connecting...
-				show_wifi_connecting();
-				break;
+	char data[132];
+	memset(data, 0xFF, sizeof(data));
+	for(int y = 0; y < 29; ++y){
+		for(int x = 0; x < 29; ++x){
+			if(qrIsBlacke(qr, y, x)){
+				uint16_t index = ((y + 2) / 8) * 33 + (x + 2);
+				data[index] &= ~(0x01 << ((y + 2) % 8));
+			}
 		}
 	}
-	// switch(show_which_page())
+	OLED_Fill();
+	OLED_ShowIMG(29, 0, data, 33, 4);
+}
+
+void show_wifi_qr()
+{
+	char command[70] = {0};
+	get_ip_addr(WiFi_IP);
+	snprintf(command, sizeof(command), "http://%s/#/WIFI?P=%s", kvm_sys_state.wifi_addr, kvm_sys_state.wifi_ap_pass);
+	int error = QR_ERR_NONE;
+	QRCode *qr = qrInit(3, QR_EM_8BIT, 1, 4, &error);
+	if(qr == NULL) return;
+	qrAddData(qr, reinterpret_cast<const qr_byte_t *>(command), strlen(command));
+	if(qrFinalize(qr)) draw_qr_code(qr);
+	qrDestroy(qr);
+}
 }
 
 void oled_auto_sleep_time_update(void)
 {
-	kvm_oled_state.oled_sleep_start = time::time_ms();
+	note_local_activity(time::ticks_ms());
+}
+
+void oled_note_wifi_activity(void)
+{
+	kvm_sys_state.oled_wifi_activity_ms = time::ticks_ms();
+}
+
+void oled_policy_tick(void)
+{
+	// All OLED deadlines use the monotonic clock. Wall-clock time can jump by
+	// years when an RTC-less device synchronizes with NTP during startup.
+	uint64_t now = time::ticks_ms();
+	if(kvm_sys_state.oled_local_activity_ms == 0) reset_idle_policy(now);
+	reload_oled_config(now);
+	refresh_viewers(now);
+
+	if(passive_state_changed() && !kvm_sys_state.oled_manual_off && kvm_sys_state.page == 0){
+		// A quiet period starts a new event burst. Repeated link flaps extend
+		// only the current burst, never beyond its 60-second hard limit.
+		if(kvm_oled_state.event_wake_last_ms == 0 || now - kvm_oled_state.event_wake_last_ms > 2000)
+			kvm_oled_state.event_wake_started_ms = now;
+		kvm_oled_state.event_wake_last_ms = now;
+		uint64_t deadline = now + OLED_EVENT_WAKE_DELAY * 1000ULL;
+		uint64_t maximum = kvm_oled_state.event_wake_started_ms + OLED_EVENT_WAKE_MAX * 1000ULL;
+		kvm_oled_state.event_wake_deadline_ms = deadline < maximum ? deadline : maximum;
+	}
+
+	bool wifi = kvm_sys_state.page == 1;
+	if(wifi && kvm_oled_state.wifi_context_started_ms == 0){
+		kvm_oled_state.wifi_context_started_ms = now;
+		oled_note_wifi_activity();
+		kvm_oled_state.force_full_redraw = 1;
+	} else if(!wifi) {
+		kvm_oled_state.wifi_context_started_ms = 0;
+	}
+
+	uint64_t local_activity = kvm_sys_state.oled_local_activity_ms;
+	uint64_t wifi_activity = kvm_sys_state.oled_wifi_activity_ms;
+	uint64_t local_idle = now >= local_activity ? now - local_activity : 0;
+	uint64_t wifi_idle = now >= wifi_activity ? now - wifi_activity : 0;
+	uint8_t desired = 1;
+	if(wifi){
+		if(wifi_idle >= OLED_WIFI_SLEEP_DELAY * 1000ULL) desired = 0;
+	} else if(kvm_sys_state.oled_manual_off) {
+		desired = 0;
+	} else if(kvm_oled_state.event_wake_deadline_ms > now) {
+		desired = 1;
+	} else if(kvm_oled_state.oled_sleep_param > 0 && local_idle >= kvm_oled_state.oled_sleep_param * 1000ULL) {
+		desired = 0;
+	}
+
+	if(desired != kvm_oled_state.power_state){
+		if(desired == 0) {
+			OLED_EnterSleep();
+			kvm_oled_state.wake_pending = 0;
+		}
+		else if(kvm_oled_state.power_state == 0) {
+			OLED_PrepareFrame();
+			kvm_oled_state.wake_pending = 1;
+		}
+		kvm_oled_state.power_state = desired;
+		kvm_oled_state.oled_sleep_state = desired == 0;
+		kvm_oled_state.force_full_redraw = desired != 0;
+	}
+
+	if(!wifi && kvm_hw_ver != 2 && kvm_oled_state.power_state != 0 && carousel_active(local_idle)){
+		if(kvm_oled_state.next_page_switch_ms == 0) kvm_oled_state.next_page_switch_ms = now + OLED_CAROUSEL_DELAY * 1000ULL;
+		if(kvm_oled_state.next_pixel_shift_ms == 0) kvm_oled_state.next_pixel_shift_ms = now + OLED_PIXEL_SHIFT_DELAY * 1000ULL;
+		if(now >= kvm_oled_state.next_page_switch_ms){
+			kvm_oled_state.main_page = (kvm_oled_state.main_page + 1) % 3;
+			kvm_oled_state.next_page_switch_ms = now + OLED_CAROUSEL_DELAY * 1000ULL;
+			kvm_oled_state.force_full_redraw = 1;
+		}
+		if(now >= kvm_oled_state.next_pixel_shift_ms){
+			int16_t next_x = kvm_oled_state.pixel_shift_x + kvm_oled_state.pixel_shift_dx;
+			int16_t next_y = kvm_oled_state.pixel_shift_y + kvm_oled_state.pixel_shift_dy;
+			if(next_x < 0 || next_x > OLED_PIXEL_SHIFT_X){
+				kvm_oled_state.pixel_shift_dx = -kvm_oled_state.pixel_shift_dx;
+				next_x = kvm_oled_state.pixel_shift_x + kvm_oled_state.pixel_shift_dx;
+			}
+			if(next_y < 0 || next_y > OLED_PIXEL_SHIFT_Y){
+				kvm_oled_state.pixel_shift_dy = -kvm_oled_state.pixel_shift_dy;
+				next_y = kvm_oled_state.pixel_shift_y + kvm_oled_state.pixel_shift_dy;
+			}
+			kvm_oled_state.pixel_shift_x = static_cast<uint8_t>(next_x);
+			kvm_oled_state.pixel_shift_y = static_cast<uint8_t>(next_y);
+			kvm_oled_state.next_pixel_shift_ms = now + OLED_PIXEL_SHIFT_DELAY * 1000ULL;
+			kvm_oled_state.force_full_redraw = 1;
+		}
+	} else if(!carousel_active(local_idle) && (kvm_oled_state.main_page != 0 || kvm_oled_state.pixel_shift_x != 0 || kvm_oled_state.pixel_shift_y != 0)) {
+		kvm_oled_state.main_page = 0;
+		kvm_oled_state.pixel_shift_x = 0;
+		kvm_oled_state.pixel_shift_y = 0;
+		kvm_oled_state.pixel_shift_dx = 1;
+		kvm_oled_state.pixel_shift_dy = 1;
+		kvm_oled_state.next_page_switch_ms = 0;
+		kvm_oled_state.next_pixel_shift_ms = 0;
+		kvm_oled_state.force_full_redraw = 1;
+	}
+}
+
+bool oled_is_awake(void)
+{
+	return kvm_oled_state.power_state != 0;
+}
+
+void oled_finish_frame(void)
+{
+	if(kvm_oled_state.wake_pending && kvm_oled_state.power_state != 0){
+		OLED_CommitAndWake();
+		kvm_oled_state.wake_pending = 0;
+	}
+}
+
+void kvm_main_ui_disp(uint8_t first_disp, uint8_t subpage_changed)
+{
+	if(!oled_is_awake()) return;
+	uint64_t signature = render_signature();
+	if(!first_disp && !subpage_changed && !kvm_oled_state.force_full_redraw && signature == kvm_oled_state.render_signature) return;
+	if(kvm_hw_ver == 2) draw_pcie_legacy();
+	else {
+		uint64_t now = time::ticks_ms();
+		uint64_t local_activity = kvm_sys_state.oled_local_activity_ms;
+		uint64_t local_idle = now >= local_activity ? now - local_activity : 0;
+		if(carousel_active(local_idle)) draw_cube_main();
+		else draw_cube_legacy();
+	}
+	kvm_oled_state.render_signature = signature;
+	kvm_oled_state.force_full_redraw = 0;
+}
+
+void kvm_wifi_config_ui_disp(uint8_t first_disp, uint8_t subpage_changed)
+{
+	if(!oled_is_awake()) return;
+	if(first_disp){
+		kvm_start_wifi_config_process();
+		oled_note_wifi_activity();
+	}
+	if(!first_disp && !subpage_changed && !kvm_oled_state.force_full_redraw) return;
+	OLED_SetLayoutOffset(0);
+	OLED_SetVerticalOffset(0);
+	switch(kvm_sys_state.sub_page){
+		case 0: OLED_Clear(); OLED_ShowString(0, 1, "WiFi AP is", 8); OLED_ShowString(0, 2, "Starting..", 8); break;
+		case 1: show_wifi_qr(); break;
+		case 2: show_text_wifi_config(kvm_sys_state.wifi_ap_pass); break;
+		case 3: show_wifi_qr(); break;
+		case 4: show_wifi_config_ip(); break;
+		case 5: OLED_Clear(); OLED_ShowString(0, 1, "WiFi", 8); OLED_ShowString(0, 2, "Connect...", 8); break;
+		default: OLED_Clear(); break;
+	}
+	kvm_oled_state.force_full_redraw = 0;
 }
 
 void oled_auto_sleep(void)
 {
-	uint16_t tmp16;
-	uint8_t sleep_close_signal = 0;
-	FILE *fp;
-	int file_size;
-	char RW_Data[10] = {0};
-	if(access("/etc/kvm/oled_sleep", F_OK) == 0){
-        fp = fopen("/etc/kvm/oled_sleep", "r");
-		fseek(fp, 0, SEEK_END);
-		file_size = ftell(fp); 
-		fseek(fp, 0, SEEK_SET);
-		if(file_size >= (int)sizeof(RW_Data)){
-			file_size = sizeof(RW_Data) - 1;
-		}
-        fread(RW_Data, sizeof(char), file_size, fp);
-		RW_Data[file_size] = '\0';
-        fclose(fp);
-		if(file_size != 0){
-			tmp16 = atoi(RW_Data);
-		} else {
-			tmp16 = OLED_SLEEP_DELAY_DEFAULT;
-		}
-		if(tmp16 != kvm_oled_state.oled_sleep_param){
-			// printf("/etc/kvm/oled_sleep = %d\n", tmp16);
-			kvm_oled_state.oled_sleep_param = tmp16;
-			if(kvm_oled_state.oled_sleep_param < OLED_SLEEP_DELAY_MIN){
-				sleep_close_signal = 1;
-			} else {
-				// printf("oled_auto_sleep_time_update\n");
-				oled_auto_sleep_time_update();
-			}
-		}
-    } else {
-		if(kvm_oled_state.oled_sleep_param != 0){
-        	kvm_oled_state.oled_sleep_param = 0;
-			sleep_close_signal = 1;
-		}	
-    }
-	
-	if(kvm_oled_state.page == 0){
-		if(kvm_oled_state.oled_sleep_param < OLED_SLEEP_DELAY_MIN){
-			if(sleep_close_signal == 1){
-				kvm_sys_state.sub_page = 0;
-			}
-		} else {
-			if((time::time_ms() - kvm_oled_state.oled_sleep_start)/1000 >= kvm_oled_state.oled_sleep_param){
-				// kvm_oled_state.oled_sleep_state = 1;
-				kvm_sys_state.sub_page = 1;
-			} else {
-				kvm_sys_state.sub_page = 0;
-			}
-		}
-	}
+	// Kept as an API compatibility shim. The real state transition lives in
+	// oled_policy_tick(), which is called only by the OLED thread.
+	oled_policy_tick();
 }
 
 void kvm_show_UE(void)
 {
-	if(kvm_hw_ver != 2){
-		OLED_ShowString(0, 0, "HDMI: UE", 16);
-	} else {
-		OLED_Revolve();
-		OLED_ShowString(0, 0, "HDMI: UE", 16);
-		// OLED_ShowString_AlignRight(AlignRightEND_P, 3, "  FPS", 4);
-		// kvm_init_pcie_ui();
-	}
+	OLED_SetLayoutOffset(0);
+	OLED_SetVerticalOffset(0);
+	OLED_Clear();
+	OLED_ShowString(0, 0, "HDMI: UE", 16);
 }

--- a/support/sg2002/kvm_system/main/lib/oled_ui/oled_ui.h
+++ b/support/sg2002/kvm_system/main/lib/oled_ui/oled_ui.h
@@ -7,6 +7,10 @@ void kvm_main_ui_disp(uint8_t first_disp, uint8_t subpage_changed);
 void kvm_wifi_config_ui_disp(uint8_t first_disp, uint8_t subpage_changed);
 void oled_auto_sleep_time_update(void);
 void oled_auto_sleep(void);
+void oled_note_wifi_activity(void);
+void oled_policy_tick(void);
+bool oled_is_awake(void);
+void oled_finish_frame(void);
 void kvm_show_UE(void);
 
 #endif // OLED_UI_H_

--- a/support/sg2002/kvm_system/main/src/main.cpp
+++ b/support/sg2002/kvm_system/main/src/main.cpp
@@ -26,17 +26,11 @@ void* thread_oled_handle(void * arg)
 	OLED_ColorTurn(0);		//0正常显示 1 反色显示
 	OLED_DisplayTurn(0);	//0正常显示 1 屏幕翻转显示
 	OLED_Clear();
-	if(kvm_oled_state.ue_patch_state == 1){
-		kvm_show_UE();
-		while(kvm_sys_state.oled_thread_running){
-			time::sleep_ms(100);
-		}
-		OLED_Clear();
-	}
 
     while(kvm_sys_state.oled_thread_running)
     {
-		oled_auto_sleep();
+		// This thread is the only owner of OLED I2C and power transitions.
+		oled_policy_tick();
 		// printf("[kvmd]thread_oled_handle - while\n");
 		uint8_t page_changed = (kvm_oled_state.page == kvm_sys_state.page)? 0:1;
 		uint8_t subpage_changed = (kvm_oled_state.sub_page == kvm_sys_state.sub_page)? 0:1;
@@ -47,29 +41,39 @@ void* thread_oled_handle(void * arg)
 		kvm_oled_state.sub_page = kvm_sys_state.sub_page;
 
 
-		switch(kvm_oled_state.page){
-			case 0 : // main page
-				kvm_main_ui_disp(page_changed, subpage_changed);
-				break;
-			case 1 : // wifi config page
-				kvm_wifi_config_ui_disp(page_changed, subpage_changed);
-				break;
-			default:
-				OLED_Clear();
+		if(oled_is_awake()){
+			if(kvm_oled_state.ue_patch_state == 1){
+				if(kvm_oled_state.force_full_redraw) kvm_show_UE();
+				kvm_oled_state.force_full_redraw = 0;
+			} else {
+				switch(kvm_oled_state.page){
+					case 0 : // main page
+						kvm_main_ui_disp(page_changed, subpage_changed);
+						break;
+					case 1 : // wifi config page
+						kvm_wifi_config_ui_disp(page_changed, subpage_changed);
+						break;
+					default:
+						OLED_Clear();
+				}
+			}
+			oled_finish_frame();
 		}
 		time::sleep_ms(OLED_DELAY);
     }
-	OLED_Clear();
+	OLED_EnterSleep();
 	kvm_sys_state.oled_thread_running = -1;
+	return NULL;
 }
 
 void* thread_key_handle(void * arg)
 {
-	uint64_t __attribute__((unused)) press_time;
+	uint64_t press_time = 0;
 	uint32_t press_cycle;
 	int fd = open ("/dev/input/event0", O_RDONLY);
 	if (fd == -1) {
 		kvm_sys_state.key_thread_running = 0;
+		return NULL;
 	}
 	struct input_event event;
 
@@ -79,11 +83,11 @@ void* thread_key_handle(void * arg)
 		if (event.type == EV_KEY) {
 			if (event.value == 1){
 				// printf ("[kvmk]按键按下\n");
-				press_time = time::time_ms();
-			} else if (event.value == 0){
+				press_time = time::ticks_ms();
+			} else if (event.value == 0 && press_time != 0){
 				oled_auto_sleep_time_update();
 				// printf ("[kvmk]按键抬起\n");
-				press_cycle = time::time_ms() - press_time;
+				press_cycle = time::ticks_ms() - press_time;
 				if(press_cycle >= KEY_LONGLONG_PRESS){
 					kvm_reset_password();
 				} else if (press_cycle >= KEY_LONG_PRESS && press_cycle < KEY_LONGLONG_PRESS){
@@ -93,18 +97,23 @@ void* thread_key_handle(void * arg)
 					if(kvm_sys_state.wifi_state == -2){
 						kvm_sys_state.page = 0;
 						kvm_sys_state.sub_page = 0;
+						kvm_sys_state.oled_manual_off = 0;
+						press_time = 0;
 						continue;
 					}
 					switch(kvm_sys_state.page){
 						case 0:	// main page
 							kvm_sys_state.page = 1;
 							kvm_sys_state.sub_page = 0;
+							kvm_sys_state.oled_manual_off = 0;
+							oled_note_wifi_activity();
 							break;
 						case 1:	// wifi coonfig page
 							system("/etc/init.d/S30wifi restart");
 							kvm_sys_state.page = 0;
 							kvm_sys_state.sub_page = 0;
 							kvm_sys_state.wifi_config_process = -1;
+							kvm_sys_state.oled_manual_off = 0;
 							break;
 					}
 				} else {
@@ -115,10 +124,18 @@ void* thread_key_handle(void * arg)
 					// printf ("[kvmk]sub_page = %d\n", kvm_sys_state.sub_page);
 					switch(kvm_sys_state.page){
 						case 0:	// main page
-							if(kvm_sys_state.sub_page == 0) kvm_sys_state.sub_page = 1;
-							else kvm_sys_state.sub_page = 0;
+							// The main-page short press is a stable manual power
+							// latch; sub_page now belongs exclusively to Wi-Fi.
+							if(kvm_oled_state.oled_sleep_state){
+								// Wake an automatically sleeping panel and consume this
+								// press instead of immediately turning it back off.
+								kvm_sys_state.oled_manual_off = 0;
+							} else {
+								kvm_sys_state.oled_manual_off = kvm_sys_state.oled_manual_off ? 0 : 1;
+							}
 							break;
 						case 1:	// wifi coonfig page
+							oled_note_wifi_activity();
 							switch(kvm_sys_state.wifi_config_process){
 								case 1:	// QR1<->TEXT2
 									if(kvm_sys_state.sub_page == 1) kvm_sys_state.sub_page = 2;
@@ -135,11 +152,14 @@ void* thread_key_handle(void * arg)
 							break;
 					}
 				}
+				press_time = 0;
 			}
 		}
 		time::sleep_ms(KEY_DELAY);
-    }
+	}
+	close(fd);
 	kvm_sys_state.key_thread_running = 0;
+	return NULL;
 }
 
 void* thread_sys_handle(void * arg)
@@ -170,18 +190,21 @@ void* thread_sys_handle(void * arg)
 		auto_remove_temp_watchdog();
     }
 	kvm_sys_state.sys_thread_running = 0;
+	return NULL;
 }
 
 int main(int argc, char* argv[])
 {
     // Catch SIGINT signal(e.g. Ctrl + C), and set exit flag to true.
-    signal(SIGINT, [](int sig){ 
+	auto stop_handler = [](int sig){
 	kvm_sys_state.oled_thread_running = 0;
 	kvm_sys_state.key_thread_running = 0;
 	kvm_sys_state.sys_thread_running = 0;
 	app::set_exit_flag(true); 
 	log::info("[kvms]Prepare to exit\n");
-	});	
+	};
+	signal(SIGINT, stop_handler);
+	signal(SIGTERM, stop_handler);
 
 	pthread_t sys_state_thread;
 	pthread_t display_thread;
@@ -259,6 +282,8 @@ int main(int argc, char* argv[])
 	kvm_sys_state.sys_thread_running = 0;
 	kvm_sys_state.oled_thread_running = 0;
 	kvm_sys_state.key_thread_running = 0;
-	while(kvm_sys_state.oled_thread_running != -1) time::sleep_ms(100);
+	if(OLED_state == 1){
+		while(kvm_sys_state.oled_thread_running != -1) time::sleep_ms(100);
+	}
 }
 


### PR DESCRIPTION
## Summary
- Validate OLED sleep values and persist them atomically. Missing configuration now uses a 60-second default, while an explicit value of `0` still disables automatic sleep.
- Restart the idle countdown and clear carousel deadlines whenever the sleep setting changes.
- Use monotonic timing for OLED inactivity, carousel, event-wake, Wi-Fi, and button timers so NTP synchronization or wall-clock changes cannot trigger immediate carousel or sleep.
- Separate OLED power state from UI subpages. Sleep disables the panel and charge pump, while wake-up renders a complete frame before enabling the display.
- Make the main-page button a stable manual power toggle and bound hardware-event wake windows. Wi-Fi provisioning preserves its workflow state while applying an independent five-minute display timeout.
- Add a Cube idle dashboard with network, video, and session pages. The `Never`, 30-minute, and one-hour modes enter the carousel after 15 minutes of local inactivity. Pages rotate every six seconds and periodically shift position to reduce fixed-pixel exposure. `Never` continues rotating without automatically turning the display off.
- Publish active MJPEG, Direct, and WebRTC viewer counts through a two-second tmpfs heartbeat. Missing or stale state falls back to zero after five seconds, and short-lived capture leases are excluded.

## Compatibility

- The OLED API remains unchanged: `POST /api/vm/oled` accepts `sleep`, and `GET /api/vm/oled` returns `exist` and `sleep`.
- Sleep values are restricted to `0` or 10–3600 seconds on both the server and `kvm_system` sides.
- Existing valid persisted values, including an explicit `0`, are preserved.
- Devices without `/etc/kvm/oled_sleep` now use a 60-second default. This is an intentional behavior change.
- PCIe devices retain the legacy layout and do not use the Cube carousel or pixel offsets.
- Devices without an OLED continue to skip the OLED thread.
- Viewer heartbeat state is runtime-only under `/run/nanokvm`; missing or stale state is treated as zero.


Related to #835.
Partially addresses #105.