### PR TITLE
feat(hid): add Spanish (Spain ISO) keyboard layout support for Paste

### DIFF
--- a/server/service/hid/paste.go
+++ b/server/service/hid/paste.go
@@ -166,6 +166,8 @@ func LangueSwitch(base map[rune]Char, lang string) map[rune]Char {
 		m['@'] = Char{0x40, 39}     // AltGr+0
 		m['\u20AC'] = Char{0x40, 8} // € AltGr+E
 
+	case "es":
+		applySpanishLayout(m)
 	}
 	return m
 }
@@ -186,13 +188,21 @@ func (s *Service) Paste(c *gin.Context) {
 	}
 
 	charMapLocal := LangueSwitch(charMap, req.Langue)
-	typeableRunes := 0
+	var followMap map[rune]Char
+	if req.Langue == "es" {
+		followMap = spanishDeadKeyContinuationMap
+	}
+
+	typeableKeys := 0
 	for _, char := range contentRunes {
 		if _, ok := charMapLocal[char]; ok {
-			typeableRunes++
+			typeableKeys++
+			if _, ok := followMap[char]; ok {
+				typeableKeys++
+			}
 		}
 	}
-	if time.Duration(typeableRunes)*defaultPasteDelay > maxPasteDuration {
+	if time.Duration(typeableKeys)*defaultPasteDelay > maxPasteDuration {
 		rsp.ErrRsp(c, -2, "paste duration exceeds 25s")
 		return
 	}
@@ -233,6 +243,18 @@ func (s *Service) Paste(c *gin.Context) {
 		if err = sleepPasteContext(c.Request.Context(), defaultPasteDelay); err != nil {
 			break
 		}
+		if followKey, ok := followMap[char]; ok {
+			followKeyDown := []byte{byte(followKey.Modifiers), 0x00, byte(followKey.Code), 0x00, 0x00, 0x00, 0x00, 0x00}
+			if err = writeKeyboardReport(followKeyDown); err != nil {
+				break
+			}
+			if err = writeKeyboardReport(keyUp); err != nil {
+				break
+			}
+			if err = sleepPasteContext(c.Request.Context(), defaultPasteDelay); err != nil {
+				break
+			}
+		}
 	}
 	if err == nil {
 		err = context.Cause(c.Request.Context())
@@ -266,6 +288,98 @@ func copyMap(src map[rune]Char) map[rune]Char {
 		dst[k] = v
 	}
 	return dst
+}
+
+var spanishDeadKeyContinuationMap = map[rune]Char{
+	'á': {0, 4},
+	'é': {0, 8},
+	'í': {0, 12},
+	'ó': {0, 18},
+	'ú': {0, 24},
+	'Á': {2, 4},
+	'É': {2, 8},
+	'Í': {2, 12},
+	'Ó': {2, 18},
+	'Ú': {2, 24},
+	'ü': {0, 24},
+	'Ü': {2, 24},
+	'´': {0, 44},
+	'¨': {0, 44},
+	'`': {0, 44},
+	'^': {0, 44},
+}
+
+func applySpanishLayout(m map[rune]Char) {
+	// Spanish (Spain) ISO layout
+	m['\u00F1'] = Char{0, 51} // ñ
+	m['\u00D1'] = Char{2, 51} // Ñ
+	m['\u00E7'] = Char{0, 49} // ç
+	m['\u00C7'] = Char{2, 49} // Ç
+
+	// Dead keys
+	m['`'] = Char{0, 47}      // `
+	m['^'] = Char{2, 47}      // ^
+	m['\u00B4'] = Char{0, 52} // ´
+	m['\u00A8'] = Char{2, 52} // ¨
+
+	// Accented vowels
+	m['\u00E1'] = Char{0, 52} // á
+	m['\u00E9'] = Char{0, 52} // é
+	m['\u00ED'] = Char{0, 52} // í
+	m['\u00F3'] = Char{0, 52} // ó
+	m['\u00FA'] = Char{0, 52} // ú
+	m['\u00C1'] = Char{0, 52} // Á
+	m['\u00C9'] = Char{0, 52} // É
+	m['\u00CD'] = Char{0, 52} // Í
+	m['\u00D3'] = Char{0, 52} // Ó
+	m['\u00DA'] = Char{0, 52} // Ú
+	m['\u00FC'] = Char{2, 52} // ü
+	m['\u00DC'] = Char{2, 52} // Ü
+
+	// Top left key (º ª \)
+	m['\u00BA'] = Char{0, 53}
+	m['\u00AA'] = Char{2, 53}
+	m['\\'] = Char{0x40, 53}
+
+	// Number row symbols
+	m['!'] = Char{2, 30}
+	m['|'] = Char{0x40, 30}
+	m['"'] = Char{2, 31}
+	m['@'] = Char{0x40, 31}
+	m['\u00B7'] = Char{2, 32}
+	m['#'] = Char{0x40, 32}
+	m['$'] = Char{2, 33}
+	m['~'] = Char{0x40, 33}
+	m['%'] = Char{2, 34}
+	m['&'] = Char{2, 35}
+	m['\u00AC'] = Char{0x40, 35}
+	m['/'] = Char{2, 36}
+	m['('] = Char{2, 37}
+	m[')'] = Char{2, 38}
+	m['='] = Char{2, 39}
+
+	// Punctuation & brackets
+	m['\''] = Char{0, 45}
+	m['?'] = Char{2, 45}
+	m['\u00A1'] = Char{0, 46}
+	m['\u00BF'] = Char{2, 46}
+	m['['] = Char{0x40, 47}
+	m['+'] = Char{0, 48}
+	m['*'] = Char{2, 48}
+	m[']'] = Char{0x40, 48}
+	m['{'] = Char{0x40, 52}
+	m['}'] = Char{0x40, 49}
+
+	// Bottom row & currency
+	m['<'] = Char{0, 100}
+	m['>'] = Char{2, 100}
+	m[','] = Char{0, 54}
+	m[';'] = Char{2, 54}
+	m['.'] = Char{0, 55}
+	m[':'] = Char{2, 55}
+	m['-'] = Char{0, 56}
+	m['_'] = Char{2, 56}
+	m['\u20AC'] = Char{0x40, 8} // €
 }
 
 func GetCharMap(lang string) map[rune]Char {

--- a/web/src/i18n/locales/ca.ts
+++ b/web/src/i18n/locales/ca.ts
@@ -109,6 +109,7 @@ const ca = {
       dropdownGerman: 'alemany',
       dropdownFrench: 'francès',
       dropdownRussian: 'rus',
+      dropdownSpanish: 'Espanyol',
       shortcut: {
         title: 'Dreceres',
         custom: 'Personalitzat',

--- a/web/src/i18n/locales/cz.ts
+++ b/web/src/i18n/locales/cz.ts
@@ -110,6 +110,7 @@ const cz = {
       dropdownGerman: 'německy',
       dropdownFrench: 'francouzsky',
       dropdownRussian: 'rusky',
+      dropdownSpanish: 'španělsky',
       shortcut: {
         title: 'Zkratky',
         custom: 'Vlastní',

--- a/web/src/i18n/locales/da.ts
+++ b/web/src/i18n/locales/da.ts
@@ -109,6 +109,7 @@ const da = {
       dropdownGerman: 'tysk',
       dropdownFrench: 'Fransk',
       dropdownRussian: 'russisk',
+      dropdownSpanish: 'Spansk',
       shortcut: {
         title: 'Genveje',
         custom: 'Brugerdefineret',

--- a/web/src/i18n/locales/de.ts
+++ b/web/src/i18n/locales/de.ts
@@ -112,6 +112,7 @@ const de = {
       dropdownGerman: 'Deutsch',
       dropdownFrench: 'Französisch',
       dropdownRussian: 'Russisch',
+      dropdownSpanish: 'Spanisch',
       shortcut: {
         title: 'Verknüpfungen',
         custom: 'Benutzerdefiniert',

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -108,6 +108,7 @@ const en = {
       dropdownGerman: 'German',
       dropdownFrench: 'French',
       dropdownRussian: 'Russian',
+      dropdownSpanish: 'Spanish',
       shortcut: {
         title: 'Shortcuts',
         custom: 'Custom',

--- a/web/src/i18n/locales/es.ts
+++ b/web/src/i18n/locales/es.ts
@@ -110,6 +110,7 @@ const es = {
       dropdownGerman: 'Alemán',
       dropdownFrench: 'Francés',
       dropdownRussian: 'ruso',
+      dropdownSpanish: 'Español',
       shortcut: {
         title: 'Atajos',
         custom: 'Personalizado',

--- a/web/src/i18n/locales/fr.ts
+++ b/web/src/i18n/locales/fr.ts
@@ -112,6 +112,7 @@ const fr = {
       dropdownGerman: 'Allemand',
       dropdownFrench: 'Français',
       dropdownRussian: 'Russe',
+      dropdownSpanish: 'Espagnol',
       shortcut: {
         title: 'Raccourcis',
         custom: 'Personnalisé',

--- a/web/src/i18n/locales/hu.ts
+++ b/web/src/i18n/locales/hu.ts
@@ -111,6 +111,7 @@ const hu = {
       dropdownGerman: 'német',
       dropdownFrench: 'francia',
       dropdownRussian: 'orosz',
+      dropdownSpanish: 'spanyol',
       shortcut: {
         title: 'Parancsikonok',
         custom: 'Egyedi',

--- a/web/src/i18n/locales/id.ts
+++ b/web/src/i18n/locales/id.ts
@@ -109,6 +109,7 @@ const id = {
       dropdownGerman: 'Jerman',
       dropdownFrench: 'Perancis',
       dropdownRussian: 'Rusia',
+      dropdownSpanish: 'Bahasa Spanyol',
       shortcut: {
         title: 'Pintasan',
         custom: 'Adat',

--- a/web/src/i18n/locales/it.ts
+++ b/web/src/i18n/locales/it.ts
@@ -111,6 +111,7 @@ const it = {
       dropdownGerman: 'Tedesco',
       dropdownFrench: 'Francese',
       dropdownRussian: 'Russo',
+      dropdownSpanish: 'Spagnolo',
       shortcut: {
         title: 'Scorciatoie',
         custom: 'Personalizzato',

--- a/web/src/i18n/locales/ja.ts
+++ b/web/src/i18n/locales/ja.ts
@@ -109,6 +109,7 @@ const ja = {
       dropdownGerman: 'ドイツ語',
       dropdownFrench: 'フランス語',
       dropdownRussian: 'ロシア語',
+      dropdownSpanish: 'スペイン語',
       shortcut: {
         title: 'ショートカット',
         custom: 'カスタム',

--- a/web/src/i18n/locales/ko.ts
+++ b/web/src/i18n/locales/ko.ts
@@ -108,6 +108,7 @@ const ko = {
       dropdownGerman: '독일어',
       dropdownFrench: '프랑스어',
       dropdownRussian: '러시아어',
+      dropdownSpanish: '스페인어',
       shortcut: {
         title: '바로가기',
         custom: '관습',

--- a/web/src/i18n/locales/nb.ts
+++ b/web/src/i18n/locales/nb.ts
@@ -110,6 +110,7 @@ const nb = {
       dropdownGerman: 'tysk',
       dropdownFrench: 'Fransk',
       dropdownRussian: 'russisk',
+      dropdownSpanish: 'Spansk',
       shortcut: {
         title: 'Snarveier',
         custom: 'Egendefinert',

--- a/web/src/i18n/locales/nl.ts
+++ b/web/src/i18n/locales/nl.ts
@@ -111,6 +111,7 @@ const nl = {
       dropdownGerman: 'Duits',
       dropdownFrench: 'Frans',
       dropdownRussian: 'Russisch',
+      dropdownSpanish: 'Spaans',
       shortcut: {
         title: 'Snelkoppelingen',
         custom: 'Aangepast',

--- a/web/src/i18n/locales/pl.ts
+++ b/web/src/i18n/locales/pl.ts
@@ -110,6 +110,7 @@ const pl = {
       dropdownGerman: 'niemiecki',
       dropdownFrench: 'Francuski',
       dropdownRussian: 'Rosyjski',
+      dropdownSpanish: 'Hiszpański',
       shortcut: {
         title: 'Skróty',
         custom: 'Niestandardowe',

--- a/web/src/i18n/locales/pt_br.ts
+++ b/web/src/i18n/locales/pt_br.ts
@@ -109,6 +109,7 @@ const pt_br = {
       dropdownGerman: 'Alemão',
       dropdownFrench: 'Francês',
       dropdownRussian: 'Russo',
+      dropdownSpanish: 'Espanhol',
       shortcut: {
         title: 'Atalhos',
         custom: 'Personalizado',

--- a/web/src/i18n/locales/ru.ts
+++ b/web/src/i18n/locales/ru.ts
@@ -109,6 +109,7 @@ const ru = {
       dropdownGerman: 'Немецкий',
       dropdownFrench: 'Французский',
       dropdownRussian: 'Русский',
+      dropdownSpanish: 'Испанский',
       shortcut: {
         title: 'Ярлыки',
         custom: 'Пользовательский',

--- a/web/src/i18n/locales/se.ts
+++ b/web/src/i18n/locales/se.ts
@@ -107,6 +107,7 @@ const se = {
       dropdownGerman: 'Tyska',
       dropdownFrench: 'Franska',
       dropdownRussian: 'ryska',
+      dropdownSpanish: 'Spanska',
       shortcut: {
         title: 'Genvägar',
         custom: 'Anpassad',

--- a/web/src/i18n/locales/th.ts
+++ b/web/src/i18n/locales/th.ts
@@ -107,6 +107,7 @@ const th = {
       dropdownGerman: 'เยอรมัน',
       dropdownFrench: 'ฝรั่งเศส',
       dropdownRussian: 'รัสเซีย',
+      dropdownSpanish: 'ภาษาสเปน',
       shortcut: {
         title: 'ทางลัด',
         custom: 'กำหนดเอง',

--- a/web/src/i18n/locales/tr.ts
+++ b/web/src/i18n/locales/tr.ts
@@ -110,6 +110,7 @@ const tr = {
       dropdownGerman: 'Almanca',
       dropdownFrench: 'Fransızca',
       dropdownRussian: 'Rusça',
+      dropdownSpanish: 'İspanyolca',
       shortcut: {
         title: 'Kısayollar',
         custom: 'Özel',

--- a/web/src/i18n/locales/uk.ts
+++ b/web/src/i18n/locales/uk.ts
@@ -110,6 +110,7 @@ const uk = {
       dropdownGerman: 'нім',
       dropdownFrench: 'французька',
       dropdownRussian: 'рос',
+      dropdownSpanish: 'Іспанська',
       shortcut: {
         title: 'Ярлики',
         custom: 'Custom',

--- a/web/src/i18n/locales/vi.ts
+++ b/web/src/i18n/locales/vi.ts
@@ -109,6 +109,7 @@ const vi = {
       dropdownGerman: 'Tiếng Đức',
       dropdownFrench: 'Tiếng Pháp',
       dropdownRussian: 'Tiếng Nga',
+      dropdownSpanish: 'Tiếng Tây Ban Nha',
       shortcut: {
         title: 'Phím tắt',
         custom: 'Tùy chỉnh',

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -104,6 +104,7 @@ const zh = {
       dropdownGerman: '德语',
       dropdownFrench: '法语',
       dropdownRussian: '俄语',
+      dropdownSpanish: '西班牙语',
       shortcut: {
         title: '快捷键',
         custom: '自定义',

--- a/web/src/i18n/locales/zh_tw.ts
+++ b/web/src/i18n/locales/zh_tw.ts
@@ -104,6 +104,7 @@ const zh_tw = {
       dropdownGerman: '德語',
       dropdownFrench: '法語',
       dropdownRussian: '俄語',
+      dropdownSpanish: '西班牙語',
       shortcut: {
         title: '快捷鍵',
         custom: '自定義',

--- a/web/src/pages/desktop/menu/keyboard/paste.tsx
+++ b/web/src/pages/desktop/menu/keyboard/paste.tsx
@@ -30,7 +30,8 @@ export const Paste = () => {
     { value: 'en', label: t('keyboard.dropdownEnglish') },
     { value: 'de', label: t('keyboard.dropdownGerman') },
     { value: 'fr', label: t('keyboard.dropdownFrench') },
-    { value: 'ru', label: t('keyboard.dropdownRussian') }
+    { value: 'ru', label: t('keyboard.dropdownRussian') },
+    { value: 'es', label: t('keyboard.dropdownSpanish') }
   ];
 
   useEffect(() => {
@@ -163,6 +164,7 @@ export const Paste = () => {
   function isValidForLanguage(value: string, selectedLangue: string) {
     const isRussian = selectedLangue === 'ru';
     const isFrench = selectedLangue === 'fr';
+    const isSpanish = selectedLangue === 'es';
 
     for (const ch of value) {
       const code = ch.codePointAt(0) ?? 0;
@@ -183,11 +185,12 @@ export const Paste = () => {
           continue;
         }
         return false;
-      } else if (isFrench) {
-        // For French, allow ASCII and Latin-1/Extended accented characters
-        // (é è ê ë à â ù û ç î ï ô œ æ ° µ £ § ¨ etc.)
+      } else if (isFrench || isSpanish) {
+        // For French and Spanish, allow ASCII and Latin-1/Extended accented characters
+        // (é è ê ë á é í ó ú ñ Ñ ü Ü ¡ ¿ ° µ £ § ¨ etc.) and € (U+20AC)
         if (code <= 0x7f) continue;
         if (code >= 0x00a0 && code <= 0x017e) continue;
+        if (code === 0x20ac) continue;
         return false;
       } else {
         // For English/German, only allow ASCII


### PR DESCRIPTION
## Summary

This PR adds support for the Spanish (Spain) ISO 105-key keyboard layout to NanoKVM's Paste feature.

The implementation follows the existing language-specific architecture already used for German and French layouts.

### Backend

- Added the Spanish keyboard layout mapping.
- Added support for Spanish dead-key compositions.
- Added support for Spanish AltGr combinations.
- Updated the paste duration calculation to account for continuation key events.

### Frontend

- Added Spanish to the keyboard layout selector.
- Updated validation to accept Spanish-specific characters.

### Localization

- Added the `keyboard.dropdownSpanish` translation to all locale files.

## Notes

The modified `service/hid` package builds successfully for the Linux target.

Manual verification is recommended on a NanoKVM connected to a host using the Spanish (Spain) keyboard layout.