### PR TITLE
Add a compressed swap (zram) toggle and status row to the settings UI

### DIFF
--- a/kvmapp/system/init.d/S01zram
+++ b/kvmapp/system/init.d/S01zram
@@ -26,6 +26,24 @@ ZRAM_MEM_LIMIT=40M
 ZRAM_COMP=lzo-rle
 ZRAM_PRIORITY=100
 
+# Where the modules live, searched in order.
+#
+# /mnt/system/ko is the base image's module directory, where the other modules
+# live and where a pair built by tools/zram/build-modules.sh is installed today.
+#
+# It is searched second, because it does not survive. /mnt is not a mount point.
+# It is a plain directory on the root filesystem, so anything put there by hand
+# is removed by a rootfs update or a re-flash, and this script then reports
+# "FAIL (no zram device)" on a board that had working swap the day before.
+# Nothing else reports the loss: the web UI shows the feature as unavailable
+# rather than broken, which reads like a board that never had it.
+#
+# /kvmapp/system/ko is searched first because it is part of the install package
+# and an update restores it. The modules are not shipped there today, so on a
+# stock device this directory simply has no pair in it and the search falls
+# through. It is first so that shipping them later needs no further change.
+ZRAM_KO_DIRS=${ZRAM_KO_DIRS:-"/kvmapp/system/ko /mnt/system/ko"}
+
 # Swap priority would put zram ahead of the optional swap file on the SD card.
 # On this image it cannot: the BusyBox 1.36.1 applet is built without
 # FEATURE_SWAPON_PRI, so `swapon --help` offers only -a and -e. The -p attempt
@@ -56,6 +74,31 @@ reset_stale_device() {
 	echo 1 > "$ZRAM_SYSFS/reset"
 }
 
+# Insert both modules from the first directory that holds both.
+#
+# The search is per directory rather than per file. zram cannot load without
+# zsmalloc, and a pair split across two directories would be two different
+# builds against the same vermagic, which loads and then behaves unpredictably.
+#
+# zsmalloc goes first because zram resolves its symbols against it. insmod
+# output is discarded: a module that is already in the kernel makes it fail,
+# and that is a success here. The device node is the only thing trusted.
+load_modules() {
+	[ -e "$ZRAM_DEV" ] && return 0
+
+	for dir in $ZRAM_KO_DIRS
+	do
+		[ -f "$dir/zsmalloc.ko" ] && [ -f "$dir/zram.ko" ] || continue
+
+		insmod "$dir/zsmalloc.ko" 2>/dev/null
+		insmod "$dir/zram.ko" 2>/dev/null
+
+		[ -e "$ZRAM_DEV" ] && return 0
+	done
+
+	return 1
+}
+
 swapon_zram() {
 	if swapon -p "$ZRAM_PRIORITY" "$ZRAM_DEV" 2>/dev/null
 	then
@@ -68,13 +111,7 @@ swapon_zram() {
 start() {
 	printf "zram: "
 
-	if [ ! -e "$ZRAM_DEV" ]
-	then
-		insmod /mnt/system/ko/zsmalloc.ko 2>/dev/null
-		insmod /mnt/system/ko/zram.ko 2>/dev/null
-	fi
-
-	if [ ! -e "$ZRAM_DEV" ]
+	if ! load_modules
 	then
 		echo "FAIL (no zram device)"
 		return 1

--- a/kvmapp/system/init.d/S01zram
+++ b/kvmapp/system/init.d/S01zram
@@ -1,0 +1,135 @@
+#!/bin/sh
+#
+# Compressed swap in RAM.
+#
+# A slot that boots from a loop image must not put swap inside that image:
+# swap writeback would route through the loop device, which itself needs memory
+# to make progress. zram avoids that dependency, and also keeps swap off the SD
+# card, which is the boot medium and wears out.
+#
+# There is deliberately no disk swap behind this. The trade is that exceeding
+# zram means the OOM killer rather than slow paging, so mem_limit caps how much
+# RAM zram may consume: it cannot grow into the pressure it exists to relieve.
+#
+# The server installs this as /etc/init.d/S01zram, mode 755, from the zram
+# toggle in Settings > Device > Advanced. Presence in /etc/init.d is what marks
+# the feature as enabled. Shutdown is already covered by the swapoff -a that
+# inittab runs at runlevel 0/6.
+#
+# The list of scripts that kvm_system copies at boot is hard-coded C++, so this
+# one is not in it. The server owns the copy instead.
+
+ZRAM_DEV=/dev/zram0
+ZRAM_SYSFS=/sys/block/zram0
+ZRAM_DISKSIZE=96M
+ZRAM_MEM_LIMIT=40M
+ZRAM_COMP=lzo-rle
+ZRAM_PRIORITY=100
+
+# Swap priority would put zram ahead of the optional swap file on the SD card.
+# On this image it cannot: the BusyBox 1.36.1 applet is built without
+# FEATURE_SWAPON_PRI, so `swapon --help` offers only -a and -e. The -p attempt
+# stays because it is correct on an image that has the feature, and the
+# fallback costs the priority rather than the swap.
+#
+# Boot order does not compensate. The swap file is enabled by a si11::sysinit
+# line that the server appends to /etc/inittab, and BusyBox init runs every
+# sysinit entry before the rcS wait entry that reaches this script. So the swap
+# file is swapped on first and takes the higher priority. Enabling both means
+# the kernel writes to the SD card before it writes to compressed RAM. Prefer
+# one or the other on this board; tools/zram/README.md records the measurement.
+# swapoff removes the device from /proc/swaps but leaves it initialised: it
+# keeps its disksize, and the kernel then rejects a second write to disksize
+# with EBUSY. A reset is what makes disksize writable again.
+#
+# Nothing hit this while the script only ran at boot, because a freshly
+# inserted module reports disksize 0. The toggle in Settings > Device >
+# Advanced stops and starts a live device, and that is the path that needs the
+# repair. The caller has already established that the device is not in
+# /proc/swaps, so the reset cannot take swap away from anything.
+reset_stale_device() {
+	size=$(cat "$ZRAM_SYSFS/disksize" 2>/dev/null || echo 0)
+
+	# No file means no device to repair, and 0 means a fresh module.
+	[ -z "$size" ] || [ "$size" = "0" ] && return 0
+
+	echo 1 > "$ZRAM_SYSFS/reset"
+}
+
+swapon_zram() {
+	if swapon -p "$ZRAM_PRIORITY" "$ZRAM_DEV" 2>/dev/null
+	then
+		return 0
+	fi
+
+	swapon "$ZRAM_DEV"
+}
+
+start() {
+	printf "zram: "
+
+	if [ ! -e "$ZRAM_DEV" ]
+	then
+		insmod /mnt/system/ko/zsmalloc.ko 2>/dev/null
+		insmod /mnt/system/ko/zram.ko 2>/dev/null
+	fi
+
+	if [ ! -e "$ZRAM_DEV" ]
+	then
+		echo "FAIL (no zram device)"
+		return 1
+	fi
+
+	if grep -q "^$ZRAM_DEV " /proc/swaps
+	then
+		echo "already active"
+		return 0
+	fi
+
+	reset_stale_device
+
+	echo "$ZRAM_COMP" > "$ZRAM_SYSFS/comp_algorithm" 2>/dev/null
+	if ! echo "$ZRAM_DISKSIZE" > "$ZRAM_SYSFS/disksize"
+	then
+		echo "FAIL (disksize)"
+		return 1
+	fi
+	# mem_limit is write-only in sysfs: reading it back gives nothing, which
+	# looks identical to it not being set. Field 4 of mm_stat is the real
+	# answer if you need to confirm it took.
+	echo "$ZRAM_MEM_LIMIT" > "$ZRAM_SYSFS/mem_limit" 2>/dev/null
+
+	mkswap "$ZRAM_DEV" > /dev/null 2>&1
+	if ! swapon_zram
+	then
+		echo "FAIL (swapon)"
+		return 1
+	fi
+
+	echo "OK ($ZRAM_DISKSIZE, limit $ZRAM_MEM_LIMIT)"
+}
+
+stop() {
+	if grep -q "^$ZRAM_DEV " /proc/swaps
+	then
+		printf "zram: "
+		swapoff "$ZRAM_DEV" && echo "OK" || echo "FAIL"
+	fi
+}
+
+case "$1" in
+	start)
+		start
+		;;
+	stop)
+		stop
+		;;
+	restart|reload)
+		stop
+		start
+		;;
+	*)
+		echo "Usage: $0 {start|stop|restart}"
+		exit 1
+		;;
+esac

--- a/server/proto/vm.go
+++ b/server/proto/vm.go
@@ -119,6 +119,30 @@ type SetSwapReq struct {
 	Size int64 `validate:"omitempty"` // unit: MB
 }
 
+// GetZramRsp separates three questions that a single on/off flag would merge.
+// Available and Enabled can each be true while the device does not run.
+type GetZramRsp struct {
+	Available bool `json:"available"` // the kernel modules are installed
+	Enabled   bool `json:"enabled"`   // the setting survives a reboot
+	Active    bool `json:"active"`    // compressed swap runs now
+
+	Algorithm  string `json:"algorithm"`
+	DiskSize   int64  `json:"diskSize"`   // unit: bytes
+	Original   int64  `json:"original"`   // unit: bytes, before compression
+	Compressed int64  `json:"compressed"` // unit: bytes, after compression
+	MemUsed    int64  `json:"memUsed"`    // unit: bytes
+	MemLimit   int64  `json:"memLimit"`   // unit: bytes, 0 when unset
+
+	// SwapIn and SwapOut are system-wide page counters. They cover every swap
+	// device, not zram alone, and they do not reset when zram restarts.
+	SwapIn  int64 `json:"swapIn"`
+	SwapOut int64 `json:"swapOut"`
+}
+
+type SetZramReq struct {
+	Enabled bool `validate:"omitempty"`
+}
+
 type GetMouseJigglerRsp struct {
 	Enabled bool   `json:"enabled"`
 	Mode    string `json:"mode"`

--- a/server/router/vm.go
+++ b/server/router/vm.go
@@ -54,6 +54,9 @@ func vmRouter(r *gin.Engine) {
 	admin.GET("/vm/swap", service.GetSwap)  // get swap file size
 	admin.POST("/vm/swap", service.SetSwap) // set swap file size
 
+	admin.GET("/vm/zram", service.GetZram)  // get compressed swap state
+	admin.POST("/vm/zram", service.SetZram) // enable or disable compressed swap
+
 	admin.GET("/vm/mouse-jiggler", service.GetMouseJiggler)   // get mouse jiggler
 	admin.POST("/vm/mouse-jiggler/", service.SetMouseJiggler) // set mouse jiggler
 

--- a/server/service/vm/swap.go
+++ b/server/service/vm/swap.go
@@ -14,10 +14,19 @@ import (
 )
 
 const (
-	SwapFile    = "/swapfile"
 	InittabPath = "/etc/inittab"
 	TempInittab = "/etc/.inittab.tmp"
 )
+
+// SwapFile is a variable rather than a constant so a test can point the
+// service at a temporary file.
+var SwapFile = "/swapfile"
+
+// runShellCommand is the seam the tests replace. Production code runs the
+// command; a test records it, because swapoff on a workstation is destructive.
+var runShellCommand = func(command string) error {
+	return exec.Command("sh", "-c", command).Run()
+}
 
 func (s *Service) GetSwap(c *gin.Context) {
 	var rsp proto.Response
@@ -102,11 +111,27 @@ func enableSwap(size int64) error {
 	return nil
 }
 
+// disableSwap turns off the swap file and deletes it.
+//
+// It names the file rather than using `swapoff -a`. The -a form also stops
+// zram, so every change to the swap file size used to disable compressed swap
+// as a side effect, which is not what a control labelled "swap file size"
+// should do.
 func disableSwap() error {
-	command := "swapoff -a"
-	if err := exec.Command("sh", "-c", command).Run(); err != nil {
-		log.Errorf("failed to execute swapoff: %s", err)
-		return err
+	if _, err := os.Stat(SwapFile); err != nil {
+		// Already disabled. Reporting a failure here would make the Disable
+		// option fail on a device that has no swap file.
+		return nil
+	}
+
+	// swapoff fails on a file that was never swapped on, which happens after a
+	// reboot with no inittab entry. Deleting it is still the right outcome.
+	if parseSwapsHas(readFileString(procSwapsPath), SwapFile) {
+		command := fmt.Sprintf("swapoff %s", SwapFile)
+		if err := runShellCommand(command); err != nil {
+			log.Errorf("failed to execute %s: %s", command, err)
+			return err
+		}
 	}
 
 	if err := os.Remove(SwapFile); err != nil {

--- a/server/service/vm/swap_test.go
+++ b/server/service/vm/swap_test.go
@@ -1,0 +1,126 @@
+package vm
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// useSwapFile points the swap service at a temporary file and captures the
+// shell commands it issues instead of running them. It returns the swap file
+// path and a pointer to the captured commands.
+func useSwapFile(t *testing.T, create bool) (string, *[]string) {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "swapfile")
+	if create {
+		if err := os.WriteFile(path, make([]byte, 64), 0o600); err != nil {
+			t.Fatalf("failed to write swap file: %s", err)
+		}
+	}
+
+	originalFile := SwapFile
+	originalRunner := runShellCommand
+	t.Cleanup(func() {
+		SwapFile = originalFile
+		runShellCommand = originalRunner
+	})
+
+	var commands []string
+	SwapFile = path
+	runShellCommand = func(command string) error {
+		commands = append(commands, command)
+		return nil
+	}
+
+	return path, &commands
+}
+
+// useSwapsFile writes a /proc/swaps stand-in for one test.
+func useSwapsFile(t *testing.T, content string) {
+	t.Helper()
+
+	original := procSwapsPath
+	t.Cleanup(func() {
+		procSwapsPath = original
+	})
+
+	path := filepath.Join(t.TempDir(), "swaps")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write swaps file: %s", err)
+	}
+
+	procSwapsPath = path
+}
+
+func TestDisableSwapNeverTurnsOffEveryDevice(t *testing.T) {
+	// `swapoff -a` also stops zram, so a change to the swap file size used to
+	// disable compressed swap as a side effect. The command must name the file.
+	path, commands := useSwapFile(t, true)
+	useSwapsFile(t, "Filename\tType\tSize\tUsed\tPriority\n"+
+		"/dev/zram0\tpartition\t98300\t3200\t100\n"+
+		path+"\tfile\t262140\t0\t-2\n")
+
+	if err := disableSwap(); err != nil {
+		t.Fatalf("disableSwap() returned %s", err)
+	}
+
+	if len(*commands) != 1 {
+		t.Fatalf("ran %d commands, want 1: %v", len(*commands), *commands)
+	}
+	if got := (*commands)[0]; got != "swapoff "+path {
+		t.Errorf("ran %q, want %q", got, "swapoff "+path)
+	}
+	for _, command := range *commands {
+		if strings.Contains(command, "swapoff -a") {
+			t.Errorf("ran %q, which also stops zram", command)
+		}
+	}
+}
+
+func TestDisableSwapRemovesTheFile(t *testing.T) {
+	path, _ := useSwapFile(t, true)
+	useSwapsFile(t, path+"\tfile\t262140\t0\t-2\n")
+
+	if err := disableSwap(); err != nil {
+		t.Fatalf("disableSwap() returned %s", err)
+	}
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("swap file still exists after disableSwap()")
+	}
+}
+
+func TestDisableSwapSkipsSwapoffForAnInactiveFile(t *testing.T) {
+	// The file exists but was never swapped on, which happens after a reboot
+	// with no inittab entry. swapoff would fail on it, and that failure used
+	// to be hidden by the -a form succeeding on other devices.
+	path, commands := useSwapFile(t, true)
+	useSwapsFile(t, "Filename\tType\tSize\tUsed\tPriority\n")
+
+	if err := disableSwap(); err != nil {
+		t.Fatalf("disableSwap() returned %s", err)
+	}
+
+	if len(*commands) != 0 {
+		t.Errorf("ran %v, want no commands", *commands)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("swap file still exists after disableSwap()")
+	}
+}
+
+func TestDisableSwapSucceedsWithNoSwapFile(t *testing.T) {
+	// Disabling an already disabled device must not report a failure.
+	_, commands := useSwapFile(t, false)
+	useSwapsFile(t, "")
+
+	if err := disableSwap(); err != nil {
+		t.Fatalf("disableSwap() returned %s", err)
+	}
+
+	if len(*commands) != 0 {
+		t.Errorf("ran %v, want no commands", *commands)
+	}
+}

--- a/server/service/vm/zram.go
+++ b/server/service/vm/zram.go
@@ -1,0 +1,365 @@
+package vm
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"NanoKVM-Server/proto"
+
+	"github.com/gin-gonic/gin"
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	// errZramUnavailable means the kernel modules are missing. They are built
+	// out of tree by tools/zram/build-modules.sh and are not part of the
+	// install package, so a device can be perfectly healthy without them.
+	errZramUnavailable = errors.New("zram modules are not installed")
+
+	// errZramStartFailed means the init script ran but produced no device.
+	errZramStartFailed = errors.New("zram did not start")
+)
+
+// zramDevice is the swap device the init script creates. There is only ever
+// one: the script does not configure zram1 and up.
+const zramDevice = "/dev/zram0"
+
+// zramModules are the two modules the device needs. zsmalloc is separate
+// because CONFIG_ZSMALLOC is unset in the stock kernel, so zram cannot pull it
+// from the image. tools/zram/build-modules.sh builds both.
+var zramModules = []string{"zram.ko", "zsmalloc.ko"}
+
+// These are variables rather than constants so a test can point the reader at
+// a temporary tree.
+var (
+	zramModuleDir  = "/mnt/system/ko"
+	zramInitScript = "/etc/init.d/S01zram"
+	zramInitSource = "/kvmapp/system/init.d/S01zram"
+	zramSysfsDir   = "/sys/block/zram0"
+	procSwapsPath  = "/proc/swaps"
+	procVmstatPath = "/proc/vmstat"
+)
+
+// zramStatus separates three questions that a single on/off flag would merge.
+// Available and Enabled can each be true while the device does not run, and
+// those are the states an operator needs to tell apart.
+type zramStatus struct {
+	Available bool // both kernel modules are installed
+	Enabled   bool // the init script is installed, so the setting survives a reboot
+	Active    bool // compressed swap runs now
+
+	Algorithm  string
+	DiskSize   int64
+	Original   int64
+	Compressed int64
+	MemUsed    int64
+	MemLimit   int64
+	SwapIn     int64
+	SwapOut    int64
+}
+
+// readZramStatus reports the current state. It never fails: a board without
+// zram is a normal board, so every unreadable source contributes a zero or a
+// false rather than an error.
+func readZramStatus() zramStatus {
+	status := zramStatus{
+		Available: zramModulesInstalled(),
+		Enabled:   fileExists(zramInitScript),
+		Active:    parseSwapsHasZram(readFileString(procSwapsPath)),
+	}
+
+	status.Algorithm = parseCompAlgorithm(readSysfsAttr("comp_algorithm"))
+	status.DiskSize = parseInt64(readSysfsAttr("disksize"))
+
+	stat := parseMmStat(readSysfsAttr("mm_stat"))
+	status.Original = stat.Original
+	status.Compressed = stat.Compressed
+	status.MemUsed = stat.MemUsed
+	status.MemLimit = stat.MemLimit
+
+	status.SwapIn, status.SwapOut = parseVmstatSwap(readFileString(procVmstatPath))
+
+	return status
+}
+
+// GetZram reports the state of compressed swap. It always succeeds: a board
+// without the kernel modules is a normal board, and a diagnostic that fails
+// the request would tell the operator less than one that reports "unavailable".
+func (s *Service) GetZram(c *gin.Context) {
+	var rsp proto.Response
+
+	status := readZramStatus()
+
+	rsp.OkRspWithData(c, &proto.GetZramRsp{
+		Available:  status.Available,
+		Enabled:    status.Enabled,
+		Active:     status.Active,
+		Algorithm:  status.Algorithm,
+		DiskSize:   status.DiskSize,
+		Original:   status.Original,
+		Compressed: status.Compressed,
+		MemUsed:    status.MemUsed,
+		MemLimit:   status.MemLimit,
+		SwapIn:     status.SwapIn,
+		SwapOut:    status.SwapOut,
+	})
+}
+
+// SetZram turns compressed swap on or off, and makes the choice survive a
+// reboot.
+func (s *Service) SetZram(c *gin.Context) {
+	var rsp proto.Response
+	var req proto.SetZramReq
+
+	if err := proto.ParseFormRequest(c, &req); err != nil {
+		rsp.ErrRsp(c, -1, "invalid arguments")
+		return
+	}
+
+	if req.Enabled {
+		switch err := enableZram(); {
+		case errors.Is(err, errZramUnavailable):
+			rsp.ErrRsp(c, -2, "zram modules are not installed")
+			return
+		case err != nil:
+			rsp.ErrRsp(c, -3, "enable zram failed")
+			return
+		}
+	} else if err := disableZram(); err != nil {
+		rsp.ErrRsp(c, -4, "disable zram failed")
+		return
+	}
+
+	rsp.OkRsp(c)
+}
+
+// enableZram installs the init script and starts compressed swap.
+//
+// The script is what makes the setting survive a reboot, so it is removed
+// again if the device does not come up. An installed script beside a dead
+// device would report "survives a reboot" for a feature that does not run.
+func enableZram() error {
+	if !zramModulesInstalled() {
+		log.Errorf("zram modules are not installed in %s", zramModuleDir)
+		return errZramUnavailable
+	}
+
+	if err := installZramInitScript(); err != nil {
+		return err
+	}
+
+	command := zramInitScript + " start"
+	if err := runShellCommand(command); err != nil {
+		log.Errorf("failed to execute %s: %s", command, err)
+		_ = os.Remove(zramInitScript)
+		return err
+	}
+
+	if !parseSwapsHasZram(readFileString(procSwapsPath)) {
+		log.Errorf("%s reported success but %s is not in %s",
+			command, zramDevice, procSwapsPath)
+		_ = os.Remove(zramInitScript)
+		return errZramStartFailed
+	}
+
+	return nil
+}
+
+// disableZram stops compressed swap and removes the init script. It succeeds
+// on a device where zram was never enabled.
+func disableZram() error {
+	switch {
+	case fileExists(zramInitScript):
+		command := zramInitScript + " stop"
+		if err := runShellCommand(command); err != nil {
+			log.Errorf("failed to execute %s: %s", command, err)
+			return err
+		}
+
+	case parseSwapsHasZram(readFileString(procSwapsPath)):
+		// The script was never installed, but someone started zram by hand.
+		// There is nothing to remove and the device must still stop.
+		command := "swapoff " + zramDevice
+		if err := runShellCommand(command); err != nil {
+			log.Errorf("failed to execute %s: %s", command, err)
+			return err
+		}
+	}
+
+	if err := os.Remove(zramInitScript); err != nil && !os.IsNotExist(err) {
+		log.Errorf("failed to delete %s: %s", zramInitScript, err)
+		return err
+	}
+
+	return nil
+}
+
+// installZramInitScript copies the packaged script into /etc/init.d.
+//
+// The list of scripts that kvm_system copies at boot is hard-coded C++, so
+// adding one there would need a MaixCDK rebuild and a redeploy on every
+// device. The server installs this one instead, the way S98tailscaled already
+// treats presence in /etc/init.d as the installed marker.
+func installZramInitScript() error {
+	content, err := os.ReadFile(zramInitSource)
+	if err != nil {
+		log.Errorf("failed to read %s: %s", zramInitSource, err)
+		return err
+	}
+
+	// The mode matters: a script that is not executable never runs at boot,
+	// and the failure only appears after a reboot.
+	if err := os.WriteFile(zramInitScript, content, 0o755); err != nil {
+		log.Errorf("failed to write %s: %s", zramInitScript, err)
+		return err
+	}
+
+	// WriteFile does not change the mode of a file that already exists.
+	if err := os.Chmod(zramInitScript, 0o755); err != nil {
+		log.Errorf("failed to chmod %s: %s", zramInitScript, err)
+		return err
+	}
+
+	return nil
+}
+
+// zramModulesInstalled reports whether every module is present. One of the two
+// on its own cannot load, so a partial installation counts as unavailable.
+func zramModulesInstalled() bool {
+	for _, module := range zramModules {
+		if !fileExists(filepath.Join(zramModuleDir, module)) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func readSysfsAttr(name string) string {
+	return readFileString(filepath.Join(zramSysfsDir, name))
+}
+
+// readFileString returns the contents of a file, or an empty string when it
+// cannot be read. Absence is the expected case here, not a fault worth logging.
+func readFileString(path string) string {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+
+	return string(content)
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func parseInt64(content string) int64 {
+	value, err := strconv.ParseInt(strings.TrimSpace(content), 10, 64)
+	if err != nil {
+		return 0
+	}
+
+	return value
+}
+
+// zramMmStat holds the four fields of /sys/block/zram0/mm_stat that this
+// service reports. mem_limit is write-only in sysfs, so field 4 here is the
+// only way to read back what the init script set.
+type zramMmStat struct {
+	Original   int64 // orig_data_size: bytes before compression
+	Compressed int64 // compr_data_size: bytes after compression
+	MemUsed    int64 // mem_used_total: RAM zram holds, including its own overhead
+	MemLimit   int64 // mem_limit: the cap on MemUsed, 0 when unset
+}
+
+// parseMmStat reads the leading fields of an mm_stat line. A device that is
+// absent, empty or truncated is a normal state on a board where zram is
+// optional, so every unreadable field stays zero instead of raising an error.
+func parseMmStat(content string) zramMmStat {
+	var stat zramMmStat
+	targets := []*int64{&stat.Original, &stat.Compressed, &stat.MemUsed, &stat.MemLimit}
+
+	for i, field := range strings.Fields(content) {
+		if i >= len(targets) {
+			break
+		}
+
+		value, err := strconv.ParseInt(field, 10, 64)
+		if err != nil {
+			// The fields before this one are still trustworthy; the ones
+			// after cannot be trusted to be in the position we expect.
+			break
+		}
+
+		*targets[i] = value
+	}
+
+	return stat
+}
+
+// parseCompAlgorithm returns the selected entry of a comp_algorithm list, which
+// sysfs marks with square brackets: "lzo [lzo-rle] zstd". The list has no
+// selection until disksize is set, and an empty result reports that honestly.
+func parseCompAlgorithm(content string) string {
+	open := strings.Index(content, "[")
+	if open < 0 {
+		return ""
+	}
+
+	closing := strings.Index(content[open:], "]")
+	if closing < 0 {
+		return ""
+	}
+
+	return content[open+1 : open+closing]
+}
+
+// parseVmstatSwap reads the pswpin and pswpout counters from /proc/vmstat.
+// Both are system-wide and cover every swap device, not zram alone.
+func parseVmstatSwap(content string) (in int64, out int64) {
+	for _, line := range strings.Split(content, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+
+		value, err := strconv.ParseInt(fields[1], 10, 64)
+		if err != nil {
+			continue
+		}
+
+		switch fields[0] {
+		case "pswpin":
+			in = value
+		case "pswpout":
+			out = value
+		}
+	}
+
+	return in, out
+}
+
+// parseSwapsHasZram reports whether /proc/swaps lists the zram device. This is
+// the runtime truth: it is true only while compressed swap actually runs.
+func parseSwapsHasZram(content string) bool {
+	return parseSwapsHas(content, zramDevice)
+}
+
+// parseSwapsHas reports whether /proc/swaps lists one device. It compares the
+// whole first field, because a substring test would match /dev/zram01 against
+// /dev/zram0.
+func parseSwapsHas(content string, device string) bool {
+	for _, line := range strings.Split(content, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) > 0 && fields[0] == device {
+			return true
+		}
+	}
+
+	return false
+}

--- a/server/service/vm/zram.go
+++ b/server/service/vm/zram.go
@@ -32,10 +32,25 @@ const zramDevice = "/dev/zram0"
 // from the image. tools/zram/build-modules.sh builds both.
 var zramModules = []string{"zram.ko", "zsmalloc.ko"}
 
+// zramModuleDirs are searched in order for the pair of modules.
+//
+// /mnt/system/ko is the base image's module directory and is where
+// tools/zram/build-modules.sh installs the pair today. It is searched second,
+// because /mnt is not a mount point: it is a plain directory on the root
+// filesystem, so a rootfs update or a re-flash removes anything put there and
+// the feature reverts to unavailable without reporting a fault.
+//
+// /kvmapp/system/ko is part of the install package, which an update restores.
+// The modules are not shipped there today, so on a stock device it holds no
+// pair and the search falls through. It is first so that shipping them later
+// needs no further change.
+//
+// S01zram searches the same two directories in the same order.
+var zramModuleDirs = []string{"/kvmapp/system/ko", "/mnt/system/ko"}
+
 // These are variables rather than constants so a test can point the reader at
 // a temporary tree.
 var (
-	zramModuleDir  = "/mnt/system/ko"
 	zramInitScript = "/etc/init.d/S01zram"
 	zramInitSource = "/kvmapp/system/init.d/S01zram"
 	zramSysfsDir   = "/sys/block/zram0"
@@ -143,7 +158,7 @@ func (s *Service) SetZram(c *gin.Context) {
 // device would report "survives a reboot" for a feature that does not run.
 func enableZram() error {
 	if !zramModulesInstalled() {
-		log.Errorf("zram modules are not installed in %s", zramModuleDir)
+		log.Errorf("zram modules are not installed in any of %s", strings.Join(zramModuleDirs, ", "))
 		return errZramUnavailable
 	}
 
@@ -226,16 +241,35 @@ func installZramInitScript() error {
 	return nil
 }
 
-// zramModulesInstalled reports whether every module is present. One of the two
-// on its own cannot load, so a partial installation counts as unavailable.
-func zramModulesInstalled() bool {
-	for _, module := range zramModules {
-		if !fileExists(filepath.Join(zramModuleDir, module)) {
-			return false
+// zramModuleDir returns the first directory that holds every module, or an
+// empty string when no directory holds a complete set.
+//
+// A directory has to hold both. One of the two on its own cannot load, and a
+// pair split across two directories would be two separate builds: they carry
+// the same vermagic, so the kernel accepts them, and zram then resolves its
+// symbols against a zsmalloc it was not compiled with.
+func zramModuleDir() string {
+	for _, dir := range zramModuleDirs {
+		complete := true
+
+		for _, module := range zramModules {
+			if !fileExists(filepath.Join(dir, module)) {
+				complete = false
+				break
+			}
+		}
+
+		if complete {
+			return dir
 		}
 	}
 
-	return true
+	return ""
+}
+
+// zramModulesInstalled reports whether a complete pair of modules is present.
+func zramModulesInstalled() bool {
+	return zramModuleDir() != ""
 }
 
 func readSysfsAttr(name string) string {

--- a/server/service/vm/zram_test.go
+++ b/server/service/vm/zram_test.go
@@ -10,7 +10,12 @@ import (
 // zramPaths collects the temporary files that stand in for the device's real
 // ones during a test.
 type zramPaths struct {
-	moduleDir  string
+	// moduleDir stands in for /kvmapp/system/ko, which the install package
+	// restores on an update. fallbackDir stands in for /mnt/system/ko, the
+	// base image directory where a pair installed by hand lands today.
+	moduleDir   string
+	fallbackDir string
+
 	initScript string
 	initSource string
 	sysfsDir   string
@@ -29,7 +34,9 @@ func useZramPaths(t *testing.T) zramPaths {
 	root := t.TempDir()
 	var commands []string
 	paths := zramPaths{
-		moduleDir:  filepath.Join(root, "ko"),
+		moduleDir:   filepath.Join(root, "kvmapp", "ko"),
+		fallbackDir: filepath.Join(root, "mnt", "ko"),
+
 		initScript: filepath.Join(root, "init.d", "S01zram"),
 		initSource: filepath.Join(root, "kvmapp", "S01zram"),
 		sysfsDir:   filepath.Join(root, "sys", "zram0"),
@@ -38,29 +45,31 @@ func useZramPaths(t *testing.T) zramPaths {
 		commands:   &commands,
 	}
 
-	for _, dir := range []string{paths.moduleDir, filepath.Dir(paths.initScript)} {
+	for _, dir := range []string{paths.moduleDir, paths.fallbackDir, filepath.Dir(paths.initScript)} {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatalf("failed to create %s: %s", dir, err)
 		}
 	}
 
 	original := []*string{
-		&zramModuleDir, &zramInitScript, &zramInitSource,
+		&zramInitScript, &zramInitSource,
 		&zramSysfsDir, &procSwapsPath, &procVmstatPath,
 	}
 	saved := make([]string, len(original))
 	for i, p := range original {
 		saved[i] = *p
 	}
+	savedDirs := zramModuleDirs
 	originalRunner := runShellCommand
 	t.Cleanup(func() {
 		for i, p := range original {
 			*p = saved[i]
 		}
+		zramModuleDirs = savedDirs
 		runShellCommand = originalRunner
 	})
 
-	zramModuleDir = paths.moduleDir
+	zramModuleDirs = []string{paths.moduleDir, paths.fallbackDir}
 	zramInitScript = paths.initScript
 	zramInitSource = paths.initSource
 	zramSysfsDir = paths.sysfsDir
@@ -174,6 +183,72 @@ func TestReadZramStatusNeedsBothModules(t *testing.T) {
 				t.Errorf("available = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// The modules used to be read from /mnt/system/ko alone. /mnt is a plain
+// directory on the root filesystem, not a mount point, so a rootfs update
+// removes a pair installed there and the board runs with no swap until
+// somebody reads /bootlog. /kvmapp/system/ko is part of the install package
+// and is searched first, so modules placed there survive an update.
+func TestReadZramStatusFindsModulesInEitherDirectory(t *testing.T) {
+	tests := []struct {
+		name    string
+		install func(t *testing.T, p zramPaths)
+		want    bool
+	}{
+		{
+			name: "install package only",
+			install: func(t *testing.T, p zramPaths) {
+				p.writeFile(t, filepath.Join(p.moduleDir, "zram.ko"), "")
+				p.writeFile(t, filepath.Join(p.moduleDir, "zsmalloc.ko"), "")
+			},
+			want: true,
+		},
+		{
+			name: "hand-installed pair only",
+			install: func(t *testing.T, p zramPaths) {
+				p.writeFile(t, filepath.Join(p.fallbackDir, "zram.ko"), "")
+				p.writeFile(t, filepath.Join(p.fallbackDir, "zsmalloc.ko"), "")
+			},
+			want: true,
+		},
+		{
+			// A pair split across two directories is two different builds.
+			// Loading one of each is how a board gets a module that resolves
+			// its symbols against the wrong copy, so neither directory counts.
+			name: "one module in each directory",
+			install: func(t *testing.T, p zramPaths) {
+				p.writeFile(t, filepath.Join(p.moduleDir, "zram.ko"), "")
+				p.writeFile(t, filepath.Join(p.fallbackDir, "zsmalloc.ko"), "")
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			paths := useZramPaths(t)
+			tt.install(t, paths)
+
+			if got := readZramStatus().Available; got != tt.want {
+				t.Errorf("available = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// The install package copy is the one an image build refreshes, so it is the
+// one that matches the rest of the installed firmware.
+func TestZramModuleDirPrefersTheInstallPackage(t *testing.T) {
+	paths := useZramPaths(t)
+	for _, dir := range []string{paths.moduleDir, paths.fallbackDir} {
+		paths.writeFile(t, filepath.Join(dir, "zram.ko"), "")
+		paths.writeFile(t, filepath.Join(dir, "zsmalloc.ko"), "")
+	}
+
+	if got := zramModuleDir(); got != paths.moduleDir {
+		t.Errorf("zramModuleDir() = %q, want %q", got, paths.moduleDir)
 	}
 }
 

--- a/server/service/vm/zram_test.go
+++ b/server/service/vm/zram_test.go
@@ -1,0 +1,592 @@
+package vm
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// zramPaths collects the temporary files that stand in for the device's real
+// ones during a test.
+type zramPaths struct {
+	moduleDir  string
+	initScript string
+	initSource string
+	sysfsDir   string
+	swaps      string
+	vmstat     string
+
+	// commands records what the service would have run on the device.
+	commands *[]string
+}
+
+// useZramPaths points the zram service at a temporary tree for one test. The
+// tree starts empty, which is a board that has never had zram installed.
+func useZramPaths(t *testing.T) zramPaths {
+	t.Helper()
+
+	root := t.TempDir()
+	var commands []string
+	paths := zramPaths{
+		moduleDir:  filepath.Join(root, "ko"),
+		initScript: filepath.Join(root, "init.d", "S01zram"),
+		initSource: filepath.Join(root, "kvmapp", "S01zram"),
+		sysfsDir:   filepath.Join(root, "sys", "zram0"),
+		swaps:      filepath.Join(root, "swaps"),
+		vmstat:     filepath.Join(root, "vmstat"),
+		commands:   &commands,
+	}
+
+	for _, dir := range []string{paths.moduleDir, filepath.Dir(paths.initScript)} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("failed to create %s: %s", dir, err)
+		}
+	}
+
+	original := []*string{
+		&zramModuleDir, &zramInitScript, &zramInitSource,
+		&zramSysfsDir, &procSwapsPath, &procVmstatPath,
+	}
+	saved := make([]string, len(original))
+	for i, p := range original {
+		saved[i] = *p
+	}
+	originalRunner := runShellCommand
+	t.Cleanup(func() {
+		for i, p := range original {
+			*p = saved[i]
+		}
+		runShellCommand = originalRunner
+	})
+
+	zramModuleDir = paths.moduleDir
+	zramInitScript = paths.initScript
+	zramInitSource = paths.initSource
+	zramSysfsDir = paths.sysfsDir
+	procSwapsPath = paths.swaps
+	procVmstatPath = paths.vmstat
+	runShellCommand = func(command string) error {
+		commands = append(commands, command)
+		return nil
+	}
+
+	// A device with no swap at all is the starting point.
+	paths.writeFile(t, paths.swaps, "Filename\tType\tSize\tUsed\tPriority\n")
+	paths.writeFile(t, paths.initSource, "#!/bin/sh\n# S01zram\n")
+
+	return paths
+}
+
+// startSucceeds makes the fake runner behave like an init script that brings
+// the device up: `start` puts zram into /proc/swaps and `stop` takes it out.
+func (p zramPaths) startSucceeds(t *testing.T) {
+	t.Helper()
+
+	runShellCommand = func(command string) error {
+		*p.commands = append(*p.commands, command)
+
+		switch {
+		case strings.HasSuffix(command, " start"):
+			p.activate(t)
+		case strings.HasSuffix(command, " stop"), strings.HasPrefix(command, "swapoff "):
+			p.writeFile(t, p.swaps, "Filename\tType\tSize\tUsed\tPriority\n")
+		}
+
+		return nil
+	}
+}
+
+// writeFile creates one file inside the temporary tree.
+func (p zramPaths) writeFile(t *testing.T, path string, content string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("failed to create %s: %s", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write %s: %s", path, err)
+	}
+}
+
+// installModules writes both kernel modules, which is what makes zram
+// available.
+func (p zramPaths) installModules(t *testing.T) {
+	t.Helper()
+
+	p.writeFile(t, filepath.Join(p.moduleDir, "zram.ko"), "")
+	p.writeFile(t, filepath.Join(p.moduleDir, "zsmalloc.ko"), "")
+}
+
+// activate writes the sysfs and /proc state of a running zram device.
+func (p zramPaths) activate(t *testing.T) {
+	t.Helper()
+
+	p.writeFile(t, filepath.Join(p.sysfsDir, "disksize"), "100663296\n")
+	p.writeFile(t, filepath.Join(p.sysfsDir, "comp_algorithm"), "lzo [lzo-rle] zstd\n")
+	p.writeFile(t, filepath.Join(p.sysfsDir, "mm_stat"),
+		"3366912  1220608  1708032 41943040  1708032      512        0        0\n")
+	p.writeFile(t, p.swaps,
+		"Filename\t\t\t\tType\t\tSize\tUsed\tPriority\n"+
+			"/dev/zram0                              partition\t98300\t3200\t100\n")
+	p.writeFile(t, p.vmstat, "pswpin 6503\npswpout 40449\n")
+}
+
+func TestReadZramStatusOnABareBoard(t *testing.T) {
+	useZramPaths(t)
+
+	status := readZramStatus()
+
+	if status.Available {
+		t.Error("available = true with no modules installed")
+	}
+	if status.Enabled {
+		t.Error("enabled = true with no init script")
+	}
+	if status.Active {
+		t.Error("active = true with no swap device")
+	}
+	if status.DiskSize != 0 || status.Original != 0 || status.MemLimit != 0 {
+		t.Errorf("expected zero sizes, got %+v", status)
+	}
+}
+
+func TestReadZramStatusNeedsBothModules(t *testing.T) {
+	tests := []struct {
+		name    string
+		present []string
+		want    bool
+	}{
+		{name: "neither module", present: nil, want: false},
+		{name: "only zram.ko", present: []string{"zram.ko"}, want: false},
+		{name: "only zsmalloc.ko", present: []string{"zsmalloc.ko"}, want: false},
+		{name: "both modules", present: []string{"zram.ko", "zsmalloc.ko"}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			paths := useZramPaths(t)
+			for _, module := range tt.present {
+				paths.writeFile(t, filepath.Join(paths.moduleDir, module), "")
+			}
+
+			if got := readZramStatus().Available; got != tt.want {
+				t.Errorf("available = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReadZramStatusReportsRunningDevice(t *testing.T) {
+	paths := useZramPaths(t)
+	paths.installModules(t)
+	paths.writeFile(t, paths.initScript, "#!/bin/sh\n")
+	paths.activate(t)
+
+	status := readZramStatus()
+
+	if !status.Available || !status.Enabled || !status.Active {
+		t.Fatalf("expected all three flags true, got %+v", status)
+	}
+	if status.Algorithm != "lzo-rle" {
+		t.Errorf("algorithm = %q, want %q", status.Algorithm, "lzo-rle")
+	}
+	if status.DiskSize != 100663296 {
+		t.Errorf("diskSize = %d, want 100663296", status.DiskSize)
+	}
+	if status.Original != 3366912 || status.Compressed != 1220608 {
+		t.Errorf("got original=%d compressed=%d, want 3366912 and 1220608",
+			status.Original, status.Compressed)
+	}
+	if status.MemUsed != 1708032 || status.MemLimit != 41943040 {
+		t.Errorf("got memUsed=%d memLimit=%d, want 1708032 and 41943040",
+			status.MemUsed, status.MemLimit)
+	}
+	if status.SwapIn != 6503 || status.SwapOut != 40449 {
+		t.Errorf("got swapIn=%d swapOut=%d, want 6503 and 40449",
+			status.SwapIn, status.SwapOut)
+	}
+}
+
+func TestReadZramStatusEnabledButNotActive(t *testing.T) {
+	// The init script is installed, so the setting survives a reboot, but the
+	// device did not come up. This is the state a single on/off flag would
+	// hide, and the one an operator most needs to see.
+	paths := useZramPaths(t)
+	paths.installModules(t)
+	paths.writeFile(t, paths.initScript, "#!/bin/sh\n")
+
+	status := readZramStatus()
+
+	if !status.Enabled {
+		t.Error("enabled = false with the init script installed")
+	}
+	if status.Active {
+		t.Error("active = true with no device in /proc/swaps")
+	}
+}
+
+func TestEnableZramRefusesWithoutModules(t *testing.T) {
+	paths := useZramPaths(t)
+
+	if err := enableZram(); err == nil {
+		t.Fatal("enableZram() succeeded with no modules installed")
+	}
+
+	if fileExists(paths.initScript) {
+		t.Error("the init script was installed anyway")
+	}
+	if len(*paths.commands) != 0 {
+		t.Errorf("ran %v, want no commands", *paths.commands)
+	}
+}
+
+func TestEnableZramInstallsTheScriptAndStartsIt(t *testing.T) {
+	paths := useZramPaths(t)
+	paths.installModules(t)
+	paths.startSucceeds(t)
+
+	if err := enableZram(); err != nil {
+		t.Fatalf("enableZram() returned %s", err)
+	}
+
+	info, err := os.Stat(paths.initScript)
+	if err != nil {
+		t.Fatalf("the init script was not installed: %s", err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o755 {
+		// An init script that is not executable never runs at boot, and the
+		// failure appears only after a reboot.
+		t.Errorf("init script mode = %o, want 755", mode)
+	}
+
+	installed, err := os.ReadFile(paths.initScript)
+	if err != nil {
+		t.Fatalf("cannot read the installed script: %s", err)
+	}
+	source, err := os.ReadFile(paths.initSource)
+	if err != nil {
+		t.Fatalf("cannot read the source script: %s", err)
+	}
+	if string(installed) != string(source) {
+		t.Error("the installed script does not match the packaged one")
+	}
+
+	want := paths.initScript + " start"
+	if len(*paths.commands) != 1 || (*paths.commands)[0] != want {
+		t.Errorf("ran %v, want [%q]", *paths.commands, want)
+	}
+}
+
+func TestEnableZramRollsBackWhenTheDeviceDoesNotCome(t *testing.T) {
+	// The default runner records the command without activating anything, so
+	// this is a start that reports success and leaves no swap device.
+	paths := useZramPaths(t)
+	paths.installModules(t)
+
+	if err := enableZram(); err == nil {
+		t.Fatal("enableZram() succeeded with no device in /proc/swaps")
+	}
+
+	if fileExists(paths.initScript) {
+		// Leaving it installed would report "survives a reboot" for a feature
+		// that does not run.
+		t.Error("the init script survived a failed start")
+	}
+}
+
+func TestEnableZramIsIdempotent(t *testing.T) {
+	paths := useZramPaths(t)
+	paths.installModules(t)
+	paths.startSucceeds(t)
+
+	if err := enableZram(); err != nil {
+		t.Fatalf("first enableZram() returned %s", err)
+	}
+	if err := enableZram(); err != nil {
+		t.Fatalf("second enableZram() returned %s", err)
+	}
+
+	status := readZramStatus()
+	if !status.Enabled || !status.Active {
+		t.Errorf("expected enabled and active, got %+v", status)
+	}
+}
+
+func TestDisableZramStopsAndRemovesTheScript(t *testing.T) {
+	paths := useZramPaths(t)
+	paths.installModules(t)
+	paths.startSucceeds(t)
+	if err := enableZram(); err != nil {
+		t.Fatalf("enableZram() returned %s", err)
+	}
+	*paths.commands = nil
+
+	if err := disableZram(); err != nil {
+		t.Fatalf("disableZram() returned %s", err)
+	}
+
+	if fileExists(paths.initScript) {
+		t.Error("the init script is still installed")
+	}
+	want := paths.initScript + " stop"
+	if len(*paths.commands) != 1 || (*paths.commands)[0] != want {
+		t.Errorf("ran %v, want [%q]", *paths.commands, want)
+	}
+	if readZramStatus().Active {
+		t.Error("the device is still active")
+	}
+}
+
+func TestDisableZramSucceedsWhenNothingIsInstalled(t *testing.T) {
+	paths := useZramPaths(t)
+
+	if err := disableZram(); err != nil {
+		t.Fatalf("disableZram() returned %s", err)
+	}
+
+	if len(*paths.commands) != 0 {
+		t.Errorf("ran %v, want no commands", *paths.commands)
+	}
+}
+
+func TestDisableZramStopsAHandStartedDevice(t *testing.T) {
+	// Someone ran the script by hand and never installed it. There is nothing
+	// to remove, but the device must still stop.
+	paths := useZramPaths(t)
+	paths.installModules(t)
+	paths.startSucceeds(t)
+	paths.activate(t)
+
+	if err := disableZram(); err != nil {
+		t.Fatalf("disableZram() returned %s", err)
+	}
+
+	want := "swapoff " + zramDevice
+	if len(*paths.commands) != 1 || (*paths.commands)[0] != want {
+		t.Errorf("ran %v, want [%q]", *paths.commands, want)
+	}
+	if readZramStatus().Active {
+		t.Error("the device is still active")
+	}
+}
+
+func TestReadZramStatusActiveButNotEnabled(t *testing.T) {
+	// Someone ran the init script by hand without installing it. zram runs
+	// now and will be gone after a reboot.
+	paths := useZramPaths(t)
+	paths.installModules(t)
+	paths.activate(t)
+
+	status := readZramStatus()
+
+	if status.Enabled {
+		t.Error("enabled = true with no init script installed")
+	}
+	if !status.Active {
+		t.Error("active = false with the device in /proc/swaps")
+	}
+}
+
+func TestParseMmStat(t *testing.T) {
+	tests := []struct {
+		name       string
+		content    string
+		original   int64
+		compressed int64
+		memUsed    int64
+		memLimit   int64
+	}{
+		{
+			name:       "a live device",
+			content:    "3366912  1220608  1708032 41943040  1708032      512        0        0\n",
+			original:   3366912,
+			compressed: 1220608,
+			memUsed:    1708032,
+			memLimit:   41943040,
+		},
+		{
+			name:    "an idle device reports zeros",
+			content: "0 0 0 41943040 0 0 0 0\n",
+			// A device with nothing swapped out still reports its limit.
+			memLimit: 41943040,
+		},
+		{
+			name:       "no trailing newline",
+			content:    "4096 1024 8192 0 8192 0 0 0",
+			original:   4096,
+			compressed: 1024,
+			memUsed:    8192,
+		},
+		{
+			name: "a short line yields what it has",
+			// mem_limit is absent, so it stays zero rather than reading a
+			// neighbouring field.
+			content:    "4096 1024 8192",
+			original:   4096,
+			compressed: 1024,
+			memUsed:    8192,
+		},
+		{
+			name:    "a non-numeric field stops the parse",
+			content: "4096 bogus 8192 16384",
+			// The fields before the bad one are still trustworthy.
+			original: 4096,
+		},
+		{
+			name:    "an empty file yields zeros",
+			content: "",
+		},
+		{
+			name:    "whitespace only yields zeros",
+			content: "   \n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stat := parseMmStat(tt.content)
+
+			if stat.Original != tt.original {
+				t.Errorf("original = %d, want %d", stat.Original, tt.original)
+			}
+			if stat.Compressed != tt.compressed {
+				t.Errorf("compressed = %d, want %d", stat.Compressed, tt.compressed)
+			}
+			if stat.MemUsed != tt.memUsed {
+				t.Errorf("memUsed = %d, want %d", stat.MemUsed, tt.memUsed)
+			}
+			if stat.MemLimit != tt.memLimit {
+				t.Errorf("memLimit = %d, want %d", stat.MemLimit, tt.memLimit)
+			}
+		})
+	}
+}
+
+func TestParseCompAlgorithm(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "the active algorithm is the bracketed one",
+			content: "lzo [lzo-rle] zstd\n",
+			want:    "lzo-rle",
+		},
+		{
+			name:    "the first entry can be the active one",
+			content: "[lzo] lzo-rle zstd\n",
+			want:    "lzo",
+		},
+		{
+			name:    "the last entry can be the active one",
+			content: "lzo lzo-rle [zstd]",
+			want:    "zstd",
+		},
+		{
+			name: "no brackets means no algorithm is selected yet",
+			// Reading comp_algorithm before disksize is set gives an
+			// unbracketed list. Reporting a guess here would be a lie.
+			content: "lzo lzo-rle zstd\n",
+			want:    "",
+		},
+		{
+			name:    "an empty file yields nothing",
+			content: "",
+			want:    "",
+		},
+		{
+			name:    "an unterminated bracket yields nothing",
+			content: "lzo [lzo-rle zstd",
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseCompAlgorithm(tt.content); got != tt.want {
+				t.Errorf("parseCompAlgorithm() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseVmstatSwap(t *testing.T) {
+	const vmstat = `nr_free_pages 8231
+pgpgin 1359382
+pswpin 6503
+pswpout 40449
+pgmajfault 4213
+`
+
+	t.Run("reads both counters", func(t *testing.T) {
+		in, out := parseVmstatSwap(vmstat)
+		if in != 6503 {
+			t.Errorf("swap in = %d, want 6503", in)
+		}
+		if out != 40449 {
+			t.Errorf("swap out = %d, want 40449", out)
+		}
+	})
+
+	t.Run("absent counters read as zero", func(t *testing.T) {
+		in, out := parseVmstatSwap("nr_free_pages 8231\n")
+		if in != 0 || out != 0 {
+			t.Errorf("got in=%d out=%d, want 0 and 0", in, out)
+		}
+	})
+
+	t.Run("a prefix match is not a match", func(t *testing.T) {
+		// pswpin_something must not be read as pswpin.
+		in, out := parseVmstatSwap("pswpin_bogus 99\npswpout_bogus 98\n")
+		if in != 0 || out != 0 {
+			t.Errorf("got in=%d out=%d, want 0 and 0", in, out)
+		}
+	})
+}
+
+func TestParseSwapsHasZram(t *testing.T) {
+	const header = "Filename\t\t\t\tType\t\tSize\tUsed\tPriority\n"
+
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name:    "zram is listed",
+			content: header + "/dev/zram0                              partition\t98300\t3200\t100\n",
+			want:    true,
+		},
+		{
+			name:    "only a swap file is listed",
+			content: header + "/swapfile                               file\t\t262140\t0\t-2\n",
+			want:    false,
+		},
+		{
+			name:    "no swap at all",
+			content: header,
+			want:    false,
+		},
+		{
+			name: "a longer device name is not zram0",
+			// /dev/zram01 would match a naive substring test.
+			content: header + "/dev/zram01                             partition\t98300\t0\t-2\n",
+			want:    false,
+		},
+		{
+			name:    "an empty file",
+			content: "",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseSwapsHasZram(tt.content); got != tt.want {
+				t.Errorf("parseSwapsHasZram() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/tools/zram/Dockerfile
+++ b/tools/zram/Dockerfile
@@ -1,0 +1,43 @@
+# Build environment for the out-of-tree zram modules.
+#
+#   docker build -t nanokvm-zram-builder tools/zram
+#
+# build-modules.sh needs three things: the cross-compiler that built the device
+# kernel, the host packages a 5.10 tree needs to configure and link a module,
+# and modinfo to read the vermagic back out.
+#
+# The toolchain is the same host-tools archive that docker/Dockerfile installs,
+# so the modules are built by the compiler the kernel was built with. This image
+# is separate from that one because it needs the kernel build packages and none
+# of the MaixCDK stage, and because a module build is rare: only a kernel move
+# requires it.
+#
+# The kernel tree does not belong on a Windows filesystem. Checking out
+# linux_5.10 there fails outright, because the tree carries paths Windows
+# refuses. Keep the source in a named volume, as tools/zram/README.md shows.
+FROM ubuntu:24.04
+
+ARG HOST_TOOLS_URL=https://sophon-file.sophon.cn/sophon-prod-s3/drive/23/03/07/16/host-tools.tar.gz
+
+# gcc-12 is here because the host half of a 5.10 build does not compile clean
+# under this image's default gcc-13. Only scripts/ and the module linker run on
+# the host; the modules themselves are built by the cross-compiler, so the host
+# compiler version cannot reach the artefact.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        wget ca-certificates git build-essential \
+        bc bison flex libssl-dev libelf-dev kmod cpio rsync python3 \
+        gcc-12 g++-12 \
+    && rm -rf /var/lib/apt/lists/* \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 100 \
+    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 100
+
+RUN wget -q -O /tmp/host-tools.tar.gz "$HOST_TOOLS_URL" \
+    && tar -C /usr/local -zxf /tmp/host-tools.tar.gz \
+    && rm -f /tmp/host-tools.tar.gz
+
+ENV PATH="/usr/local/host-tools/gcc/riscv64-linux-musl-x86_64/bin:${PATH}"
+
+RUN riscv64-unknown-linux-musl-gcc --version | head -1 \
+    && gcc --version | head -1 \
+    && modinfo --version

--- a/tools/zram/README.md
+++ b/tools/zram/README.md
@@ -62,20 +62,80 @@ Switching is one write, before `disksize` is set:
 echo zstd > /sys/block/zram0/comp_algorithm
 ```
 
-## Build and install
+## Getting the modules onto a device
 
 The modules are the only manual step. The server installs the init script.
 
+There are two ways, and the first one is better.
+
+### 1. Enable them in the kernel config
+
+`CONFIG_ZRAM` and `CONFIG_ZSMALLOC` are both unset in the shipped kernel. Two
+lines in the defconfig build them as part of the normal image:
+
+```
+CONFIG_ZSMALLOC=m
+CONFIG_ZRAM=m
+```
+
+They then land in `/mnt/system/ko` with the other modules, they are rebuilt
+whenever the kernel is, and no prebuilt binary has to be trusted or maintained.
+This is the whole change needed to make the feature work for every device.
+
+### 2. Build them out of tree
+
+For a device running an image that does not have them. The build runs in a
+container, because the kernel tree cannot be checked out on a Windows
+filesystem: it carries paths Windows refuses and `git clone` fails at checkout.
+
 ```shell
+docker build -t nanokvm-zram-builder tools/zram
+
 ssh root@<device> 'zcat /proc/config.gz' > kernel.config
-tools/zram/build-modules.sh /path/to/linux_5.10 kernel.config ./ko
+
+docker volume create nanokvm-kernel
+docker run --rm -v nanokvm-kernel:/src -w /src nanokvm-zram-builder sh -c '
+  git clone --depth 1 --filter=blob:none --sparse -b NanoKVM \
+      https://github.com/sipeed/LicheeRV-Nano-Build
+  cd LicheeRV-Nano-Build && git sparse-checkout set linux_5.10'
+
+docker run --rm \
+  -v nanokvm-kernel:/kernel \
+  -v "$PWD/tools/zram:/tools:ro" \
+  -v "$PWD/ko:/work" \
+  nanokvm-zram-builder \
+  bash /tools/build-modules.sh /kernel/LicheeRV-Nano-Build/linux_5.10 \
+       /work/kernel.config /work/ko
+
 scp ko/*.ko root@<device>:/mnt/system/ko/
 ```
 
-Then open `Settings > Device > Advanced` in the web UI and turn on **Compressed
-swap (zram)**. The toggle copies `/kvmapp/system/init.d/S01zram` to
-`/etc/init.d/`, makes it executable, and starts it. Turning the toggle off
-stops the device and removes the script again.
+## Where the modules are looked for
+
+`S01zram` and the server both search `/kvmapp/system/ko` first and
+`/mnt/system/ko` second. A directory has to hold both modules to be used: zram
+cannot load without zsmalloc, and a pair split across two directories is two
+builds carrying the same vermagic, which the kernel accepts and then resolves
+against the wrong copy.
+
+`/mnt` is not a mount point. It is a plain directory on the root filesystem, so
+modules copied there by method 2 are removed by a rootfs update or a re-flash.
+The loss is quiet: `S01zram` prints `FAIL (no zram device)` and returns 1, rcS
+records the exit status and carries on, and the web UI reports the feature as
+unavailable rather than broken. A device that had working compressed swap
+yesterday reads as one that never had it.
+
+`/kvmapp/system/ko` is part of the install package, so an update restores what
+is in it. Nothing is shipped there today and the search falls through on a
+stock device. It is searched first so that shipping the modules there, or
+placing them there by hand, survives an update with no further change.
+
+## Turning it on
+
+Open `Settings > Device > Advanced` in the web UI and turn on **Compressed swap
+(zram)**. The toggle copies `/kvmapp/system/init.d/S01zram` to `/etc/init.d/`,
+makes it executable, and starts it. Turning the toggle off stops the device and
+removes the script again.
 
 The row reports "The kernel modules are not installed on this device" and the
 toggle stays disabled until both `.ko` files are in place.
@@ -155,6 +215,43 @@ device, which is the path that needs the repair.
 
 `disable` does not remove the modules. They stay loaded, so the toggle keeps
 reporting the feature as available and a re-enable costs no `insmod`.
+
+## Testing on a live board
+
+Use a `hot_add` device, never the live swap, and give it a `mem_limit`. Keep the
+payload small: 8 MB is what the measurements above used, and it is small for a
+reason.
+
+```shell
+N=$(cat /sys/class/zram-control/hot_add)
+echo 16M > /sys/block/zram$N/disksize
+echo 8M  > /sys/block/zram$N/mem_limit     # do not skip this
+dd if=/some/real/file of=/dev/zram$N bs=64k count=128
+cat /sys/block/zram$N/mm_stat
+echo 1 > /sys/block/zram$N/reset
+echo $N > /sys/class/zram-control/hot_remove
+```
+
+Two mistakes will wedge the board, and each on its own is enough:
+
+- **Staging the payload in `/tmp`.** `/tmp` is tmpfs, so the file is spent out
+  of the same RAM the test is measuring, before the test begins. Read from a
+  real file on `/data`, or generate the data in the pipe.
+- **A `hot_add` device with no `mem_limit`.** `zram0` is capped at 40 MB by
+  `S01zram` and cannot spiral. A device created by hand is uncapped and will
+  compress the payload into whatever RAM is left.
+
+The board does not crash and the kernel kills nothing. It stops being able to
+`fork`: `ping` answers, the already-running `NanoKVM-Server` answers HTTP in
+well under a second, and `ssh` times out during the banner exchange because
+`sshd` cannot start a child. Recovery is a power cycle. Everything that would
+free the memory can be done with shell builtins, which need no new process
+(`: > /tmp/file`, `echo 1 > /sys/block/zramN/reset`), so it is worth retrying
+ssh on a slow loop before giving up on it.
+
+Use `/dev/zero` only to check deduplication. It never reaches the compressor:
+identical pages are counted in the `same_pages` field of `mm_stat` and the
+compressed size stays 0.
 
 ## The trade
 

--- a/tools/zram/README.md
+++ b/tools/zram/README.md
@@ -1,0 +1,166 @@
+# zram
+
+Compressed swap in RAM, as two loadable modules against the stock kernel. No
+new image, no kernel replacement, no boot-path change; `rmmod` undoes it.
+
+## Why it is possible
+
+```
+# CONFIG_MODVERSIONS is not set     only vermagic must match, no symbol CRCs
+# CONFIG_MODULE_SIG is not set      no signature enforcement
+CONFIG_MODULES=y                    ~30 .ko already load from /mnt/system/ko
+CONFIG_SWAP=y  CONFIG_CRYPTO_LZO=y  CONFIG_CRYPTO_ZSTD=y
+# CONFIG_ZSMALLOC is not set        so zram needs zsmalloc built too
+```
+
+The board's own toolchain is the one in `tools/build` — Xuantie V2.6.1, gcc
+10.2.0 — which is what `CONFIG_CC_VERSION_TEXT` on the device names.
+
+## Why lzo-rle
+
+`lz4` is not an option: `CONFIG_CRYPTO_LZ4` is unset, so `/proc/crypto` offers
+only `deflate`, `lzo`, `lzo-rle` and `zstd`. The real choice is lzo-rle against
+zstd.
+
+The scarce resource on this board is CPU, not compression ratio: one in-order
+C906 at 1GHz with no acceleration, also running H.264 encode. Compression is
+paid on swap-*out*, which happens under memory pressure — exactly when that core
+is already saturated. zstd costs several times more there for a better ratio.
+
+## Reconsidered, with numbers
+
+The reason above is a *kernel config* constraint, and this repository can now
+build modules against the stock kernel — that is what `build-modules.sh` does.
+So `CONFIG_CRYPTO_LZ4` could be built and lz4 offered to zram. Measured on a
+live board, it would buy nothing:
+
+```
+zram offers   : lzo [lzo-rle] zstd
+ratio         : 2.76x   (orig 3.21 MB -> compressed 1.17 MB)
+mem_used      : 1.63 MB against the 40 MB mem_limit -> 4% of the cap
+swap in use   : 3.2 MB of 96 MB
+lifetime      : pswpout 40449 pages, pswpin 6503
+```
+
+Ratio is not the binding constraint: at 4% of the cap, a much worse ratio would
+still fit. lz4 over lzo-rle is a few percent of compression time on a board that
+idles at 5% of one core. And lzo-rle is the kernel's default for zram because of
+its run-length handling of zero pages, which is most of what swap holds — lz4
+has no equivalent. Against that, an extra module pinned to the kernel's vermagic
+has to be rebuilt whenever the kernel moves.
+
+If this is revisited, measure CPU during a sustained swap-out, not the ratio.
+The ratio is already comfortable and is not what costs anything here.
+
+An earlier version of this file claimed lzo-rle "reached about 5x". Today it
+measures 2.76x on live pages. Both are real; they are different workloads, and
+a single figure should not have been stated as the property of the algorithm.
+
+Switching is one write, before `disksize` is set:
+
+```shell
+echo zstd > /sys/block/zram0/comp_algorithm
+```
+
+## Build and install
+
+The modules are the only manual step. The server installs the init script.
+
+```shell
+ssh root@<device> 'zcat /proc/config.gz' > kernel.config
+tools/zram/build-modules.sh /path/to/linux_5.10 kernel.config ./ko
+scp ko/*.ko root@<device>:/mnt/system/ko/
+```
+
+Then open `Settings > Device > Advanced` in the web UI and turn on **Compressed
+swap (zram)**. The toggle copies `/kvmapp/system/init.d/S01zram` to
+`/etc/init.d/`, makes it executable, and starts it. Turning the toggle off
+stops the device and removes the script again.
+
+The row reports "The kernel modules are not installed on this device" and the
+toggle stays disabled until both `.ko` files are in place.
+
+`build-modules.sh` refuses to emit modules whose vermagic does not match
+`5.10.4-tag- preempt mod_unload riscv` exactly, so a module that cannot load
+never reaches a device.
+
+`loadsystemko.sh` lists modules explicitly and does not glob, so dropping files
+into `/mnt/system/ko` does not make them load. `S01zram` is what enables them.
+
+## Where the script lives
+
+`S01zram` moved to `kvmapp/system/init.d/` so that it ships in the install
+package and the server has a source to copy from. It is not in the list of
+scripts that `kvm_system` copies at boot: that list is hard-coded C++, and
+adding a name to it needs a MaixCDK rebuild and a redeploy on every device. The
+presence of `/etc/init.d/S01zram` is what marks the feature as enabled, the
+same way `S98tailscaled` already works.
+
+`tools/zram/test-zram-swapon.sh` checks the swap priority and its fallback:
+
+```shell
+sh tools/zram/test-zram-swapon.sh
+```
+
+## Swap priority cannot be set on this image
+
+The script asks for `swapon -p 100` and falls back to a plain `swapon`. On this
+board the fallback is what always runs. Measured 2026-08-13:
+
+```
+$ swapon --help
+Usage: swapon [-a] [-e] [DEVICE]
+	-a	Start swapping on all swap devices
+	-e	Silently skip devices that do not exist
+```
+
+BusyBox 1.36.1 here is built without `FEATURE_SWAPON_PRI`, so neither `-p` nor
+the `pri=` option in `/etc/fstab` is available. zram lands at the kernel's
+default priority, which shows as `-2` in `/proc/swaps`.
+
+The `-p` attempt stays in the script. It is correct on an image that has the
+feature, and `tools/zram/test-zram-swapon.sh` covers both paths.
+
+Boot order does not compensate. The kernel gives the first device swapped on
+the higher priority, and the swap file goes first:
+
+```
+si5::sysinit:/sbin/swapon -a          <- inittab, sysinit
+si11::sysinit:/sbin/swapon /swapfile  <- appended by the swap file feature
+rcS:12345:wait:/etc/init.d/rcS        <- reaches S01zram
+```
+
+BusyBox init runs every `sysinit` entry to completion before it starts the
+`wait` entries, so the swap file is always enabled first and always takes the
+better priority.
+
+**Do not enable both on this board.** With both on, the kernel writes to the SD
+card before it writes to compressed RAM, which defeats the reason for using
+zram. The two controls in `Settings > Device > Advanced` are independent by
+design, so nothing stops you; this is the reason not to.
+
+## Stopping and starting a live device
+
+`swapoff` takes the device out of `/proc/swaps` but leaves it initialised: it
+keeps its `disksize`. The kernel then rejects a second write to `disksize`:
+
+```
+sh: write error: Resource busy
+```
+
+`start` therefore resets a device that reports a non-zero `disksize` before it
+configures one. Nothing hit this while the script only ran at boot, because a
+freshly inserted module reports 0. The UI toggle stops and starts a live
+device, which is the path that needs the repair.
+
+`disable` does not remove the modules. They stay loaded, so the toggle keeps
+reporting the feature as available and a re-enable costs no `insmod`.
+
+## The trade
+
+With no disk swap behind it, exceeding zram means the OOM killer rather than
+slow paging, and the largest process is `NanoKVM-Server` — so an OOM takes video
+with it. `mem_limit` caps the RAM zram may consume so it cannot spiral, but the
+tail behaviour is a cliff rather than a slope. On a board that measured 143
+pages ever swapped, and zero under a live streaming session, that cliff is a
+long way off.

--- a/tools/zram/build-modules.sh
+++ b/tools/zram/build-modules.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Build zsmalloc.ko and zram.ko for the stock kernel.
+#
+#   build-modules.sh <kernel-source> <device-config> [output-dir]
+#
+# The device kernel has CONFIG_ZSMALLOC unset, so zram needs both modules. It
+# also has MODVERSIONS and MODULE_SIG off, which means a module only has to
+# match the vermagic string - no symbol CRCs, no signing.
+#
+# Get the config from the device itself:
+#   ssh root@<device> 'zcat /proc/config.gz' > kernel.config
+# Get the source from the board's build tree:
+#   git clone --depth 1 --filter=blob:none --sparse -b NanoKVM \
+#       https://github.com/sipeed/LicheeRV-Nano-Build
+#   cd LicheeRV-Nano-Build && git sparse-checkout set linux_5.10
+#
+# Seeding .config from the running kernel means every option the vermagic is
+# derived from already matches. Only CONFIG_LOCALVERSION is forced: the device
+# reports 5.10.4-tag-, and reproducing that through LOCALVERSION_AUTO would
+# depend on the git state of the machine Sipeed built on.
+set -e
+
+SRC=${1:?usage: build-modules.sh <kernel-source> <device-config> [output-dir]}
+CONFIG=${2:?usage: build-modules.sh <kernel-source> <device-config> [output-dir]}
+OUT=${3:-$PWD/ko}
+WANT_VERMAGIC="5.10.4-tag- preempt mod_unload riscv"
+
+[ -f "$SRC/Makefile" ] || { echo "not a kernel tree: $SRC"; exit 1; }
+[ -f "$CONFIG" ]       || { echo "no such config: $CONFIG"; exit 1; }
+
+cd "$SRC"
+export ARCH=riscv
+export CROSS_COMPILE=riscv64-unknown-linux-musl-
+export KBUILD_BUILD_USER=build
+export KBUILD_BUILD_HOST=nanokvm
+
+echo "===== configure ====="
+cp "$CONFIG" .config
+./scripts/config --file .config --set-str CONFIG_LOCALVERSION "-tag-"
+./scripts/config --file .config --disable CONFIG_LOCALVERSION_AUTO
+./scripts/config --file .config --module CONFIG_ZSMALLOC
+./scripts/config --file .config --module CONFIG_ZRAM
+make olddefconfig >/dev/null
+grep -E '^CONFIG_(ZRAM|ZSMALLOC|LOCALVERSION|PREEMPT=|MODULE_UNLOAD)' .config | sed 's/^/  /'
+echo "  kernelrelease: $(make -s kernelrelease)"
+
+echo
+echo "===== build ====="
+make -j"$(nproc)" modules_prepare 2>&1 | tail -3
+make -j"$(nproc)" mm/zsmalloc.ko drivers/block/zram/zram.ko 2>&1 | tail -10
+
+echo
+echo "===== collect ====="
+mkdir -p "$OUT"
+for m in mm/zsmalloc.ko drivers/block/zram/zram.ko; do
+    [ -f "$m" ] || { echo "MISSING: $m"; exit 1; }
+    cp "$m" "$OUT/"
+done
+
+echo
+echo "===== vermagic must match the device exactly ====="
+ok=1
+for m in "$OUT"/*.ko; do
+    got=$(modinfo "$m" | sed -n 's/^vermagic: *//p')
+    if [ "$got" = "$WANT_VERMAGIC" ]; then
+        echo "  OK   $(basename "$m"): $got"
+    else
+        echo "  FAIL $(basename "$m"): '$got'"
+        echo "       want                 '$WANT_VERMAGIC'"
+        ok=0
+    fi
+done
+[ "$ok" -eq 1 ] || { echo "vermagic mismatch - these will not load"; exit 1; }
+
+echo
+echo "  modules in $OUT"
+echo "  install with: scp $OUT/*.ko root@<device>:/mnt/system/ko/"

--- a/tools/zram/test-zram-modpath.sh
+++ b/tools/zram/test-zram-modpath.sh
@@ -1,0 +1,194 @@
+#!/bin/sh
+# Check that S01zram looks for its modules where an image build can put them.
+#
+#   test-zram-modpath.sh [path-to-S01zram]
+#
+# zsmalloc.ko and zram.ko are built out of tree by build-modules.sh and
+# installed into /mnt/system/ko, beside the base image's own modules. /mnt is
+# not a mount point. It is a plain directory on the root filesystem, so a rootfs
+# update or a re-flash removes both modules.
+#
+# That loss is quiet. S01zram prints "FAIL (no zram device)" and returns 1, rcS
+# records the exit status and carries on, and the web UI reports the feature as
+# unavailable rather than broken. A board that had working compressed swap
+# yesterday reads as a board that never had it.
+#
+# So /kvmapp/system/ko is searched first. It is part of the install package, so
+# an update restores whatever is in it. Nothing is shipped there today and the
+# search falls through on a stock device; putting the pair there is what makes
+# the feature survive an update, and needs no further change to this script.
+#
+# The search is per directory, not per file. A directory has to hold both
+# modules to be used, because zram cannot load without zsmalloc and a pair
+# split across two directories would be two different builds.
+S01=${1:-$(dirname "$0")/../../kvmapp/system/init.d/S01zram}
+[ -f "$S01" ] || { echo "usage: test-zram-modpath.sh <S01zram>"; exit 1; }
+
+fails=0
+note() { printf '  %-62s %s\n' "$1" "$2"; [ "$2" = FAIL ] && fails=$((fails + 1)); return 0; }
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+echo "===== the modules are found where the install package puts them ====="
+
+# Run the shipped function rather than a copy of it.
+sed -n '/^load_modules() {/,/^}/p' "$S01" > "$work/func.sh"
+
+if [ ! -s "$work/func.sh" ]; then
+    note "the script defines load_modules" FAIL
+    echo
+    echo "$fails case(s) FAILED"
+    exit "$fails"
+fi
+note "the script defines load_modules" OK
+
+# The stub records every insmod. It creates the device only when it is asked
+# for zram.ko, and only after zsmalloc.ko has been loaded, which is what the
+# kernel does: zram cannot resolve its symbols without zsmalloc first.
+cat > "$work/harness.sh" <<'HARNESS'
+insmod() {
+    printf '%s\n' "insmod $1" >> "$LOGFILE"
+
+    case "$1" in
+        *zsmalloc.ko) : > "$WORKDIR/zsmalloc.loaded" ;;
+        *zram.ko)
+            if [ -e "$WORKDIR/zsmalloc.loaded" ]; then
+                : > "$ZRAM_DEV"
+            else
+                printf '%s\n' "REFUSED $1 (no zsmalloc)" >> "$LOGFILE"
+                return 1
+            fi
+            ;;
+    esac
+}
+HARNESS
+
+# $1 = which directories get a full pair: kvmapp | mnt | both | none | partial
+# Prints the function's exit status; the insmod log is left at "$work/log".
+run() {
+    rm -rf "$work/root"
+    mkdir -p "$work/root/kvmapp/system/ko" "$work/root/mnt/system/ko"
+    : > "$work/log"
+
+    case "$1" in
+        kvmapp)  : > "$work/root/kvmapp/system/ko/zsmalloc.ko"
+                 : > "$work/root/kvmapp/system/ko/zram.ko" ;;
+        mnt)     : > "$work/root/mnt/system/ko/zsmalloc.ko"
+                 : > "$work/root/mnt/system/ko/zram.ko" ;;
+        both)    : > "$work/root/kvmapp/system/ko/zsmalloc.ko"
+                 : > "$work/root/kvmapp/system/ko/zram.ko"
+                 : > "$work/root/mnt/system/ko/zsmalloc.ko"
+                 : > "$work/root/mnt/system/ko/zram.ko" ;;
+        partial) # zram.ko alone cannot load, so this directory must be skipped
+                 : > "$work/root/kvmapp/system/ko/zram.ko"
+                 : > "$work/root/mnt/system/ko/zsmalloc.ko"
+                 : > "$work/root/mnt/system/ko/zram.ko" ;;
+        none)    : ;;
+    esac
+
+    ZRAM_DEV="$work/root/zram0" \
+    ZRAM_KO_DIRS="$work/root/kvmapp/system/ko $work/root/mnt/system/ko" \
+    LOGFILE="$work/log" WORKDIR="$work/root" \
+        sh -c ". $work/harness.sh; . $work/func.sh; load_modules"
+    echo $?
+}
+
+loaded_from() {
+    # The directory every insmod in the log came from, or "mixed".
+    sed -n 's|^insmod \(.*\)/[a-z]*\.ko$|\1|p' "$work/log" | sort -u | tr '\n' ' '
+}
+
+# --- the install package carries them -------------------------------------
+rc=$(run kvmapp)
+[ "$rc" = 0 ] && note "modules under /kvmapp/system/ko load" OK \
+              || note "modules under /kvmapp/system/ko load (rc=$rc)" FAIL
+[ "$(loaded_from)" = "$work/root/kvmapp/system/ko " ] \
+    && note "and they are loaded from there" OK \
+    || note "and they are loaded from there (got: $(loaded_from))" FAIL
+
+# --- a board set up by hand before this change ------------------------------
+rc=$(run mnt)
+[ "$rc" = 0 ] && note "modules under /mnt/system/ko still load" OK \
+              || note "modules under /mnt/system/ko still load (rc=$rc)" FAIL
+[ "$(loaded_from)" = "$work/root/mnt/system/ko " ] \
+    && note "and they are loaded from there" OK \
+    || note "and they are loaded from there (got: $(loaded_from))" FAIL
+
+# --- both present: the install package wins --------------------------------
+# It is the copy an image build refreshes, so it is the copy that matches the
+# rest of the installed firmware.
+rc=$(run both)
+[ "$rc" = 0 ] && note "with both present the load succeeds" OK \
+              || note "with both present the load succeeds (rc=$rc)" FAIL
+[ "$(loaded_from)" = "$work/root/kvmapp/system/ko " ] \
+    && note "the install package copy is preferred" OK \
+    || note "the install package copy is preferred (got: $(loaded_from))" FAIL
+
+# --- ordering: zsmalloc before zram ----------------------------------------
+# The harness refuses zram.ko without it, so a wrong order shows up as a
+# REFUSED line rather than as a silent success.
+run both > /dev/null
+order=$(sed -n 's|^insmod .*/\([a-z]*\)\.ko$|\1|p' "$work/log" | tr '\n' ' ')
+[ "$order" = "zsmalloc zram " ] \
+    && note "zsmalloc is loaded before zram" OK \
+    || note "zsmalloc is loaded before zram (got: '$order')" FAIL
+grep -q REFUSED "$work/log" \
+    && note "the kernel never refused a module" FAIL \
+    || note "the kernel never refused a module" OK
+
+# --- a directory holding only one of the pair is skipped -------------------
+rc=$(run partial)
+[ "$rc" = 0 ] && note "a half-populated directory falls through to the next" OK \
+              || note "a half-populated directory falls through to the next (rc=$rc)" FAIL
+[ "$(loaded_from)" = "$work/root/mnt/system/ko " ] \
+    && note "and the complete directory is the one used" OK \
+    || note "and the complete directory is the one used (got: $(loaded_from))" FAIL
+
+# --- no modules anywhere ---------------------------------------------------
+# This is the state the reference board was in. It has to report failure, and
+# it must not call insmod on a path that does not exist.
+rc=$(run none)
+[ "$rc" != 0 ] && note "no modules anywhere reports failure" OK \
+               || note "no modules anywhere reports failure (rc=$rc)" FAIL
+[ ! -s "$work/log" ] && note "and nothing is insmod-ed" OK \
+                     || note "and nothing is insmod-ed (got: $(cat "$work/log"))" FAIL
+
+# --- the device already exists ---------------------------------------------
+# A re-run must not insmod a module that is already in the kernel.
+rm -rf "$work/root"
+mkdir -p "$work/root/kvmapp/system/ko"
+: > "$work/root/kvmapp/system/ko/zsmalloc.ko"
+: > "$work/root/kvmapp/system/ko/zram.ko"
+: > "$work/root/zram0"
+: > "$work/log"
+rc=$(ZRAM_DEV="$work/root/zram0" \
+     ZRAM_KO_DIRS="$work/root/kvmapp/system/ko" \
+     LOGFILE="$work/log" WORKDIR="$work/root" \
+     sh -c ". $work/harness.sh; . $work/func.sh; load_modules"; echo $?)
+[ "$rc" = 0 ] && note "an already-loaded module reports success" OK \
+              || note "an already-loaded module reports success (rc=$rc)" FAIL
+[ ! -s "$work/log" ] && note "and is not inserted twice" OK \
+                     || note "and is not inserted twice (got: $(cat "$work/log"))" FAIL
+
+# --- the shipped text ------------------------------------------------------
+# The hardcoded path is the defect. Assert it is gone, ignoring comments, since
+# the block above names /mnt/system/ko in prose to explain why it is second.
+code="$work/code.sh"
+grep -v '^[[:space:]]*#' "$S01" > "$code"
+
+grep -q 'insmod /mnt/system/ko' "$code" \
+    && note "no insmod hardcodes /mnt/system/ko" FAIL \
+    || note "no insmod hardcodes /mnt/system/ko" OK
+
+grep -q 'kvmapp/system/ko' "$code" \
+    && note "the install package directory is in the search list" OK \
+    || note "the install package directory is in the search list" FAIL
+
+echo
+if [ "$fails" -eq 0 ]; then
+    echo "all cases passed"
+else
+    echo "$fails case(s) FAILED"
+fi
+exit "$fails"

--- a/tools/zram/test-zram-reset.sh
+++ b/tools/zram/test-zram-reset.sh
@@ -1,0 +1,99 @@
+#!/bin/sh
+# Check that S01zram resets a zram device that is already initialised.
+#
+#   test-zram-reset.sh [path-to-S01zram]
+#
+# swapoff removes the device from /proc/swaps but leaves it initialised: it
+# keeps its disksize. The kernel then rejects a second write to disksize with
+# EBUSY, and the start fails:
+#
+#   + echo 96M
+#   sh: write error: Resource busy
+#   + echo 'FAIL (disksize)'
+#
+# Nothing hit this while the script only ran at boot, because a freshly
+# inserted module reports disksize 0. The toggle in Settings > Device >
+# Advanced stops and starts a live device, which is the path that needs a
+# reset first.
+#
+# The reset must not run on a fresh module. Writing to reset is harmless there,
+# but the guard is what documents that this is repair and not routine.
+S01=${1:-$(dirname "$0")/../../kvmapp/system/init.d/S01zram}
+[ -f "$S01" ] || { echo "usage: test-zram-reset.sh <S01zram>"; exit 1; }
+
+fails=0
+note() { printf '  %-58s %s\n' "$1" "$2"; [ "$2" = FAIL ] && fails=$((fails + 1)); return 0; }
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+echo "===== a stale device is reset before it is configured ====="
+
+# Run the shipped text rather than a copy of it.
+sed -n '/^reset_stale_device() {/,/^}/p' "$S01" > "$work/func.sh"
+
+if [ ! -s "$work/func.sh" ]; then
+    note "the script defines reset_stale_device" FAIL
+    echo
+    echo "$fails case(s) FAILED"
+    exit "$fails"
+fi
+note "the script defines reset_stale_device" OK
+
+# sysfs is a directory of plain files here. reset starts absent, so its
+# contents afterwards say whether the function wrote to it.
+setup() {
+    rm -rf "$work/sys"
+    mkdir -p "$work/sys"
+    [ -n "$1" ] && printf '%s\n' "$1" > "$work/sys/disksize"
+    return 0
+}
+
+run() {
+    ZRAM_SYSFS="$work/sys" sh -c ". $work/func.sh; reset_stale_device"
+}
+
+# A device left initialised by a swapoff must be reset, or disksize is EBUSY.
+setup 100663296
+run
+status=$?
+
+[ "$status" -eq 0 ] && note "a stale device resets without error" OK \
+    || note "a stale device resets without error" FAIL
+
+[ "$(cat "$work/sys/reset" 2>/dev/null)" = "1" ] \
+    && note "reset is written for a stale device" OK \
+    || note "reset is written for a stale device" FAIL
+
+# A freshly inserted module reports 0 and needs no repair.
+setup 0
+run
+status=$?
+
+[ "$status" -eq 0 ] && note "a fresh module succeeds" OK \
+    || note "a fresh module succeeds" FAIL
+
+[ ! -f "$work/sys/reset" ] \
+    && note "reset is left alone for a fresh module" OK \
+    || note "reset is left alone for a fresh module" FAIL
+
+# No disksize file means no device to repair. Writing reset here would create
+# a file in sysfs that the kernel does not have.
+setup ""
+run
+status=$?
+
+[ "$status" -eq 0 ] && note "a missing disksize succeeds" OK \
+    || note "a missing disksize succeeds" FAIL
+
+[ ! -f "$work/sys/reset" ] \
+    && note "reset is left alone when there is no device" OK \
+    || note "reset is left alone when there is no device" FAIL
+
+echo
+if [ "$fails" -eq 0 ]; then
+    echo "all cases passed"
+else
+    echo "$fails case(s) FAILED"
+fi
+exit "$fails"

--- a/tools/zram/test-zram-swapon.sh
+++ b/tools/zram/test-zram-swapon.sh
@@ -1,0 +1,107 @@
+#!/bin/sh
+# Check that S01zram asks for a swap priority, and still works without one.
+#
+#   test-zram-swapon.sh [path-to-S01zram]
+#
+# zram and the optional swap file are both swapped on during boot, and the
+# order between them is not defined: S01zram runs from rcS, and the swap file
+# runs from the si11::sysinit line that the server appends to /etc/inittab. If
+# the swap file wins, the kernel writes to the SD card before it writes to
+# compressed RAM, which is the opposite of the intent. A priority settles it.
+#
+# BusyBox swapon documents -p PRI, but the applet on a given image may be built
+# without it. A rejected option must not leave the board with no swap at all,
+# so the script falls back to a plain swapon.
+#
+# This runs the shipped function against a stub swapon and checks what it was
+# asked to do, so it fails if the priority or the fallback is removed.
+S01=${1:-$(dirname "$0")/../../kvmapp/system/init.d/S01zram}
+[ -f "$S01" ] || { echo "usage: test-zram-swapon.sh <S01zram>"; exit 1; }
+
+fails=0
+note() { printf '  %-58s %s\n' "$1" "$2"; [ "$2" = FAIL ] && fails=$((fails + 1)); return 0; }
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+echo "===== swapon asks for a priority, and copes without one ====="
+
+# Run the shipped text rather than a copy of it.
+sed -n '/^swapon_zram() {/,/^}/p' "$S01" > "$work/func.sh"
+
+if [ ! -s "$work/func.sh" ]; then
+    note "the script defines swapon_zram" FAIL
+    echo
+    echo "$fails case(s) FAILED"
+    exit "$fails"
+fi
+note "the script defines swapon_zram" OK
+
+# MODE decides how the stub behaves: "modern" accepts -p, "old" rejects it the
+# way a busybox applet built without the option does, and "broken" fails either
+# way. Every call is recorded.
+cat > "$work/harness.sh" <<'HARNESS'
+swapon() {
+    printf '%s\n' "swapon $*" >> "$LOGFILE"
+
+    case "$MODE" in
+        modern) return 0 ;;
+        old)    [ "$1" = "-p" ] && return 1
+                return 0 ;;
+        broken) return 1 ;;
+    esac
+}
+HARNESS
+
+run() {
+    MODE=$1
+    LOGFILE="$work/log"
+    : > "$LOGFILE"
+
+    ZRAM_DEV=/dev/zram0 ZRAM_PRIORITY=100 MODE="$MODE" LOGFILE="$LOGFILE" \
+        sh -c ". $work/harness.sh; . $work/func.sh; swapon_zram"
+}
+
+# A swapon that takes -p must be asked for the priority, and asked only once.
+run modern
+status=$?
+log=$(cat "$work/log")
+
+[ "$status" -eq 0 ] && note "a modern swapon succeeds" OK \
+    || note "a modern swapon succeeds" FAIL
+
+[ "$log" = "swapon -p 100 /dev/zram0" ] \
+    && note "it is asked for priority 100" OK \
+    || note "it is asked for priority 100 (got: $log)" FAIL
+
+# A swapon without -p must still end with zram active.
+run old
+status=$?
+log=$(cat "$work/log")
+
+[ "$status" -eq 0 ] && note "an old swapon succeeds" OK \
+    || note "an old swapon succeeds" FAIL
+
+echo "$log" | grep -q '^swapon -p 100 /dev/zram0$' \
+    && note "it tries the priority first" OK \
+    || note "it tries the priority first (got: $log)" FAIL
+
+echo "$log" | grep -q '^swapon /dev/zram0$' \
+    && note "it falls back to a plain swapon" OK \
+    || note "it falls back to a plain swapon (got: $log)" FAIL
+
+# A device that cannot be swapped on at all must report the failure. Reporting
+# success here would leave the init script printing OK for a dead device.
+run broken
+status=$?
+
+[ "$status" -ne 0 ] && note "a failing swapon reports failure" OK \
+    || note "a failing swapon reports failure" FAIL
+
+echo
+if [ "$fails" -eq 0 ]; then
+    echo "all cases passed"
+else
+    echo "$fails case(s) FAILED"
+fi
+exit "$fails"

--- a/web/src/api/vm.ts
+++ b/web/src/api/vm.ts
@@ -115,6 +115,16 @@ export function setSwap(size: number) {
   return http.post('/api/vm/swap', { size });
 }
 
+// get the state of compressed swap in RAM
+export function getZram() {
+  return http.get('/api/vm/zram');
+}
+
+// enable or disable compressed swap in RAM
+export function setZram(enabled: boolean) {
+  return http.post('/api/vm/zram', { enabled });
+}
+
 // get mouse jiggler
 export function getMouseJiggler() {
   return http.get('/api/vm/mouse-jiggler');

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -383,6 +383,21 @@ const en = {
           description: 'Set the swap file size',
           tip: "Enabling this feature could shorten your SD card's usable life!"
         },
+        zram: {
+          title: 'Compressed swap (zram)',
+          description: 'Swap in compressed RAM, instead of on the SD card',
+          tip: 'zram keeps swap off the SD card, so it causes no wear. There is no disk swap behind it: if zram fills up, the kernel stops a process instead of paging slowly. The memory limit caps how much RAM zram can take.',
+          unavailable: 'The kernel modules are not installed on this device',
+          inactive: 'Enabled, but the device did not start',
+          active: 'Active - {{used}} of {{total}}, {{ratio}}x',
+          off: 'Off',
+          detail: {
+            algorithm: 'Algorithm: {{algorithm}}',
+            memory: 'Memory used: {{used}} of {{limit}}',
+            memoryNoLimit: 'Memory used: {{used}}, no limit set',
+            counters: 'Pages swapped in {{in}}, out {{out}} (all swap devices, since boot)'
+          }
+        },
         mouseJiggler: {
           title: 'Mouse Jiggler',
           description: 'Prevent the remote host from sleeping',

--- a/web/src/pages/desktop/menu/settings/device/advanced/index.tsx
+++ b/web/src/pages/desktop/menu/settings/device/advanced/index.tsx
@@ -2,9 +2,11 @@ import { Collapse } from 'antd';
 import { useTranslation } from 'react-i18next';
 
 import { Swap } from './swap.tsx';
+import { Zram } from './zram.tsx';
 
 const children = (
   <div className="space-y-6 py-3">
+    <Zram />
     <Swap />
     {/*<Autostart />*/}
   </div>

--- a/web/src/pages/desktop/menu/settings/device/advanced/zram.tsx
+++ b/web/src/pages/desktop/menu/settings/device/advanced/zram.tsx
@@ -1,0 +1,181 @@
+import { useEffect, useState } from 'react';
+import { Switch, Tooltip } from 'antd';
+import { CircleAlertIcon } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import * as api from '@/api/vm.ts';
+
+type ZramState = {
+  available: boolean;
+  enabled: boolean;
+  active: boolean;
+  algorithm: string;
+  diskSize: number;
+  original: number;
+  compressed: number;
+  memUsed: number;
+  memLimit: number;
+  swapIn: number;
+  swapOut: number;
+};
+
+// formatBytes keeps one decimal place, which is enough to tell 3.2 MB from
+// 3.9 MB on a board where the whole swap device is 96 MB.
+function formatBytes(bytes: number): string {
+  if (bytes <= 0) return '0 MB';
+
+  const units = ['B', 'KB', 'MB', 'GB'];
+  let value = bytes;
+  let unit = 0;
+
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit++;
+  }
+
+  return `${value.toFixed(unit === 0 ? 0 : 1)} ${units[unit]}`;
+}
+
+export const Zram = () => {
+  const { t } = useTranslation();
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [state, setState] = useState<ZramState | null>(null);
+
+  useEffect(() => {
+    getZram();
+  }, []);
+
+  function getZram() {
+    setIsLoading(true);
+
+    api
+      .getZram()
+      .then((rsp) => {
+        if (rsp.code !== 0) {
+          console.log(rsp.msg);
+          return;
+        }
+        setState(rsp.data);
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }
+
+  function update(enabled: boolean) {
+    if (isLoading) return;
+    setIsLoading(true);
+
+    api
+      .setZram(enabled)
+      .then((rsp) => {
+        if (rsp.code !== 0) {
+          console.log(rsp.msg);
+        }
+      })
+      .finally(() => {
+        // Read the state back either way. The server rolls a failed enable
+        // back, so what it reports is the only trustworthy answer.
+        getZram();
+      });
+  }
+
+  // status is the compact line under the description.
+  function status(): string {
+    if (!state) return '';
+    if (!state.available) return t('settings.device.zram.unavailable');
+    if (!state.active) {
+      return state.enabled ? t('settings.device.zram.inactive') : t('settings.device.zram.off');
+    }
+
+    const ratio = state.compressed > 0 ? (state.original / state.compressed).toFixed(1) : '-';
+
+    return t('settings.device.zram.active', {
+      used: formatBytes(state.original),
+      total: formatBytes(state.diskSize),
+      ratio
+    });
+  }
+
+  // detail is the tooltip on the status line. It is empty when there is no
+  // running device to describe.
+  function detail(): string[] {
+    if (!state?.active) return [];
+
+    const lines = [];
+
+    if (state.algorithm) {
+      lines.push(t('settings.device.zram.detail.algorithm', { algorithm: state.algorithm }));
+    }
+
+    lines.push(
+      state.memLimit > 0
+        ? t('settings.device.zram.detail.memory', {
+            used: formatBytes(state.memUsed),
+            limit: formatBytes(state.memLimit)
+          })
+        : t('settings.device.zram.detail.memoryNoLimit', { used: formatBytes(state.memUsed) })
+    );
+
+    lines.push(t('settings.device.zram.detail.counters', { in: state.swapIn, out: state.swapOut }));
+
+    return lines;
+  }
+
+  const lines = detail();
+
+  return (
+    <div className="flex items-center justify-between">
+      <div className="flex flex-col space-y-1">
+        <div className="flex items-center space-x-2">
+          <span>{t('settings.device.zram.title')}</span>
+
+          <Tooltip
+            title={t('settings.device.zram.tip')}
+            className="cursor-pointer"
+            placement="right"
+            styles={{ root: { maxWidth: '400px' } }}
+          >
+            <CircleAlertIcon className="text-neutral-500" size={14} />
+          </Tooltip>
+        </div>
+
+        <span className="text-xs text-neutral-500">{t('settings.device.zram.description')}</span>
+
+        {state && (
+          <Tooltip
+            title={
+              lines.length > 0 ? (
+                <div className="flex flex-col">
+                  {lines.map((line) => (
+                    <span key={line}>{line}</span>
+                  ))}
+                </div>
+              ) : null
+            }
+            placement="right"
+            styles={{ root: { maxWidth: '400px' } }}
+          >
+            <span
+              className={
+                state.enabled && !state.active
+                  ? 'w-fit cursor-default text-xs text-amber-500'
+                  : 'w-fit cursor-default text-xs text-neutral-400'
+              }
+            >
+              {status()}
+            </span>
+          </Tooltip>
+        )}
+      </div>
+
+      <Switch
+        checked={state?.enabled ?? false}
+        disabled={!state?.available}
+        loading={isLoading}
+        onChange={update}
+      />
+    </div>
+  );
+};


### PR DESCRIPTION
The SG2002 board has ~158MB of usable RAM after the 75MB ION carveout, and the only swap the UI offers is a file on the boot SD card, the card that `Settings > Swap` warns will wear out. zram gives the same relief in compressed RAM, with no card wear at all.

zram already works on this hardware today, but only as a manual install: build the modules, copy an init script to `/etc/init.d` by hand. Nothing in the web UI reports it, so an operator cannot tell whether compressed swap is running or how close it is to its memory cap.

This adds one row to `Settings > Device > Advanced`.

### Three booleans, not one flag

The row reports `available`, `enabled` and `active` separately:

| field | means |
| --- | --- |
| `available` | the kernel modules are present |
| `enabled` | `/etc/init.d/S01zram` is installed, so the setting survives a reboot |
| `active` | `/dev/zram0` is in `/proc/swaps` right now |

"Enabled but not active" is the state that matters most. A single flag renders it as plain "off", which invites the operator to toggle it on and watch nothing happen. The row shows it in amber and says so.

When zram is running the row also reports the algorithm, the compression ratio, memory used against the memory cap, and the system-wide `pswpin`/`pswpout` counters.

### The one thing this needs from you: two lines in the defconfig

`zram` and `zsmalloc` are not in the stock image. `CONFIG_ZRAM` is absent and `CONFIG_ZSMALLOC` is unset, and zram needs both:

```
CONFIG_ZSMALLOC=m
CONFIG_ZRAM=m
```

That builds them as part of the normal image, lands them in `/mnt/system/ko` beside the other modules, and rebuilds them whenever the kernel is rebuilt. It is the whole change needed to make this feature work on every device, and it means no prebuilt binary has to be trusted or maintained by anyone.

**This PR deliberately ships no `.ko`.** The modules are pinned to the kernel vermagic, `5.10.4-tag- preempt mod_unload riscv`, so a binary committed here would silently stop loading the next time the kernel moves, and you would own the bug reports with nothing in CI to rebuild it. The kernel config is the right layer, and it is yours.

Until that lands, `tools/zram/build-modules.sh` builds the pair out of tree for a device already running an image without them, and `tools/zram/Dockerfile` makes that reproducible: it installs the same host-tools archive `docker/Dockerfile` already uses, so the modules come from the compiler that built the kernel. The build refuses to emit a module whose vermagic does not match the device exactly, and rebuilding in that image reproduces the same bytes. If you would rather take a prebuilt pair than change the kernel config, say so and I will attach one, but I would not put it in this diff.

**Without the modules the toggle is disabled and states why.** No dead control, no silent failure.

### Where the modules are looked for

`S01zram` and the server search `/kvmapp/system/ko` first, then `/mnt/system/ko`.

`/mnt` is not a mount point. It is a plain directory on the root filesystem, so a pair installed there by hand is removed by a rootfs update or a re-flash. The loss is quiet: `S01zram` prints `FAIL (no zram device)` and returns 1, `rcS` records the exit status and carries on, and the settings row reports the feature as unavailable rather than broken. A device that had compressed swap yesterday reads as one that never had it, and any measurement taken afterwards is a no-swap measurement. This happened on my board and took three days to notice.

If you take the defconfig change above, this costs nothing: `/kvmapp/system/ko` holds no pair, the search falls through, and the modules load from `/mnt/system/ko` exactly as before. It is searched first only so that placing them in the install package later needs no further change.

The search is per directory, not per file. zram cannot load without zsmalloc, and a pair split across two directories is two separate builds: they carry the same vermagic, so the kernel accepts them, and zram then resolves its symbols against a zsmalloc it was not compiled with.

### Why the server installs the init script

`S01zram` ships in `kvmapp/system/init.d/` so the package carries it and the server has a source to copy from. It is deliberately **not** added to the copy list in `system_init.cpp`: that list is hard-coded C++, and adding a name there needs a MaixCDK rebuild plus a `kvm_system` redeploy on every device. The server owns the copy instead, the way `S98tailscaled` already treats presence in `/etc/init.d` as the installed marker.

A start that produces no device rolls the install back, so `enabled` never claims that a reboot will help.

### Three defects fixed on the way

**`disableSwap` ran `swapoff -a`.** That stops *every* swap device, so any change to the swap file size stopped zram as a side effect. That is not what a control labelled "swap file size" should do. It now names the file, and skips the call entirely when that file is not swapped on. (`swapoff` fails on an inactive file; the `-a` form used to hide that by succeeding on some other device.)

**`S01zram` did not reset a device that was already initialised.** The script had only ever run at boot, where a freshly inserted module reports `disksize 0`. A toggle introduces a stop-then-start on a live device, and the kernel rejects the second `disksize` write:

```
+ echo 96M
sh: write error: Resource busy
+ echo 'FAIL (disksize)'
```

`start` now resets a device reporting a non-zero disksize. The caller has already established the device is not in `/proc/swaps`, so the reset cannot take swap away from anything.

**`S01zram` set no swap priority.** It now asks for `-p 100` and falls back to a plain `swapon`, because a BusyBox applet built without `FEATURE_SWAPON_PRI` rejects the option, and this image's BusyBox 1.36.1 is such a build. Boot order does not compensate: the swap file is enabled from a `si11::sysinit` line and `S01zram` runs from the `rcS` wait entry, and BusyBox init runs every sysinit entry before any wait entry. So on this board the swap file always wins the better priority. The two controls stay independent, and `tools/zram/README.md` says why you should still pick one rather than enabling both.

### API

```
GET  /api/vm/zram   -> {available, enabled, active, algorithm, diskSize,
                        original, compressed, memUsed, memLimit, swapIn, swapOut}
POST /api/vm/zram   <- {enabled}
```

Both sit behind the same auth middleware as the rest of `/api/vm`.

### Testing

- `server/service/vm/zram_test.go` and `swap_test.go` cover the service off-device. The service reads and writes through injectable paths and a command seam, so the whole state machine is exercised, including the rollback path and every parse failure.
- `tools/zram/test-zram-swapon.sh` and `test-zram-reset.sh` are on-device checks for the priority fallback and the stale-device reset.
- `tools/zram/test-zram-modpath.sh` runs the shipped `load_modules` against stub `insmod` calls, covering each directory alone, both together, a directory holding only one of the pair, neither directory, and a module already loaded. The stub refuses `zram.ko` unless `zsmalloc.ko` loaded first, so a wrong order fails rather than passing quietly.
- Verified on hardware: the stale-device start reproduced the `EBUSY` failure and now reports OK.
- Verified on hardware: both modules insmod from `/kvmapp/system/ko` with `/mnt/system/ko` empty, `/dev/zram0` appears, `zram: OK (96M, limit 40M)`, and the device takes a `swapon`. Compression measured 6.12x on real data with no deduplicated pages.

Only `en.ts` carries the new strings; the other locales fall back to English until translated.

