### PR TITLE
Created a new reboot-button in the top-menu, to reboot the device (Na…

### DIFF
--- a/web/src/i18n/locales/ca.ts
+++ b/web/src/i18n/locales/ca.ts
@@ -278,6 +278,9 @@ const ca = {
       okBtn: 'Sí',
       cancelBtn: 'No'
     },
+    reboot: {
+      title: "Reinicia"
+    },
     settings: {
       title: 'Configuració',
       mcp: {

--- a/web/src/i18n/locales/cz.ts
+++ b/web/src/i18n/locales/cz.ts
@@ -281,6 +281,9 @@ const cz = {
       okBtn: 'Ano',
       cancelBtn: 'Ne'
     },
+    reboot: {
+      title: 'Restartujte'
+    },
     settings: {
       title: 'Nastavení',
       mcp: {

--- a/web/src/i18n/locales/da.ts
+++ b/web/src/i18n/locales/da.ts
@@ -279,6 +279,9 @@ const da = {
       okBtn: 'Ja',
       cancelBtn: 'Annuller'
     },
+    reboot: {
+      title: 'Genstart'
+    },
     settings: {
       title: 'Indstillinger',
       mcp: {

--- a/web/src/i18n/locales/de.ts
+++ b/web/src/i18n/locales/de.ts
@@ -284,6 +284,9 @@ const de = {
       okBtn: 'Ja',
       cancelBtn: 'Nein'
     },
+    reboot: {
+      title: 'Neustarten'
+    },
     settings: {
       title: 'Einstellungen',
       mcp: {

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -278,6 +278,9 @@ const en = {
       okBtn: 'Yes',
       cancelBtn: 'No'
     },
+    reboot: {
+      title: 'Reboot'
+    },
     settings: {
       title: 'Settings',
       mcp: {

--- a/web/src/i18n/locales/es.ts
+++ b/web/src/i18n/locales/es.ts
@@ -281,6 +281,9 @@ const es = {
       okBtn: 'Sí',
       cancelBtn: 'No'
     },
+    reboot: {
+      title: 'Reiniciar'
+    },
     settings: {
       title: 'Ajustes',
       mcp: {

--- a/web/src/i18n/locales/fr.ts
+++ b/web/src/i18n/locales/fr.ts
@@ -283,6 +283,9 @@ const fr = {
       okBtn: 'Oui',
       cancelBtn: 'Non'
     },
+    reboot: {
+      title: 'Redémarrer'
+    },
     settings: {
       title: 'Paramètres',
       mcp: {

--- a/web/src/i18n/locales/hu.ts
+++ b/web/src/i18n/locales/hu.ts
@@ -282,6 +282,9 @@ const hu = {
       okBtn: 'Igen',
       cancelBtn: 'Nem'
     },
+    reboot: {
+      title: 'Újraindítás'
+    },
     settings: {
       title: 'Beállítások',
       mcp: {

--- a/web/src/i18n/locales/id.ts
+++ b/web/src/i18n/locales/id.ts
@@ -280,6 +280,9 @@ const id = {
       okBtn: 'Ya',
       cancelBtn: 'Tidak'
     },
+    reboot: {
+      title: 'Mulai ulang'
+    },
     settings: {
       title: 'Pengaturan',
       mcp: {

--- a/web/src/i18n/locales/it.ts
+++ b/web/src/i18n/locales/it.ts
@@ -282,6 +282,9 @@ const it = {
       okBtn: 'Sì',
       cancelBtn: 'No'
     },
+    reboot: {
+      title: 'Riavvia'
+    },
     settings: {
       title: 'Impostazioni',
       mcp: {

--- a/web/src/i18n/locales/ja.ts
+++ b/web/src/i18n/locales/ja.ts
@@ -281,6 +281,9 @@ const ja = {
       okBtn: 'はい',
       cancelBtn: 'いいえ'
     },
+    reboot: {
+      title: '再起動'
+    },
     settings: {
       title: '設定',
       mcp: {

--- a/web/src/i18n/locales/ko.ts
+++ b/web/src/i18n/locales/ko.ts
@@ -276,6 +276,9 @@ const ko = {
       okBtn: '네',
       cancelBtn: '아니오'
     },
+    reboot: {
+      title: '재부팅'
+    },
     settings: {
       title: '설정',
       mcp: {

--- a/web/src/i18n/locales/nb.ts
+++ b/web/src/i18n/locales/nb.ts
@@ -280,6 +280,9 @@ const nb = {
       okBtn: 'Ja',
       cancelBtn: 'Nei'
     },
+    reboot: {
+      title: 'Start på nytt'
+    },
     settings: {
       title: 'Innstillinger',
       mcp: {

--- a/web/src/i18n/locales/nl.ts
+++ b/web/src/i18n/locales/nl.ts
@@ -282,6 +282,9 @@ const nl = {
       okBtn: 'Ja',
       cancelBtn: 'Nee'
     },
+    reboot: {
+      title: 'Opnieuw opstarten'
+    },
     settings: {
       title: 'Instellingen',
       mcp: {

--- a/web/src/i18n/locales/pl.ts
+++ b/web/src/i18n/locales/pl.ts
@@ -281,6 +281,9 @@ const pl = {
       okBtn: 'Tak',
       cancelBtn: 'Nie'
     },
+    reboot: {
+      title: 'Uruchom ponownie'
+    },
     settings: {
       title: 'Ustawienia',
       mcp: {

--- a/web/src/i18n/locales/pt_br.ts
+++ b/web/src/i18n/locales/pt_br.ts
@@ -280,6 +280,9 @@ const pt_br = {
       okBtn: 'Sim',
       cancelBtn: 'Não'
     },
+    reboot: {
+      title: 'Reiniciar'
+    },
     settings: {
       title: 'Configurações',
       mcp: {

--- a/web/src/i18n/locales/ru.ts
+++ b/web/src/i18n/locales/ru.ts
@@ -280,6 +280,9 @@ const ru = {
       okBtn: 'Да',
       cancelBtn: 'Нет'
     },
+    reboot: {
+      title: 'Перезагрузка'
+    },
     settings: {
       title: 'Настройки',
       mcp: {

--- a/web/src/i18n/locales/se.ts
+++ b/web/src/i18n/locales/se.ts
@@ -277,6 +277,9 @@ const se = {
       okBtn: 'Ja',
       cancelBtn: 'Nej'
     },
+    reboot: {
+      title: 'Starta om'
+    },
     settings: {
       title: 'Inställningar',
       mcp: {

--- a/web/src/i18n/locales/th.ts
+++ b/web/src/i18n/locales/th.ts
@@ -274,6 +274,9 @@ const th = {
       okBtn: 'ใช่',
       cancelBtn: 'ไม่ใช่'
     },
+    reboot: {
+      title: 'รีบูต'
+    },
     settings: {
       title: 'การตั้งค่า',
       mcp: {

--- a/web/src/i18n/locales/tr.ts
+++ b/web/src/i18n/locales/tr.ts
@@ -279,6 +279,9 @@ const tr = {
       okBtn: 'Evet',
       cancelBtn: 'Hayır'
     },
+    reboot: {
+      title: 'Yeniden Başlat'
+    },
     settings: {
       title: 'Ayarlar',
       mcp: {

--- a/web/src/i18n/locales/uk.ts
+++ b/web/src/i18n/locales/uk.ts
@@ -281,6 +281,9 @@ const uk = {
       okBtn: 'Так',
       cancelBtn: 'Ні'
     },
+    reboot: {
+      title: 'Перезавантажити'
+    },
     settings: {
       title: 'Налаштування',
       mcp: {

--- a/web/src/i18n/locales/vi.ts
+++ b/web/src/i18n/locales/vi.ts
@@ -278,6 +278,9 @@ const vi = {
       okBtn: 'Có',
       cancelBtn: 'Không'
     },
+    reboot: {
+      title: 'Khởi động lại'
+    },
     settings: {
       title: 'Cài đặt',
       mcp: {

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -270,6 +270,9 @@ const zh = {
       okBtn: '确认',
       cancelBtn: '取消'
     },
+    reboot: {
+      title: '重启'
+    },
     settings: {
       title: '设置',
       mcp: {

--- a/web/src/i18n/locales/zh_tw.ts
+++ b/web/src/i18n/locales/zh_tw.ts
@@ -270,6 +270,9 @@ const zh_tw = {
       okBtn: '確認',
       cancelBtn: '取消'
     },
+    reboot: {
+      title: '重新啟動'
+    },
     settings: {
       title: '設定',
       mcp: {

--- a/web/src/pages/desktop/menu/index.tsx
+++ b/web/src/pages/desktop/menu/index.tsx
@@ -18,6 +18,7 @@ import { Mouse } from './mouse';
 import { Collapse, Expand } from './operations';
 import { Picoclaw } from './picoclaw';
 import { Power } from './power';
+import { Reboot } from './reboot';
 import { Screen } from './screen';
 import { Script } from './script';
 import { Settings } from './settings';
@@ -121,9 +122,10 @@ export const Menu = () => {
               </>
             )}
 
-            {isEnabled('power') && (
+            {(isEnabled('power') || isEnabled('reboot')) && (
               <>
-                <Power />
+                {isEnabled('power') && <Power />}
+                {isEnabled('reboot') && <Reboot />}
                 <Divider type="vertical" />
               </>
             )}

--- a/web/src/pages/desktop/menu/reboot.tsx
+++ b/web/src/pages/desktop/menu/reboot.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import { Popconfirm, Tooltip } from 'antd';
+import { RefreshCwIcon } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import * as api from '@/api/vm.ts';
+
+export const Reboot = () => {
+  const { t } = useTranslation();
+  const [isLoading, setIsLoading] = useState(false);
+
+  function reboot() {
+    if (isLoading) return;
+    setIsLoading(true);
+
+    const timeoutId = setTimeout(() => {
+      window.location.reload();
+    }, 30000);
+
+    api
+      .reboot()
+      .then((rsp) => {
+        if (rsp.code !== 0) {
+          console.log(rsp.msg);
+          setIsLoading(false);
+          clearTimeout(timeoutId);
+        }
+      })
+      .catch((err) => {
+        console.log(err);
+        setIsLoading(false);
+        clearTimeout(timeoutId);
+      });
+  }
+
+  return (
+    <Popconfirm
+      placement="bottom"
+      title={t('settings.device.rebootDesc')}
+      okText={t('settings.device.okBtn')}
+      cancelText={t('settings.device.cancelBtn')}
+      onConfirm={reboot}
+    >
+      <Tooltip title={t('settings.device.reboot')} placement="bottom" mouseEnterDelay={0.6}>
+        <div className="flex h-[30px] w-[30px] cursor-pointer items-center justify-center rounded text-red-500 hover:bg-neutral-700/80 hover:text-red-400">
+          <RefreshCwIcon size={18} className={isLoading ? 'animate-spin' : ''} />
+        </div>
+      </Tooltip>
+    </Popconfirm>
+  );
+};

--- a/web/src/pages/desktop/menu/settings/appearance/menu-icons.tsx
+++ b/web/src/pages/desktop/menu/settings/appearance/menu-icons.tsx
@@ -7,6 +7,7 @@ import {
   MaximizeIcon,
   NetworkIcon,
   PowerIcon,
+  RefreshCwIcon,
   TerminalSquareIcon,
   XIcon
 } from 'lucide-react';
@@ -29,6 +30,7 @@ export const MenuIcons = () => {
     { key: 'wol', icon: <NetworkIcon size={16} /> },
     { key: 'picoclaw', icon: <Robot size={16} /> },
     { key: 'power', icon: <PowerIcon size={16} /> },
+    { key: 'reboot', icon: <RefreshCwIcon size={16} /> },
     { key: 'fullscreen', icon: <MaximizeIcon size={16} />, label: 'fullscreen.toggle' },
     { key: 'collapse', icon: <XIcon size={16} />, label: 'menu.collapse' }
   ];


### PR DESCRIPTION
This is to

Adds a configurable red reboot button to the desktop toolbar, with confirmation, loading feedback, and automatic reconnection after restarting NanoKVM.
Adds translated labels for all 24 supported locales and a Settings > Appearance > Menu Bar toggle to show or hide the button.