### PR TITLE
fix(tailscale): propagate init-script failures and bound command runtime

### DIFF
--- a/kvmapp/system/init.d/S98tailscaled
+++ b/kvmapp/system/init.d/S98tailscaled
@@ -67,12 +67,24 @@ case "$1" in
                     tailscale set --accept-dns=false
                 else
                     echo "FAIL"
+                    exit 1
                 fi
                 ;;
         stop)
                 printf "Stopping $DAEMON: "
-                start-stop-daemon -K -p "$PIDFILE"
-                [ $? = 0 ]  && (echo "OK"; rm -f "$PIDFILE") || echo "FAIL"
+                if start-stop-daemon -K -p "$PIDFILE"; then
+                    echo "OK"
+                    rm -f "$PIDFILE"
+                elif pidof "$DAEMON" >/dev/null 2>&1; then
+                    # A failed stop with the daemon still alive must not report
+                    # success: callers use the exit status to decide whether it
+                    # is safe to start something else.
+                    echo "FAIL"
+                    exit 1
+                else
+                    echo "OK"
+                    rm -f "$PIDFILE"
+                fi
                 printf "cleaning tailscaled: "
                 /usr/sbin/$DAEMON --cleanup >/dev/null 2>&1
                 [ $? = 0 ] && echo "OK" || echo "FAIL"

--- a/server/service/extensions/tailscale/cli.go
+++ b/server/service/extensions/tailscale/cli.go
@@ -3,6 +3,7 @@ package tailscale
 import (
 	"NanoKVM-Server/utils"
 	"bufio"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,12 +11,32 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
+	"time"
 )
 
 const (
 	ScriptPath       = "/etc/init.d/S98tailscaled"
 	ScriptBackupPath = "/kvmapp/system/init.d/S98tailscaled"
 )
+
+// CommandTimeout bounds every init-script call. S98tailscaled sleeps 5 seconds
+// on start and then runs `tailscale set`, so without a deadline a wedged daemon
+// leaves the HTTP handler hanging past any client timeout.
+const CommandTimeout = 1 * time.Minute
+
+func runCommand(command string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), CommandTimeout)
+	defer cancel()
+
+	if err := exec.CommandContext(ctx, "sh", "-c", command).Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("command timed out after %s: %s", CommandTimeout, command)
+		}
+		return err
+	}
+
+	return nil
+}
 
 type Cli struct{}
 
@@ -49,7 +70,7 @@ func (c *Cli) Start() error {
 	}
 
 	command := strings.Join(commands, " && ")
-	return exec.Command("sh", "-c", command).Run()
+	return runCommand(command)
 }
 
 func (c *Cli) Restart() error {
@@ -59,12 +80,12 @@ func (c *Cli) Restart() error {
 	}
 
 	command := strings.Join(commands, " && ")
-	return exec.Command("sh", "-c", command).Run()
+	return runCommand(command)
 }
 
 func (c *Cli) Stop() error {
 	command := fmt.Sprintf("%s stop", ScriptPath)
-	err := exec.Command("sh", "-c", command).Run()
+	err := runCommand(command)
 	if err != nil {
 		return err
 	}
@@ -74,17 +95,21 @@ func (c *Cli) Stop() error {
 
 func (c *Cli) Up() error {
 	command := "tailscale up --accept-dns=false"
-	return exec.Command("sh", "-c", command).Run()
+	return runCommand(command)
 }
 
 func (c *Cli) Down() error {
 	command := "tailscale down"
-	return exec.Command("sh", "-c", command).Run()
+	return runCommand(command)
 }
 
 func (c *Cli) Status() (*TsStatus, error) {
 	command := "tailscale status --json"
-	cmd := exec.Command("sh", "-c", command)
+
+	ctx, cancel := context.WithTimeout(context.Background(), CommandTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "sh", "-c", command)
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -111,6 +136,8 @@ func (c *Cli) Status() (*TsStatus, error) {
 }
 
 func (c *Cli) Login() (string, error) {
+	// Left without a context on purpose: the command carries its own --timeout,
+	// and the caller reads the login URL off stderr while it keeps running.
 	command := "tailscale login --accept-dns=false --timeout=10m"
 	cmd := exec.Command("sh", "-c", command)
 
@@ -143,5 +170,5 @@ func (c *Cli) Login() (string, error) {
 
 func (c *Cli) Logout() error {
 	command := "tailscale logout"
-	return exec.Command("sh", "-c", command).Run()
+	return runCommand(command)
 }


### PR DESCRIPTION
## Problem

`S98tailscaled` reports success regardless of what happened:

- `start` prints `FAIL` without a non-zero exit (lines 68-70)
- `stop` does `[ $? = 0 ] && (echo "OK"; rm -f "$PIDFILE") || echo "FAIL"` (line 75)
- the script ends in `exit 0` (line 89)

The only non-zero exit is the missing-binary check at the top.

Two consequences for the Go side:

- `Cli.Start()` returns `nil` even when `start-stop-daemon` never brought the daemon up, so a
  caller cannot tell a working tunnel from a dead one.
- `Cli.Stop()` returns `nil` after a failed stop and then does `os.Remove(ScriptPath)`, leaving a
  live `tailscaled` with no init script left to stop it.

A caller that stops one VPN before starting another cannot detect either case. On a device with
RAM for a single client, that is how you end up running two.

## Also: unbounded command runtime

`tailscale/cli.go` called `exec.Command("sh", "-c", …).Run()` with no context. `S98tailscaled start`
sleeps 5 seconds and then runs `tailscale set`, so a wedged daemon left the HTTP handler hanging
well past any client timeout. This adds a one-minute deadline to the init-script calls and to
`Status()`.

`Login()` is deliberately left unbounded: the command carries its own `--timeout=10m`, and the
caller reads the login URL off stderr while it runs.

## Notes

- Found while working on #759, but it is not NetBird-specific and touches no NetBird code — hence
  a separate PR. #759 currently has to word its rollback message as "rollback attempted" because
  a successful rollback cannot be distinguished from a failed one; this is what would let it say
  something definite.
- Verified locally: `go build`, `go vet`, `gofmt` clean; `sh -n` and `busybox sh -n` on the init
  script. Not tested on hardware.