### PR TITLE
fix(kvm_mmf): advance destination by row stride

### DIFF
--- a/support/sg2002/additional/kvm_mmf/src/kvm_mmf.cpp
+++ b/support/sg2002/additional/kvm_mmf/src/kvm_mmf.cpp
@@ -2322,7 +2322,7 @@ int mmf_venc_push(int ch, uint8_t *data, int w, int h, int format) {
 		{
 			if (frame_info->stVFrame.u32Stride[0] != (CVI_U32)w) {
 				for (int h0 = 0; h0 < h * 3 / 2; h0 ++) {
-					memcpy((uint8_t *)frame_info->stVFrame.pu8VirAddr[0] + frame_info->stVFrame.u32Stride[0] * h,
+					memcpy((uint8_t *)frame_info->stVFrame.pu8VirAddr[0] + frame_info->stVFrame.u32Stride[0] * h0,
 							((uint8_t *)data) + w * h0, w);
 				}
 			} else {


### PR DESCRIPTION
## Summary

Advance the destination pointer by the current row (`h0`) when copying a YUV420 frame into a VENC input buffer whose stride differs from the visible width.

## Bug

The fallback row-copy loop iterates with `h0`, but the destination offset used the full frame height (`stride * h`) on every iteration. That repeatedly overwrote the same location and could write beyond the intended frame buffer instead of copying each row to its matching stride-aligned destination.

The common zero-copy/equal-stride path is unchanged.

## Validation

- `git diff --check`
- reviewed both Y and UV row bounds: the loop covers `h * 3 / 2` rows and now advances the destination and source once per row

A full SG2002 cross-build/runtime test was not available locally. The branch is only exercised when `u32Stride[0] != w`; the audited idle device had no HDMI source attached.

## Audit update (2026-09-03)

- Independent full release-package build passed: https://github.com/dormancygrace/NanoKVM/actions/runs/33734379996
