### PR TITLE
perf(kvm_vision): throttle idle HDMI polling

### DIFF
--- a/support/sg2002/additional/kvm/src/kvm_vision.cpp
+++ b/support/sg2002/additional/kvm/src/kvm_vision.cpp
@@ -51,6 +51,8 @@
 #define watchdog_temp_path      "/tmp/watchdog"
 #define watchdog_file           "/tmp/nanokvm_wd"
 #define vi_state_publish_interval_ms 10000U
+#define vi_detection_active_poll_ms 10U
+#define vi_detection_idle_poll_ms 100U
 
 #define LT6911_ADDR 	0x2B
 #define LT6911_READ 	0xFF
@@ -1440,7 +1442,11 @@ void* vi_subsystem_detection(void * arg)
             break;
         }
 
-		time::sleep_ms(10);
+		const uint32_t poll_interval_ms =
+			(kvmv_cfg.hdmi_mode == 0 || kvmv_cfg.vi_detect_state == 2)
+				? vi_detection_idle_poll_ms
+				: vi_detection_active_poll_ms;
+		time::sleep_ms(poll_interval_ms);
     }
     kvmv_cfg.thread_is_running = 0;
 }


### PR DESCRIPTION
## Summary

- poll HDMI state at 10 Hz while the input is stable
- retain the existing 100 Hz polling while automatic/manual resolution detection is active

## Why

On a NanoKVM PCIe running app 2.5.0 with an active 1920x1080@60 HDMI input and one Direct H.264 viewer, the server delivered 20-24 FPS against a configured 30 FPS. `pidstat -t` attributed about 15% of the single C906 core and roughly 5,054 voluntary context switches/s to the high-frequency background thread. A focused one-second trace observed 56 opens of `/proc/lt_int` and 56 failed `faccessat` calls for the optional `/etc/kvm/hdmi_mode` file.

`vi_subsystem_detection` performs those checks on every loop and currently sleeps only 10 ms even after the input is stable. HDMI hot-plug and configuration changes do not need 100 Hz response while stable. A 100 ms idle interval bounds their additional detection latency to 100 ms while reducing the polling rate by up to 10x. Resolution probing keeps the original 10 ms interval.

## Validation

- `git diff --check`
- hardware profile collected with an active 1920x1080@60 source and a Direct H.264 client
- verified that modes 1/2 retain the 10 ms interval while `vi_detect_state != 2`
- verified that stable mode 0 and completed detection use the 100 ms interval

A full SG2002/MaixCDK cross-build was not available locally; CI/maintainer cross-build and hardware verification are requested.

## Audit update (2026-09-03)

- Independent full release-package build passed: https://github.com/dormancygrace/NanoKVM/actions/runs/33734382839
