### PR TITLE
perf(kvm_mmf): reuse VENC pack storage

### DIFF
--- a/support/sg2002/additional/kvm_mmf/src/kvm_mmf.cpp
+++ b/support/sg2002/additional/kvm_mmf/src/kvm_mmf.cpp
@@ -29,6 +29,7 @@
 #define MMF_VI_MAX_CHN 			2		// manually limit the max channel number of vi
 #define MMF_RGN_MAX_NUM			16
 #define MMF_VENC_MAX_CHN		4
+#define MMF_VENC_MAX_PACKS		8
 
 #define MMF_VB_VI_ID			0
 
@@ -150,6 +151,7 @@ typedef struct {
 
 static priv_t priv;
 static g_priv_t g_priv;
+static VENC_PACK_S venc_pack_storage[MMF_VENC_MAX_CHN][MMF_VENC_MAX_PACKS];
 
 #define MODULE_NAME "soph_vi"
 
@@ -2382,38 +2384,35 @@ int mmf_venc_pop(int ch, mmf_stream_t *stream) {
 		return -1;
 	}
 
-	venc_stream->pstPack = (VENC_PACK_S *)malloc(sizeof(VENC_PACK_S) * 8);
-	if (!venc_stream->pstPack) {
-		printf("Malloc failed!\r\n");
-		return -1;
-	}
-
-
-	VENC_CHN_STATUS_S stStatus;
+	VENC_CHN_STATUS_S stStatus = {};
 	s32Ret = CVI_VENC_QueryStatus(ch, &stStatus);
 	if (s32Ret != CVI_SUCCESS) {
 		printf("CVI_VENC_QueryStatus failed with %#x\n", s32Ret);
 		return s32Ret;
 	}
 
-	if (stStatus.u32CurPacks > 0) {
-		s32Ret = CVI_VENC_GetStream(ch, venc_stream, 1000);
-		if (s32Ret != CVI_SUCCESS) {
-			printf("CVI_VENC_GetStream failed with %#x\n", s32Ret);
-			free(venc_stream->pstPack);
-			return s32Ret;
-		}
-	} else {
+	if (stStatus.u32CurPacks == 0) {
 		printf("CVI_VENC_QueryStatus find not pack\r\n");
-		free(venc_stream->pstPack);
 		return -1;
+	}
+	if (stStatus.u32CurPacks > MMF_VENC_MAX_PACKS) {
+		printf("pack count is too large! cnt:%d\r\n", stStatus.u32CurPacks);
+		return -1;
+	}
+
+	memset(venc_pack_storage[ch], 0, sizeof(venc_pack_storage[ch]));
+	venc_stream->pstPack = venc_pack_storage[ch];
+	s32Ret = CVI_VENC_GetStream(ch, venc_stream, 1000);
+	if (s32Ret != CVI_SUCCESS) {
+		printf("CVI_VENC_GetStream failed with %#x\n", s32Ret);
+		venc_stream->pstPack = NULL;
+		return s32Ret;
 	}
 
 	if (stream) {
 		stream->count = venc_stream->u32PackCount;
-		if (stream->count > 8) {
+		if (stream->count > MMF_VENC_MAX_PACKS) {
 			printf("pack count is too large! cnt:%d\r\n", stream->count);
-			free(venc_stream->pstPack);
 			return -1;
 		}
 		for (int i = 0; i < stream->count; i++) {
@@ -2448,7 +2447,6 @@ int mmf_venc_free(int ch) {
 	}
 
 	if (venc_stream->pstPack) {
-		free(venc_stream->pstPack);
 		venc_stream->pstPack = NULL;
 	}
 


### PR DESCRIPTION
## Summary

- reuse one fixed VENC pack array per encoder channel instead of allocating and freeing it for every frame
- validate `u32CurPacks` before passing the fixed-capacity array to `CVI_VENC_GetStream`
- clear the pack pointer on failed acquisition and release

## Why

`mmf_venc_pop` is called once per encoded frame. The current implementation allocates eight `VENC_PACK_S` entries on every call and frees them in `mmf_venc_free`, adding allocator work to the 30/60 FPS hot path. It also checks `u32PackCount > 8` only after `CVI_VENC_GetStream` has already received an eight-entry buffer.

A hardware profile at 1080p H.264 showed substantial per-frame VM/allocator activity (about 67 `mmap` and 68 `munmap` calls/s while delivering 21-23 FPS). This change removes the VENC metadata allocation entirely and makes the capacity check effective before the vendor API writes pack descriptors.

Storage is separate per VENC channel, preserving the existing channel-level concurrency model without changing the layout of the middleware-facing `priv_t` structure.

## Validation

- `git diff --check`
- verified all `mmf_venc_pop` error paths leave `pstPack` null or point at valid per-channel storage
- verified successful streams retain the storage until `CVI_VENC_ReleaseStream` in `mmf_venc_free`
- verified the capacity check runs before `CVI_VENC_GetStream`

A full SG2002/MaixCDK cross-build was not available locally; CI/maintainer cross-build and hardware verification are requested.

## Audit update (2026-09-03)

- Independent full release-package build passed: https://github.com/dormancygrace/NanoKVM/actions/runs/33734385707
