### PR TITLE
fix(stream): align VENC rate control with capture FPS

### DIFF
--- a/server/common/kvm_vision.go
+++ b/server/common/kvm_vision.go
@@ -145,7 +145,7 @@ func (k *KvmVision) SetFPS(fps uint8) {
 	}
 
 	_fps := C.uint8_t(fps)
-	C.set_h264_fps(_fps)
+	C.set_h264_fps_if_available(_fps)
 }
 
 func (k *KvmVision) SetFrameDetect(frame uint8) {

--- a/server/common/kvm_vision.go
+++ b/server/common/kvm_vision.go
@@ -137,6 +137,17 @@ func (k *KvmVision) SetGop(gop uint8) {
 	C.set_h264_gop(_gop)
 }
 
+func (k *KvmVision) SetFPS(fps uint8) {
+	k.mutex.Lock()
+	defer k.mutex.Unlock()
+	if k.closed {
+		return
+	}
+
+	_fps := C.uint8_t(fps)
+	C.set_h264_fps(_fps)
+}
+
 func (k *KvmVision) SetFrameDetect(frame uint8) {
 	k.mutex.RLock()
 	defer k.mutex.RUnlock()

--- a/server/include/kvm_vision.h
+++ b/server/include/kvm_vision.h
@@ -63,7 +63,21 @@ int kvmv_read_img(uint16_t _width, uint16_t _height, uint8_t _type, uint16_t _ql
 int free_kvmv_data(uint8_t ** _pp_kvm_data);
 void free_all_kvmv_data();
 void set_h264_gop(uint8_t _gop);
+#if defined(__GNUC__)
+void set_h264_fps(uint8_t _fps) __attribute__((weak));
+#else
 void set_h264_fps(uint8_t _fps);
+#endif
+
+static inline uint8_t set_h264_fps_if_available(uint8_t _fps)
+{
+    if (!set_h264_fps) {
+        return 0;
+    }
+
+    set_h264_fps(_fps);
+    return 1;
+}
 void set_frame_detact(uint8_t _frame_detact);
 void kvmv_deinit();
 uint8_t kvmv_hdmi_control(uint8_t _en);

--- a/server/include/kvm_vision.h
+++ b/server/include/kvm_vision.h
@@ -63,6 +63,7 @@ int kvmv_read_img(uint16_t _width, uint16_t _height, uint8_t _type, uint16_t _ql
 int free_kvmv_data(uint8_t ** _pp_kvm_data);
 void free_all_kvmv_data();
 void set_h264_gop(uint8_t _gop);
+void set_h264_fps(uint8_t _fps);
 void set_frame_detact(uint8_t _frame_detact);
 void kvmv_deinit();
 uint8_t kvmv_hdmi_control(uint8_t _en);

--- a/server/service/stream/h264_source.go
+++ b/server/service/stream/h264_source.go
@@ -88,6 +88,7 @@ func (s *H264Source) run() {
 	defer ticker.Stop()
 
 	vision := common.GetKvmVision()
+	vision.SetFPS(uint8(fps))
 	startTime := time.Now()
 
 	for range ticker.C {
@@ -105,6 +106,7 @@ func (s *H264Source) run() {
 
 		if screen.FPS != fps && screen.FPS != 0 {
 			fps = screen.FPS
+			vision.SetFPS(uint8(fps))
 			ticker.Reset(time.Second / time.Duration(fps))
 		}
 

--- a/support/sg2002/additional/kvm/include/kvm_vision.h
+++ b/support/sg2002/additional/kvm/include/kvm_vision.h
@@ -71,6 +71,7 @@ int kvmv_read_img(uint16_t _width, uint16_t _height, uint8_t _type, uint16_t _ql
 int free_kvmv_data(uint8_t ** _pp_kvm_data);
 void free_all_kvmv_data();
 void set_h264_gop(uint8_t _gop);
+void set_h264_fps(uint8_t _fps);
 void set_frame_detact(uint8_t _frame_detact);
 void kvmv_deinit();
 uint8_t kvmv_hdmi_control(uint8_t _en);

--- a/support/sg2002/additional/kvm/src/kvm_vision.cpp
+++ b/support/sg2002/additional/kvm/src/kvm_vision.cpp
@@ -37,7 +37,9 @@
 #define default_mjpeg_qlty      60
 #define default_h264_qlty       1000
 #define default_h264_gop        30
-#define default_h264_fps        30
+// Preserve the legacy library behaviour until the server supplies the user's
+// configured FPS through set_h264_fps().
+#define default_h264_fps        60
 #define fresh_frame_discard_count 5
 
 #define kvmv_data_buffer_size   4

--- a/support/sg2002/additional/kvm/src/kvm_vision.cpp
+++ b/support/sg2002/additional/kvm/src/kvm_vision.cpp
@@ -37,6 +37,7 @@
 #define default_mjpeg_qlty      60
 #define default_h264_qlty       1000
 #define default_h264_gop        30
+#define default_h264_fps        30
 #define fresh_frame_discard_count 5
 
 #define kvmv_data_buffer_size   4
@@ -1540,6 +1541,7 @@ bool jpg_dump(kvmv_data_t* dump_to, image::Image *raw)
 }
 
 uint8_t kvmvenc_gop = default_h264_gop;
+uint8_t kvmvenc_fps = default_h264_fps;
 kvm_venc_t kvm_venc;
 mmf_venc_cfg_t cfg;
 void init_venc_h264(uint16_t _width, uint16_t _height, uint16_t _qlty)
@@ -1550,8 +1552,8 @@ void init_venc_h264(uint16_t _width, uint16_t _height, uint16_t _qlty)
     cfg.fmt = mmf_invert_format_to_mmf(image::Format::FMT_YVU420SP);
     cfg.jpg_quality = 0;       // unused
     cfg.gop = kvmvenc_gop;
-    cfg.intput_fps = 60;
-    cfg.output_fps = 60;
+    cfg.intput_fps = kvmvenc_fps;
+    cfg.output_fps = kvmvenc_fps;
     cfg.bitrate = _qlty;  // 码率
 
     kvm_venc.mmf_venc_chn = default_venc_chn;
@@ -1608,6 +1610,18 @@ void set_h264_gop(uint8_t _gop)
     kvm_venc.enc_h264_init = 0; // call
     kvmvenc_gop = maxmin_data(100, 1, (int)_gop);
     debug("[kvmv] set_h264_gop = %d\n", kvmvenc_gop);
+}
+
+void set_h264_fps(uint8_t _fps)
+{
+    uint8_t fps = maxmin_data(60, 10, (int)_fps);
+    if (fps == kvmvenc_fps) {
+        return;
+    }
+
+    kvmvenc_fps = fps;
+    kvm_venc.enc_h264_init = 0;
+    debug("[kvmv] set_h264_fps = %d\n", kvmvenc_fps);
 }
 
 void set_frame_detact(uint8_t _frame_detact)


### PR DESCRIPTION
## Summary

- configure H.264 VENC source/destination frame rates from the requested stream FPS instead of hard-coding 60/60
- reinitialize the encoder when the requested FPS changes
- serialize the FPS update against in-flight capture calls

## Why

The Go H.264 source schedules capture at the user-selected rate (30 FPS by default), but `init_venc_h264` always programs the hardware rate controller for 60 FPS. On hardware with a 1080p60 HDMI input and a Direct stream configured for 30 FPS, `/proc/cvitek/venc` and `/proc/cvitek/rc` reported `SrcFr: 60`, `TarFr: 60`, and `ViFr/TrgFr: 60`, while only 21-28 frames/s were submitted and encoded.

The rate controller should use the actual submission cadence. Keeping it at 60 when capture runs at 10-30 FPS gives CBR/GOP timing the wrong frame-rate model and makes bandwidth/quality behavior harder to predict.

The new setter clamps to the same 10-60 range as the Go screen setting. The H.264 source applies it when capture starts and whenever its ticker rate changes. A changed value marks VENC for reinitialization on the next frame, matching the existing GOP update mechanism.

## Validation

- `git diff --check`
- verified the public C declaration is mirrored in both headers used by the library and CGO server
- verified initial source startup and runtime FPS changes both update VENC
- verified the setter uses the KvmVision write lock so it cannot race an in-flight capture call

A full SG2002/MaixCDK cross-build was not available locally; CI/maintainer cross-build and hardware verification are requested.

## Audit update (2026-09-03)

- Independent full release-package build passed at commit `65c45b6`: https://github.com/dormancygrace/NanoKVM/actions/runs/33735223769
- The library default remains the legacy 60 FPS until a new server supplies the configured value, preserving old-server/new-library compatibility.
