### PR TITLE
perf(kvm_vision): reuse encoded frame buffers

### DIFF
--- a/support/sg2002/additional/kvm/src/kvm_vision.cpp
+++ b/support/sg2002/additional/kvm/src/kvm_vision.cpp
@@ -2004,19 +2004,27 @@ int kvmv_read_img(uint16_t _width, uint16_t _height, uint8_t _type, uint16_t _ql
 
 int free_kvmv_data(uint8_t ** _pp_kvm_data)
 {
-        // debug("[kvmv]free_kvmv_data - 1\r\n");
+    if(_pp_kvm_data == NULL){
+        return IMG_NOT_EXIST;
+    }
+
+    pthread_mutex_lock(&vi_mutex);
+    // debug("[kvmv]free_kvmv_data - 1\r\n");
     for(int i = 0; i < kvmv_data_buffer_size; i++){
         if(*_pp_kvm_data == kvmv_data_buffer[i].p_img_data){
             // debug("[kvmv]free buffer : %d\n", *_pp_kvm_data);
             if (*_pp_kvm_data != NULL){
                 kvmv_data_buffer[i].in_use = 0;
                 uint8_t _type = kvmv_data_buffer[i].img_data_type;
+                pthread_mutex_unlock(&vi_mutex);
                 return _type;
             } else {
+                pthread_mutex_unlock(&vi_mutex);
                 return IMG_NOT_EXIST;
             }
         }
     }
+    pthread_mutex_unlock(&vi_mutex);
     return IMG_NOT_EXIST;
 }
 

--- a/support/sg2002/additional/kvm/src/kvm_vision.cpp
+++ b/support/sg2002/additional/kvm/src/kvm_vision.cpp
@@ -108,6 +108,8 @@ typedef struct {
 	uint8_t* p_img_data = NULL;
     uint8_t img_data_type = 0;
     uint32_t img_data_size = 0;
+    uint32_t img_data_capacity = 0;
+    uint8_t in_use = 0;
 } kvmv_data_t;
 
 typedef struct {
@@ -239,13 +241,42 @@ int maxmin_data(int _max, int _min, int _data)
 
 kvmv_data_t* get_save_buffer()
 {
-    kvmv_data_buffer_index = to_roll(kvmv_data_buffer_index + 1);
-    // debug("[kvmv]kvmv_data_buffer_index = %d\n", kvmv_data_buffer_index);
-    // debug("[kvmv]kvmv_data_buffer.p_img_data = %d\n", kvmv_data_buffer[kvmv_data_buffer_index].p_img_data);
-    if(kvmv_data_buffer[kvmv_data_buffer_index].p_img_data == NULL){
-        return &kvmv_data_buffer[kvmv_data_buffer_index];
+    for(int i = 0; i < kvmv_data_buffer_size; i++){
+        kvmv_data_buffer_index = to_roll(kvmv_data_buffer_index + 1);
+        kvmv_data_t* buffer = &kvmv_data_buffer[kvmv_data_buffer_index];
+        if(buffer->in_use == 0){
+            buffer->in_use = 1;
+            buffer->img_data_type = 0;
+            buffer->img_data_size = 0;
+            return buffer;
+        }
     }
     return NULL;
+}
+
+static void release_save_buffer(kvmv_data_t* buffer)
+{
+    if(buffer != NULL){
+        buffer->in_use = 0;
+    }
+}
+
+static bool reserve_save_buffer(kvmv_data_t* buffer, uint32_t size)
+{
+    if(buffer == NULL || size == 0){
+        return false;
+    }
+    if(buffer->p_img_data != NULL && buffer->img_data_capacity >= size){
+        return true;
+    }
+
+    uint8_t* data = (uint8_t *)realloc(buffer->p_img_data, size);
+    if(data == NULL){
+        return false;
+    }
+    buffer->p_img_data = data;
+    buffer->img_data_capacity = size;
+    return true;
 }
 
 // ====HDMI RES==================================================
@@ -1527,8 +1558,7 @@ bool jpg_dump(kvmv_data_t* dump_to, image::Image *raw)
     if(dump_to == NULL || raw == NULL || raw->data() == NULL || raw->data_size() == 0){
         return false;
     }
-    dump_to->p_img_data = (uint8_t *)malloc(raw->data_size());
-    if(dump_to->p_img_data == NULL){
+    if(raw->data_size() > UINT32_MAX || !reserve_save_buffer(dump_to, (uint32_t)raw->data_size())){
         dump_to->img_data_size = 0;
         dump_to->img_data_type = 0;
         return false;
@@ -1573,11 +1603,23 @@ void init_venc_h264(uint16_t _width, uint16_t _height, uint16_t _qlty)
 int h264_stream_dump(kvmv_data_t* dump_to, mmf_stream_t* dump_from)
 {
     static int8_t I_Frame_index = -1;
+    if(dump_to == NULL || dump_from == NULL){
+        return IMG_VENC_ERROR;
+    }
     // debug("[kvmv]dump_from->count = %d\n", dump_from->count);
     if (dump_from->count == 3) {
-
-        dump_to->p_img_data = (uint8_t *)malloc(dump_from->data_size[0]+dump_from->data_size[1]+dump_from->data_size[2]);
-        dump_to->img_data_size = dump_from->data_size[0]+dump_from->data_size[1]+dump_from->data_size[2];
+        for(int i = 0; i < dump_from->count; i++){
+            if(dump_from->data[i] == NULL || dump_from->data_size[i] <= 0){
+                return IMG_VENC_ERROR;
+            }
+        }
+        uint64_t total_size = (uint64_t)dump_from->data_size[0] +
+                              (uint64_t)dump_from->data_size[1] +
+                              (uint64_t)dump_from->data_size[2];
+        if(total_size > UINT32_MAX || !reserve_save_buffer(dump_to, (uint32_t)total_size)){
+            return IMG_BUFFER_FULL;
+        }
+        dump_to->img_data_size = (uint32_t)total_size;
         dump_to->img_data_type = IMG_H264_TYPE_IF;
         memcpy(dump_to->p_img_data, dump_from->data[0], dump_from->data_size[0]);
         memcpy(dump_to->p_img_data+dump_from->data_size[0], dump_from->data[1], dump_from->data_size[1]);
@@ -1592,7 +1634,12 @@ int h264_stream_dump(kvmv_data_t* dump_to, mmf_stream_t* dump_from)
     } else if (dump_from->count == 1) {
         // debug("[kvmv]dump P-Frame\r\n");
         I_Frame_index = -1;
-        dump_to->p_img_data = (uint8_t *)malloc(dump_from->data_size[0]);
+        if(dump_from->data[0] == NULL || dump_from->data_size[0] <= 0){
+            return IMG_VENC_ERROR;
+        }
+        if(!reserve_save_buffer(dump_to, (uint32_t)dump_from->data_size[0])){
+            return IMG_BUFFER_FULL;
+        }
         dump_to->img_data_size = dump_from->data_size[0];
         dump_to->img_data_type = IMG_H264_TYPE_PF;
         memcpy(dump_to->p_img_data, dump_from->data[0], dump_from->data_size[0]);
@@ -1698,6 +1745,8 @@ void kvmv_init(uint8_t _debug_info_en)
     cam->restart(default_vpss_width, default_vpss_height, image::FMT_YVU420SP);
     for(int i = 0; i < kvmv_data_buffer_size; i++){
         kvmv_data_buffer[i].p_img_data = NULL;
+        kvmv_data_buffer[i].img_data_capacity = 0;
+        kvmv_data_buffer[i].in_use = 0;
     }
 
     kvmv_cfg.try_exit_thread = 0;
@@ -1909,6 +1958,7 @@ int kvmv_read_img(uint16_t _width, uint16_t _height, uint8_t _type, uint16_t _ql
             if(jpg == NULL || !jpg_dump(p_kvmv_data, jpg)){
                 delete jpg;
 			    delete img;
+                release_save_buffer(p_kvmv_data);
                 debug("[kvmv]failed to allocate jpg buffer\n");
                 pthread_mutex_unlock(&vi_mutex);
                 return IMG_BUFFER_FULL;
@@ -1933,6 +1983,13 @@ int kvmv_read_img(uint16_t _width, uint16_t _height, uint8_t _type, uint16_t _ql
             ret = raw_to_h264(img, p_kvmv_data, maxmin_data(10000, 500, (int)_qlty));
             // debug("[kvmv]venc raw_to_h264: %d \r\n", (int)(time::time_ms() - start_time));
 			delete img;
+            if(ret < 0){
+                release_save_buffer(p_kvmv_data);
+                *_pp_kvm_data = NULL;
+                *_p_kvmv_data_size = 0;
+                pthread_mutex_unlock(&vi_mutex);
+                return ret;
+            }
             *_pp_kvm_data = p_kvmv_data->p_img_data;
             *_p_kvmv_data_size = p_kvmv_data->img_data_size;
             pthread_mutex_unlock(&vi_mutex);
@@ -1952,10 +2009,7 @@ int free_kvmv_data(uint8_t ** _pp_kvm_data)
         if(*_pp_kvm_data == kvmv_data_buffer[i].p_img_data){
             // debug("[kvmv]free buffer : %d\n", *_pp_kvm_data);
             if (*_pp_kvm_data != NULL){
-        // debug("[kvmv]free_kvmv_data - 2\r\n");
-                free(*_pp_kvm_data);
-        // debug("[kvmv]free_kvmv_data - 3\r\n");
-                kvmv_data_buffer[i].p_img_data = NULL;
+                kvmv_data_buffer[i].in_use = 0;
                 uint8_t _type = kvmv_data_buffer[i].img_data_type;
                 return _type;
             } else {
@@ -1972,6 +2026,8 @@ void free_all_kvmv_data()
         if(kvmv_data_buffer[i].p_img_data != NULL){
             free(kvmv_data_buffer[i].p_img_data);
             kvmv_data_buffer[i].p_img_data = NULL;
+            kvmv_data_buffer[i].img_data_capacity = 0;
+            kvmv_data_buffer[i].in_use = 0;
         }
     }
 }


### PR DESCRIPTION
## Summary

Reuse the four existing encoded-frame slots instead of allocating and freeing their payload on every MJPEG or H.264 frame.

## Why

A live 1080p H.264 profile on a NanoKVM PCIe showed 361 `mmap` and 362 `munmap` calls in five seconds. `h264_stream_dump()` allocated a fresh payload for every frame and `free_kvmv_data()` immediately freed it after cgo copied the frame.

## Changes

- track capacity and ownership separately for each existing frame slot
- grow a slot with `realloc()` only when the encoded frame no longer fits
- release a slot without returning its storage to the allocator
- scan all four slots before reporting a full buffer
- release claimed slots on JPEG/H.264 error paths
- validate VENC pack pointers and sizes before copying
- keep the public C ABI unchanged

The unavoidable VENC-to-owned-buffer copy remains; this PR only removes allocator churn and its related VM syscalls.

## Validation

- `git diff --check`
- duplicate open-PR search: no matching change found
- full SG2002 cross-build is being prepared with the repository builder image

## Audit update (2026-09-03)

- Independent full release-package build passed at commit `d5e2263`: https://github.com/dormancygrace/NanoKVM/actions/runs/33735227597
- Buffer release is now serialized with buffer selection/reallocation, closing the parallel-reader data race.
