### PR TITLE
perf(stream): avoid Direct H264 payload copy

### DIFF
--- a/server/common/kvm_vision.go
+++ b/server/common/kvm_vision.go
@@ -4,6 +4,7 @@ package common
 	#cgo CFLAGS: -I../include
 	#cgo LDFLAGS: -L../dl_lib -lkvm
 	#include "kvm_vision.h"
+	#include <string.h>
 */
 import "C"
 import (
@@ -66,10 +67,15 @@ func (k *KvmVision) ReadMjpeg(width uint16, height uint16, quality uint16) (data
 }
 
 func (k *KvmVision) ReadH264(width uint16, height uint16, bitRate uint16) (data []byte, result int) {
+	_, data, result = k.ReadH264WithHeadroom(width, height, bitRate, 0)
+	return
+}
+
+func (k *KvmVision) ReadH264WithHeadroom(width uint16, height uint16, bitRate uint16, headroom int) (storage []byte, data []byte, result int) {
 	k.mutex.RLock()
 	defer k.mutex.RUnlock()
-	if k.closed {
-		return nil, -1
+	if k.closed || headroom < 0 {
+		return nil, nil, -1
 	}
 
 	var (
@@ -91,7 +97,11 @@ func (k *KvmVision) ReadH264(width uint16, height uint16, bitRate uint16) (data 
 	}
 	defer C.free_kvmv_data(&kvmData)
 
-	data = C.GoBytes(unsafe.Pointer(kvmData), C.int(dataSize))
+	storage = make([]byte, headroom+int(dataSize))
+	data = storage[headroom:]
+	if dataSize != 0 {
+		C.memcpy(unsafe.Pointer(&data[0]), unsafe.Pointer(kvmData), C.size_t(dataSize))
+	}
 	return
 }
 

--- a/server/service/stream/direct/client.go
+++ b/server/service/stream/direct/client.go
@@ -289,8 +289,13 @@ func (c *client) handleControl(messageType int, data []byte) {
 }
 
 func newOutboundFrame(isKeyFrame bool, timestamp int64, storage []byte, data []byte) *outboundFrame {
+	reuseStorage := len(storage) == 9+len(data)
+	if reuseStorage && len(data) != 0 {
+		reuseStorage = &storage[9] == &data[0]
+	}
+
 	payload := storage
-	if len(payload) != 9+len(data) {
+	if !reuseStorage {
 		payload = make([]byte, 9+len(data))
 		copy(payload[9:], data)
 	}

--- a/server/service/stream/direct/client.go
+++ b/server/service/stream/direct/client.go
@@ -288,13 +288,16 @@ func (c *client) handleControl(messageType int, data []byte) {
 	}
 }
 
-func newOutboundFrame(isKeyFrame bool, timestamp int64, data []byte) *outboundFrame {
-	payload := make([]byte, 9+len(data))
+func newOutboundFrame(isKeyFrame bool, timestamp int64, storage []byte, data []byte) *outboundFrame {
+	payload := storage
+	if len(payload) != 9+len(data) {
+		payload = make([]byte, 9+len(data))
+		copy(payload[9:], data)
+	}
 	if isKeyFrame {
 		payload[0] = 1
 	}
 	binary.LittleEndian.PutUint64(payload[1:9], uint64(timestamp))
-	copy(payload[9:], data)
 
 	return &outboundFrame{
 		key:       isKeyFrame,

--- a/server/service/stream/direct/client_test.go
+++ b/server/service/stream/direct/client_test.go
@@ -41,3 +41,16 @@ func TestNewOutboundFrameFallsBackWithoutHeadroom(t *testing.T) {
 		t.Fatalf("frame data = %v, want %v", frame.payload[9:], data)
 	}
 }
+
+func TestNewOutboundFrameFallsBackForUnrelatedStorage(t *testing.T) {
+	storage := make([]byte, 12)
+	data := []byte{8, 9, 10}
+	frame := newOutboundFrame(false, 11, storage, data)
+
+	if &frame.payload[0] == &storage[0] {
+		t.Fatal("payload reused storage that does not contain frame data")
+	}
+	if !bytes.Equal(frame.payload[9:], data) {
+		t.Fatalf("frame data = %v, want %v", frame.payload[9:], data)
+	}
+}

--- a/server/service/stream/direct/client_test.go
+++ b/server/service/stream/direct/client_test.go
@@ -1,0 +1,43 @@
+package direct
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+func TestNewOutboundFrameReusesHeadroom(t *testing.T) {
+	storage := make([]byte, 13)
+	data := storage[9:]
+	copy(data, []byte{1, 2, 3, 4})
+
+	frame := newOutboundFrame(true, 42, storage, data)
+
+	if &frame.payload[0] != &storage[0] {
+		t.Fatal("payload did not reuse capture storage")
+	}
+	if frame.payload[0] != 1 {
+		t.Fatalf("keyframe marker = %d, want 1", frame.payload[0])
+	}
+	if timestamp := binary.LittleEndian.Uint64(frame.payload[1:9]); timestamp != 42 {
+		t.Fatalf("timestamp = %d, want 42", timestamp)
+	}
+	if !bytes.Equal(frame.payload[9:], []byte{1, 2, 3, 4}) {
+		t.Fatalf("frame data = %v", frame.payload[9:])
+	}
+}
+
+func TestNewOutboundFrameFallsBackWithoutHeadroom(t *testing.T) {
+	data := []byte{5, 6, 7}
+	frame := newOutboundFrame(false, 7, nil, data)
+
+	if frame.payload[0] != 0 {
+		t.Fatalf("keyframe marker = %d, want 0", frame.payload[0])
+	}
+	if timestamp := binary.LittleEndian.Uint64(frame.payload[1:9]); timestamp != 7 {
+		t.Fatalf("timestamp = %d, want 7", timestamp)
+	}
+	if !bytes.Equal(frame.payload[9:], data) {
+		t.Fatalf("frame data = %v, want %v", frame.payload[9:], data)
+	}
+}

--- a/server/service/stream/direct/streamer.go
+++ b/server/service/stream/direct/streamer.go
@@ -111,7 +111,7 @@ func (s *Streamer) run() {
 			continue
 		}
 
-		outbound := newOutboundFrame(frame.Result == 3, frame.Timestamp, frame.Data)
+		outbound := newOutboundFrame(frame.Result == 3, frame.Timestamp, frame.Storage, frame.Data)
 		for _, client := range clients {
 			client.offer(outbound)
 		}

--- a/server/service/stream/h264_source.go
+++ b/server/service/stream/h264_source.go
@@ -8,6 +8,7 @@ import (
 )
 
 type H264Frame struct {
+	Storage   []byte
 	Data      []byte
 	Result    int
 	Duration  time.Duration
@@ -108,7 +109,7 @@ func (s *H264Source) run() {
 			ticker.Reset(time.Second / time.Duration(fps))
 		}
 
-		data, result := vision.ReadH264(screen.Width, screen.Height, screen.BitRate)
+		storage, data, result := vision.ReadH264WithHeadroom(screen.Width, screen.Height, screen.BitRate, 9)
 		if result < 0 {
 			frame := H264Frame{Result: result}
 			for _, subscription := range subscribers {
@@ -121,6 +122,7 @@ func (s *H264Source) run() {
 		}
 
 		frame := H264Frame{
+			Storage:   storage,
 			Data:      data,
 			Result:    result,
 			Duration:  time.Second / time.Duration(fps),


### PR DESCRIPTION
## Summary

Reserve the Direct protocol's 9-byte header in the Go-owned H.264 frame allocation, so the Direct streamer can prepend metadata without allocating and copying the encoded payload again.

## Why

The cgo boundary must copy VENC-owned bytes before releasing the hardware stream. Direct mode then copied the complete encoded frame a second time solely to prepend its keyframe marker and timestamp. At 1080p this happens for every frame.

## Changes

- add an ABI-compatible `ReadH264WithHeadroom` helper
- allocate each shared H.264 frame with nine bytes of headroom while preserving the raw slice consumed by WebRTC
- let Direct reuse that backing allocation and write only its nine-byte header
- retain a safe copy fallback for callers without headroom
- add tests for both zero-copy and fallback paths

WebRTC still receives the exact raw H.264 slice, and queued Direct frames remain independently owned Go allocations.

## Validation

- formatted with Go 1.25.0 `gofmt`
- `git diff --check`
- focused tests added; native Windows test cannot link the target-only cgo/libkvm dependency
- full riscv64 cgo build will run with the repository's SG2002 builder image
- duplicate open-PR search found no matching change

## Audit update (2026-09-03)

- Independent full release-package build passed at commit `e26b537`: https://github.com/dormancygrace/NanoKVM/actions/runs/33735231380
- Reuse now verifies that `data` actually aliases the supplied headroom storage; unrelated equal-length storage falls back to a copy and is covered by a regression test.
