### PR TITLE
perf(h264): submit VI frames without CPU mapping

### DIFF
--- a/support/sg2002/additional/kvm/src/kvm_vision.cpp
+++ b/support/sg2002/additional/kvm/src/kvm_vision.cpp
@@ -1651,6 +1651,9 @@ int8_t frame_to_h264(uint8_t *data, int width, int height, int format, int vi_ch
         : mmf_venc_push(kvm_venc.mmf_venc_chn, data, width, height, format);
     if (push_ret) {
         mmf_del_venc_channel(kvm_venc.mmf_venc_chn);
+        if (vi_ch >= 0) {
+            mmf_vi_frame_release(vi_ch);
+        }
         kvm_venc.enc_h264_init = 0;
         // rtmp->unlock();
 		debug("[kvmv]mmf venc push failed!\n");
@@ -1947,6 +1950,9 @@ int kvmv_read_img(uint16_t _width, uint16_t _height, uint8_t _type, uint16_t _ql
             if(p_kvmv_data == NULL){
                 // buffer full
 			    delete img;
+                if(native_vi_ch >= 0){
+                    mmf_vi_frame_release(native_vi_ch);
+                }
                 *_pp_kvm_data = NULL;
                 pthread_mutex_unlock(&vi_mutex);
                 return IMG_BUFFER_FULL;

--- a/support/sg2002/additional/kvm/src/kvm_vision.cpp
+++ b/support/sg2002/additional/kvm/src/kvm_vision.cpp
@@ -1618,7 +1618,8 @@ void set_frame_detact(uint8_t _frame_detact)
     kvmv_cfg.stream_stop = 0;
 }
 
-int8_t raw_to_h264(image::Image *raw, kvmv_data_t* ret_stream, uint16_t _qlty)
+int8_t frame_to_h264(uint8_t *data, int width, int height, int format, int vi_ch,
+    kvmv_data_t* ret_stream, uint16_t _qlty)
 {
 	uint64_t __attribute__((unused)) start_time;
 	uint64_t __attribute__((unused)) frame_time;
@@ -1627,25 +1628,28 @@ int8_t raw_to_h264(image::Image *raw, kvmv_data_t* ret_stream, uint16_t _qlty)
 		// start_time = time::time_ms();
 		// log::info("getimg: %d \r\n", (int)(time::time_ms()));
     mmf_stream_t _stream = {0};
-    if(kvm_venc.enc_h264_init != 1 || raw->width() != kvm_venc.kvm_venc_cfg.w || raw->height() != kvm_venc.kvm_venc_cfg.h || _qlty != kvm_venc.kvm_venc_cfg.bitrate){
-		debug("[kvmv]init_venc_h264	enc_h264_init = %d; raw->width() = %d | %d raw->height() = %d | %d \n",
+    if(kvm_venc.enc_h264_init != 1 || width != kvm_venc.kvm_venc_cfg.w || height != kvm_venc.kvm_venc_cfg.h || _qlty != kvm_venc.kvm_venc_cfg.bitrate){
+		debug("[kvmv]init_venc_h264	enc_h264_init = %d; width = %d | %d height = %d | %d \n",
 				kvm_venc.enc_h264_init,
-				raw->width(), kvm_venc.kvm_venc_cfg.w,
-				raw->height(), kvm_venc.kvm_venc_cfg.h);
+				width, kvm_venc.kvm_venc_cfg.w,
+				height, kvm_venc.kvm_venc_cfg.h);
 
-		init_venc_h264(raw->width(), raw->height(), _qlty);
-        debug("[kvmv]init_venc_h264 finish enc_h264_init = %d; raw->width() = %d | %d raw->height() = %d | %d \n",
+		init_venc_h264(width, height, _qlty);
+        debug("[kvmv]init_venc_h264 finish enc_h264_init = %d; width = %d | %d height = %d | %d \n",
 				kvm_venc.enc_h264_init,
-				raw->width(), kvm_venc.kvm_venc_cfg.w,
-				raw->height(), kvm_venc.kvm_venc_cfg.h);
+				width, kvm_venc.kvm_venc_cfg.w,
+				height, kvm_venc.kvm_venc_cfg.h);
         // if(kvm_venc.enc_h264_init == 1){
-		// 	init_venc_h264(raw->width(), raw->height(), _qlty);
+		// 	init_venc_h264(width, height, _qlty);
 		// } else {
 		// 	init_venc_h264(default_vpss_width, default_vpss_height, default_h264_qlty);
 		// }
     }
 	// log::info("init(): %d \r\n", (int)(time::time_ms() - start_time));
-    if (mmf_venc_push(kvm_venc.mmf_venc_chn, (uint8_t *)raw->data(), raw->width(), raw->height(), mmf_invert_format_to_mmf(raw->format()))) {
+    int push_ret = vi_ch >= 0
+        ? mmf_venc_push_vi(kvm_venc.mmf_venc_chn, vi_ch)
+        : mmf_venc_push(kvm_venc.mmf_venc_chn, data, width, height, format);
+    if (push_ret) {
         mmf_del_venc_channel(kvm_venc.mmf_venc_chn);
         kvm_venc.enc_h264_init = 0;
         // rtmp->unlock();
@@ -1834,17 +1838,35 @@ int kvmv_read_img(uint16_t _width, uint16_t _height, uint8_t _type, uint16_t _ql
 			kvmv_cfg.reinit_flag = 0;
         }
         // debug("[kvmv]befor read img: %d \r\n", (int)(time::time_ms() - start_time));
-        image::Image *img = cam->read();
+        image::Image *img = NULL;
+        int native_vi_ch = -1;
+        int native_len = 0;
+        int native_width = 0;
+        int native_height = 0;
+        int native_format = 0;
+        if (_type == VENC_H264) {
+            native_vi_ch = cam->get_channel();
+            if (mmf_vi_frame_pop_native(native_vi_ch, &native_len, &native_width,
+                    &native_height, &native_format) != 0) {
+                native_vi_ch = -1;
+            }
+        } else {
+            img = cam->read();
+        }
         // debug("[kvmv]read img: %d \r\n", (int)(time::time_ms() - start_time));
 
-        if(img != NULL){
+        if(img != NULL || native_vi_ch >= 0){
             if(kvmv_cfg.fresh_frame_count != 0){
                 // Do not restart VI after HDMI idle. Reopening the MMF
                 // channel can exhaust the carveout heap when the detector
                 // thread is also transitioning. Consume queued frames
                 // instead; the camera buffer contains at most three frames.
                 kvmv_cfg.fresh_frame_count--;
-                delete img;
+                if (native_vi_ch >= 0) {
+                    mmf_vi_frame_release(native_vi_ch);
+                } else {
+                    delete img;
+                }
                 continue;
             }
 
@@ -1930,8 +1952,9 @@ int kvmv_read_img(uint16_t _width, uint16_t _height, uint8_t _type, uint16_t _ql
                 return IMG_BUFFER_FULL;
             }
             // debug("[kvmv]get_save_buffer: %d \r\n", (int)(time::time_ms() - start_time));
-            ret = raw_to_h264(img, p_kvmv_data, maxmin_data(10000, 500, (int)_qlty));
-            // debug("[kvmv]venc raw_to_h264: %d \r\n", (int)(time::time_ms() - start_time));
+            ret = frame_to_h264(NULL, native_width, native_height, native_format,
+                native_vi_ch, p_kvmv_data, maxmin_data(10000, 500, (int)_qlty));
+            // debug("[kvmv]venc frame_to_h264: %d \r\n", (int)(time::time_ms() - start_time));
 			delete img;
             *_pp_kvm_data = p_kvmv_data->p_img_data;
             *_p_kvmv_data_size = p_kvmv_data->img_data_size;

--- a/support/sg2002/additional/kvm_mmf/include/kvm_mmf.hpp
+++ b/support/sg2002/additional/kvm_mmf/include/kvm_mmf.hpp
@@ -45,6 +45,9 @@ void mmf_get_vi_vflip(int ch, bool *en);
 
 // get vi frame
 int mmf_vi_frame_pop(int ch, void **data, int *len, int *width, int *height, int *format);
+// Lease a VI frame without mapping it into CPU address space. The frame can be
+// submitted to an H.264 encoder with mmf_venc_push_vi().
+int mmf_vi_frame_pop_native(int ch, int *len, int *width, int *height, int *format);
 void mmf_vi_frame_free(int ch);
 // Release the current VI frame immediately. mmf_vi_frame_free() defers
 // release so the frame can be sent directly to VENC without a second copy.
@@ -65,6 +68,7 @@ int mmf_add_venc_channel(int ch, mmf_venc_cfg_t *cfg);
 int mmf_del_venc_channel(int ch);
 int mmf_del_venc_channel_all();
 int mmf_venc_push(int ch, uint8_t *data, int w, int h, int format);
+int mmf_venc_push_vi(int ch, int vi_ch);
 int mmf_venc_pop(int ch, mmf_stream_t *stream);
 int mmf_venc_free(int ch);
 

--- a/support/sg2002/additional/kvm_mmf/src/kvm_mmf.cpp
+++ b/support/sg2002/additional/kvm_mmf/src/kvm_mmf.cpp
@@ -2342,7 +2342,7 @@ static int _mmf_venc_push_copy(int ch, uint8_t *data, int w, int h, int format) 
 		{
 			if (frame_info->stVFrame.u32Stride[0] != (CVI_U32)w) {
 				for (int h0 = 0; h0 < h * 3 / 2; h0 ++) {
-					memcpy((uint8_t *)frame_info->stVFrame.pu8VirAddr[0] + frame_info->stVFrame.u32Stride[0] * h,
+					memcpy((uint8_t *)frame_info->stVFrame.pu8VirAddr[0] + frame_info->stVFrame.u32Stride[0] * h0,
 							((uint8_t *)data) + w * h0, w);
 				}
 			} else {

--- a/support/sg2002/additional/kvm_mmf/src/kvm_mmf.cpp
+++ b/support/sg2002/additional/kvm_mmf/src/kvm_mmf.cpp
@@ -207,6 +207,61 @@ static int _mmf_find_deferred_vi_frame(int width, int height, int format,
 	return -1;
 }
 
+static int _mmf_acquire_vi_frame(int ch, int *len, int *width, int *height,
+	int *format)
+{
+	VIDEO_FRAME_INFO_S *frame = &priv.vi_frame[ch];
+	_mmf_release_vi_frame(ch);
+	memset(frame, 0, sizeof(*frame));
+	if (CVI_VPSS_GetChnFrame(0, ch, frame, 1000) != CVI_SUCCESS) {
+		return -1;
+	}
+
+	int image_size = frame->stVFrame.u32Length[0]
+		+ frame->stVFrame.u32Length[1]
+		+ frame->stVFrame.u32Length[2];
+	if (frame->stVFrame.u64PhyAddr[0] == 0 || image_size <= 0) {
+		SAMPLE_PRT("invalid VI frame address or size\n");
+		CVI_VPSS_ReleaseChnFrame(0, ch, frame);
+		memset(frame, 0, sizeof(*frame));
+		return -1;
+	}
+
+	priv.vi_frame_valid[ch] = true;
+	priv.vi_frame_mapped[ch] = false;
+	priv.vi_frame_deferred[ch] = false;
+	*len = image_size;
+	*width = frame->stVFrame.u32Width;
+	*height = frame->stVFrame.u32Height;
+	*format = frame->stVFrame.enPixelFormat;
+	return 0;
+}
+
+static void *_mmf_map_vi_frame(int ch)
+{
+	if (ch < 0 || ch >= MMF_VI_MAX_CHN || !priv.vi_frame_valid[ch]) {
+		return NULL;
+	}
+
+	VIDEO_FRAME_INFO_S *frame = &priv.vi_frame[ch];
+	if (priv.vi_frame_mapped[ch]) {
+		return frame->stVFrame.pu8VirAddr[0];
+	}
+
+	int image_size = frame->stVFrame.u32Length[0]
+		+ frame->stVFrame.u32Length[1]
+		+ frame->stVFrame.u32Length[2];
+	CVI_VOID *vir_addr = CVI_SYS_MmapCache(frame->stVFrame.u64PhyAddr[0], image_size);
+	if (vir_addr == NULL) {
+		SAMPLE_PRT("CVI_SYS_MmapCache failed for VI frame\n");
+		return NULL;
+	}
+	CVI_SYS_IonInvalidateCache(frame->stVFrame.u64PhyAddr[0], vir_addr, image_size);
+	frame->stVFrame.pu8VirAddr[0] = (CVI_U8 *)vir_addr;
+	priv.vi_frame_mapped[ch] = true;
+	return vir_addr;
+}
+
 static int _is_module_in_use(const char *module_name) {
     FILE *fp;
     char buffer[256];
@@ -1499,48 +1554,30 @@ int mmf_vi_frame_pop(int ch, void **data, int *len, int *width, int *height, int
         return -1;
     }
 
-	int ret = -1;
-	VIDEO_FRAME_INFO_S *frame = &priv.vi_frame[ch];
-	_mmf_release_vi_frame(ch);
-	memset(frame, 0, sizeof(*frame));
-	if (CVI_VPSS_GetChnFrame(0, ch, frame, 1000) == 0) {
-        int image_size = frame->stVFrame.u32Length[0]
-                        + frame->stVFrame.u32Length[1]
-				        + frame->stVFrame.u32Length[2];
-		if (frame->stVFrame.u64PhyAddr[0] == 0 || image_size <= 0) {
-			SAMPLE_PRT("invalid VI frame address or size\n");
-			CVI_VPSS_ReleaseChnFrame(0, ch, frame);
-			memset(frame, 0, sizeof(*frame));
-			return -1;
-		}
+	if (_mmf_acquire_vi_frame(ch, len, width, height, format) != 0) {
+		return -1;
+	}
+	*data = _mmf_map_vi_frame(ch);
+	if (*data == NULL) {
+		_mmf_release_vi_frame(ch);
+		return -1;
+	}
+	return 0;
+}
 
-		CVI_VOID *vir_addr;
-		vir_addr = CVI_SYS_MmapCache(frame->stVFrame.u64PhyAddr[0], image_size);
-		if (vir_addr == NULL) {
-			SAMPLE_PRT("CVI_SYS_MmapCache failed for VI frame\n");
-			CVI_VPSS_ReleaseChnFrame(0, ch, frame);
-			memset(frame, 0, sizeof(*frame));
-			return -1;
-		}
-		CVI_SYS_IonInvalidateCache(frame->stVFrame.u64PhyAddr[0], vir_addr, image_size);
-
-		frame->stVFrame.pu8VirAddr[0] = (CVI_U8 *)vir_addr;		// save virtual address for munmap
-		priv.vi_frame_valid[ch] = true;
-		priv.vi_frame_mapped[ch] = true;
-		priv.vi_frame_deferred[ch] = false;
-		// printf("width: %d, height: %d, total_buf_length: %d, phy:%#lx  vir:%p\n",
-		// 	   frame->stVFrame.u32Width,
-		// 	   frame->stVFrame.u32Height, image_size,
-        //        frame->stVFrame.u64PhyAddr[0], vir_addr);
-
-		*data = vir_addr;
-        *len = image_size;
-        *width = frame->stVFrame.u32Width;
-        *height = frame->stVFrame.u32Height;
-        *format = frame->stVFrame.enPixelFormat;
-		return 0;
-    }
-	return ret;
+int mmf_vi_frame_pop_native(int ch, int *len, int *width, int *height, int *format) {
+	if (ch < 0 || ch >= MMF_VI_MAX_CHN || !priv.vi_chn_is_inited[ch]) {
+		return -1;
+	}
+	if (len == NULL || width == NULL || height == NULL || format == NULL) {
+		printf("invalid param\n");
+		return -1;
+	}
+	if (_mmf_acquire_vi_frame(ch, len, width, height, format) != 0) {
+		return -1;
+	}
+	priv.vi_frame_deferred[ch] = true;
+	return 0;
 }
 
 void mmf_vi_frame_free(int ch) {
@@ -2284,10 +2321,10 @@ int mmf_del_venc_channel_all() {
 	return 0;
 }
 
-int mmf_venc_push(int ch, uint8_t *data, int w, int h, int format) {
+static int _mmf_venc_push_copy(int ch, uint8_t *data, int w, int h, int format) {
 	int res = 0;
 	CVI_S32 s32Ret = CVI_SUCCESS;
-	if (ch >= MMF_VENC_MAX_CHN || data == NULL
+	if (ch < 0 || ch >= MMF_VENC_MAX_CHN || data == NULL
 		|| (format != PIXEL_FORMAT_NV21 && format != PIXEL_FORMAT_RGB_888)) {
 		printf("Invalid param. ch:%d data:%p format:%d\r\n", ch, data, format);
 		return -1;
@@ -2298,23 +2335,6 @@ int mmf_venc_push(int ch, uint8_t *data, int w, int h, int format) {
 	if (frame_info == NULL) {
 		printf("frame info is null!\r\n");
 		return -1;
-	}
-
-	/*
-	 * CameraCviMmf can return an Image backed by the mapped VPSS buffer.
-	 * When that frame is deferred, send it directly to VENC and skip the
-	 * Image -> VENC buffer copy. Non-camera callers still use the old path.
-	 */
-	if (info->type == 2) {
-		VIDEO_FRAME_INFO_S *vi_frame = NULL;
-		if (_mmf_find_deferred_vi_frame(w, h, format, &vi_frame) >= 0) {
-			s32Ret = CVI_VENC_SendFrame(ch, vi_frame, 1000);
-			if (s32Ret == CVI_SUCCESS) {
-				info->is_running = 1;
-				return 0;
-			}
-			printf("CVI_VENC_SendFrame zero-copy failed with %#x, fallback to copy\n", s32Ret);
-		}
 	}
 
 	switch (format) {
@@ -2344,6 +2364,59 @@ int mmf_venc_push(int ch, uint8_t *data, int w, int h, int format) {
 	info->is_running = 1;
 
 	return res;
+}
+
+int mmf_venc_push(int ch, uint8_t *data, int w, int h, int format) {
+	if (ch < 0 || ch >= MMF_VENC_MAX_CHN || data == NULL
+		|| (format != PIXEL_FORMAT_NV21 && format != PIXEL_FORMAT_RGB_888)) {
+		printf("Invalid param. ch:%d data:%p format:%d\r\n", ch, data, format);
+		return -1;
+	}
+
+	venc_info_t *info = (venc_info_t *)&priv.venc[ch];
+	if (info->type == 2) {
+		VIDEO_FRAME_INFO_S *vi_frame = NULL;
+		if (_mmf_find_deferred_vi_frame(w, h, format, &vi_frame) >= 0) {
+			CVI_S32 ret = CVI_VENC_SendFrame(ch, vi_frame, 1000);
+			if (ret == CVI_SUCCESS) {
+				info->is_running = 1;
+				return 0;
+			}
+			printf("CVI_VENC_SendFrame zero-copy failed with %#x, fallback to copy\n", ret);
+		}
+	}
+
+	return _mmf_venc_push_copy(ch, data, w, h, format);
+}
+
+int mmf_venc_push_vi(int ch, int vi_ch) {
+	if (ch < 0 || ch >= MMF_VENC_MAX_CHN || vi_ch < 0 || vi_ch >= MMF_VI_MAX_CHN
+		|| !priv.vi_frame_valid[vi_ch] || !priv.vi_frame_deferred[vi_ch]) {
+		printf("Invalid native frame. venc:%d vi:%d\r\n", ch, vi_ch);
+		return -1;
+	}
+
+	venc_info_t *info = (venc_info_t *)&priv.venc[ch];
+	VIDEO_FRAME_INFO_S *frame = &priv.vi_frame[vi_ch];
+	if (info->type != 2 || frame->stVFrame.enPixelFormat != PIXEL_FORMAT_NV21) {
+		printf("Unsupported native frame. venc_type:%d format:%d\r\n",
+			info->type, frame->stVFrame.enPixelFormat);
+		return -1;
+	}
+
+	CVI_S32 ret = CVI_VENC_SendFrame(ch, frame, 1000);
+	if (ret == CVI_SUCCESS) {
+		info->is_running = 1;
+		return 0;
+	}
+
+	printf("CVI_VENC_SendFrame native failed with %#x, fallback to mapped copy\n", ret);
+	uint8_t *data = (uint8_t *)_mmf_map_vi_frame(vi_ch);
+	if (data == NULL) {
+		return -1;
+	}
+	return _mmf_venc_push_copy(ch, data, frame->stVFrame.u32Width,
+		frame->stVFrame.u32Height, frame->stVFrame.enPixelFormat);
 }
 
 int mmf_venc_pop(int ch, mmf_stream_t *stream) {


### PR DESCRIPTION
## Summary

- add an explicit MMF API for leasing a VI frame without mapping it into CPU address space
- submit that physical VPSS frame directly to the H.264 VENC path
- preserve the mapped-copy path as a fallback if native submission fails
- leave MJPEG and other CPU consumers on the existing mapped path

The existing H.264 path already avoids copying the raw frame into a separate VENC buffer, but `CameraCviMmf::read()` still maps and invalidates the full NV21 frame before VENC submission. At 1920x1080/30 this touches about 93 MB/s of raw frame address space that the CPU never reads.

## Measured on NanoKVM PCIe / SG2002

Same HDMI source, 1920x1080 at 30 FPS, same Direct client and bitrate:

| Metric | Before | After |
| --- | ---: | ---: |
| `NanoKVM-Server` CPU | 19.58% | 16.30% |
| `mmap` calls / 5 s | 323 | 160 |
| `munmap` calls / 5 s | 310 | 160 |
| transmit rate | 4.28 Mbit/s | 4.29 Mbit/s |
| VENC output | 29-30 FPS | 29-30 FPS |
| VENC hardware time | 11.74 ms | 11.75 ms |

That is a 3.28 percentage-point / 16.8% reduction in server CPU. The remaining roughly 30 map/unmap pairs per second are the small encoded VENC output packets.

No native-submit fallback or VENC errors were logged during the test.

The same change was also measured with the browser switched to H.264 WebRTC.
A 20-second stabilized sample fell from 41.00% to 39.08% server CPU (4.7%),
while remaining at 29-30 FPS. WebRTC retains a much larger protocol overhead
than Direct, so eliminating the common raw-frame mapping is a smaller fraction
of its total CPU use.

## Validation

- complete package build with the repository's pinned builder image and Xuantie GCC 10.2
- package checksum/provenance verification passed
- staged libraries resolved successfully with the device's RVV 0.7.1 musl loader
- deployed both `libkvm.so` and `libkvm_mmf.so` together and verified persistent/runtime hashes
- Direct H.264 remained stable at 1920x1080, 29-30 FPS

CI build: https://github.com/dormancygrace/NanoKVM/actions/runs/33683946200


## Audit update (2026-09-03)

- Independent full release-package build passed at commit `8b0c043`: https://github.com/dormancygrace/NanoKVM/actions/runs/33735235804
- Native VI frames are now released on push/buffer-capacity failures.
- The mapped-copy fallback includes the row-stride correction from #892 so merge order cannot reintroduce the out-of-bounds offset.
