### PR TITLE
fix(runtime): make service restarts and sessions durable

### DIFF
--- a/kvmapp/jpg_stream/S95nanokvm
+++ b/kvmapp/jpg_stream/S95nanokvm
@@ -1,6 +1,11 @@
 #!/bin/sh
 # nanokvm Rev2.1
 
+start_background() {
+    executable="$1"
+    nohup "$executable" </dev/null >/dev/null 2>&1 &
+}
+
 case "$1" in
   start)
     echo -n kvm > /boot/hostname.prefix
@@ -34,7 +39,7 @@ case "$1" in
     iptables -A OUTPUT -o eth0 -p tcp --sport 8000 -m state --state ESTABLISHED -j DROP
 
     cp -r /kvmapp/kvm_system /tmp/
-    /tmp/kvm_system/kvm_system &
+    start_background /tmp/kvm_system/kvm_system
 
     # if [ -e /kvmapp/kvm_stream ]
     # then
@@ -43,7 +48,7 @@ case "$1" in
     # fi
     
     cp -r /kvmapp/server /tmp/
-    /tmp/server/NanoKVM-Server &
+    start_background /tmp/server/NanoKVM-Server
   ;;
   stop)
     killall kvm_system
@@ -73,7 +78,7 @@ case "$1" in
     rm -r /tmp/server
     
     cp -r /kvmapp/kvm_system /tmp/
-    /tmp/kvm_system/kvm_system &
+    start_background /tmp/kvm_system/kvm_system
 
     # if [ -e /kvmapp/kvm_stream ]
     # then
@@ -82,7 +87,7 @@ case "$1" in
     # fi
     
     cp -r /kvmapp/server /tmp/
-    /tmp/server/NanoKVM-Server &
+    start_background /tmp/server/NanoKVM-Server
 
     sync
 

--- a/kvmapp/system/init.d/S95nanokvm
+++ b/kvmapp/system/init.d/S95nanokvm
@@ -23,13 +23,10 @@ stop_process() {
         return
     fi
 
-    killall -INT "$process" 2>/dev/null || true
-    if wait_for_exit "$process" 20; then
-        return
-    fi
-
+    # Non-interactive shells start asynchronous jobs with SIGINT ignored.
+    # SIGTERM is handled by NanoKVM-Server and reaches detached services.
     killall -TERM "$process" 2>/dev/null || true
-    if wait_for_exit "$process" 5; then
+    if wait_for_exit "$process" 10; then
         return
     fi
 
@@ -44,11 +41,16 @@ stop_services() {
     rm -rf /tmp/kvm_system /tmp/server
 }
 
+start_background() {
+    executable="$1"
+    nohup "$executable" </dev/null >/dev/null 2>&1 &
+}
+
 start_services() {
     cp -r /kvmapp/kvm_system /tmp/
     if [ -f /kvmapp/kvm_new_app ]; then
         touch /tmp/.nanokvm_migrating
-        /tmp/kvm_system/kvm_system &
+        start_background /tmp/kvm_system/kvm_system
 
         # The legacy migration invokes this init script recursively and starts
         # the server itself. Wait for that single migration path to finish.
@@ -63,13 +65,13 @@ start_services() {
         done
         rm -f /tmp/.nanokvm_migrating
     else
-        /tmp/kvm_system/kvm_system &
+        start_background /tmp/kvm_system/kvm_system
     fi
 
     if ! pidof NanoKVM-Server >/dev/null 2>&1; then
         rm -rf /tmp/server
         cp -r /kvmapp/server /tmp/
-        /tmp/server/NanoKVM-Server &
+        start_background /tmp/server/NanoKVM-Server
     fi
 }
 

--- a/server/config/default.go
+++ b/server/config/default.go
@@ -1,5 +1,7 @@
 package config
 
+import "log"
+
 var defaultConfig = &Config{
 	Proto: "http",
 	Host:  "",
@@ -35,7 +37,12 @@ var defaultConfig = &Config{
 
 func checkDefaultValue() {
 	if instance.JWT.SecretKey == "" {
-		instance.JWT.SecretKey = generateRandomSecretKey()
+		secret, err := loadOrCreateJWTSecret(jwtSecretFile)
+		if err != nil {
+			log.Printf("failed to persist JWT secret: %s", err)
+			secret = generateRandomSecretKey()
+		}
+		instance.JWT.SecretKey = secret
 		instance.JWT.RevokeTokensOnLogout = true
 	}
 

--- a/server/config/jwt.go
+++ b/server/config/jwt.go
@@ -4,8 +4,13 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"time"
 )
+
+const jwtSecretFile = "/etc/kvm/.jwt_secret"
 
 // Generate random string for secret key.
 func generateRandomSecretKey() string {
@@ -18,4 +23,55 @@ func generateRandomSecretKey() string {
 	}
 
 	return base64.URLEncoding.EncodeToString(b)
+}
+
+func loadOrCreateJWTSecret(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err == nil {
+		if secret := strings.TrimSpace(string(data)); secret != "" {
+			if err = os.Chmod(path, 0o600); err != nil {
+				return "", err
+			}
+			return secret, nil
+		}
+	} else if !os.IsNotExist(err) {
+		return "", err
+	}
+
+	secret := generateRandomSecretKey()
+	directory := filepath.Dir(path)
+	if err = os.MkdirAll(directory, 0o755); err != nil {
+		return "", err
+	}
+
+	temporary, err := os.CreateTemp(directory, ".jwt-secret-*")
+	if err != nil {
+		return "", err
+	}
+	temporaryPath := temporary.Name()
+	removeTemporary := true
+	defer func() {
+		_ = temporary.Close()
+		if removeTemporary {
+			_ = os.Remove(temporaryPath)
+		}
+	}()
+
+	if err = temporary.Chmod(0o600); err != nil {
+		return "", err
+	}
+	if _, err = temporary.WriteString(secret + "\n"); err != nil {
+		return "", err
+	}
+	if err = temporary.Sync(); err != nil {
+		return "", err
+	}
+	if err = temporary.Close(); err != nil {
+		return "", err
+	}
+	if err = os.Rename(temporaryPath, path); err != nil {
+		return "", err
+	}
+	removeTemporary = false
+	return secret, nil
 }

--- a/server/config/jwt_test.go
+++ b/server/config/jwt_test.go
@@ -1,0 +1,83 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestLoadOrCreateJWTSecretPersistsValue(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".jwt_secret")
+
+	first, err := loadOrCreateJWTSecret(path)
+	if err != nil {
+		t.Fatalf("create JWT secret: %v", err)
+	}
+	if first == "" {
+		t.Fatal("created an empty JWT secret")
+	}
+
+	second, err := loadOrCreateJWTSecret(path)
+	if err != nil {
+		t.Fatalf("reload JWT secret: %v", err)
+	}
+	if second != first {
+		t.Fatalf("secret changed after reload")
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat JWT secret: %v", err)
+	}
+	if mode := info.Mode().Perm(); runtime.GOOS != "windows" && mode != 0o600 {
+		t.Fatalf("JWT secret mode = %o, want 600", mode)
+	}
+}
+
+func TestLoadOrCreateJWTSecretKeepsConfiguredFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".jwt_secret")
+	if err := os.WriteFile(path, []byte("existing-secret\n"), 0o644); err != nil {
+		t.Fatalf("seed JWT secret: %v", err)
+	}
+
+	secret, err := loadOrCreateJWTSecret(path)
+	if err != nil {
+		t.Fatalf("load JWT secret: %v", err)
+	}
+	if secret != "existing-secret" {
+		t.Fatalf("secret = %q, want existing-secret", secret)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat JWT secret: %v", err)
+	}
+	if mode := info.Mode().Perm(); runtime.GOOS != "windows" && mode != 0o600 {
+		t.Fatalf("JWT secret mode = %o, want 600", mode)
+	}
+}
+
+func TestLoadOrCreateJWTSecretRepairsEmptyFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".jwt_secret")
+	if err := os.WriteFile(path, []byte(" \n"), 0o600); err != nil {
+		t.Fatalf("seed empty JWT secret: %v", err)
+	}
+
+	secret, err := loadOrCreateJWTSecret(path)
+	if err != nil {
+		t.Fatalf("repair JWT secret: %v", err)
+	}
+	if strings.TrimSpace(secret) == "" {
+		t.Fatal("replacement JWT secret is empty")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read repaired JWT secret: %v", err)
+	}
+	if strings.TrimSpace(string(data)) != secret {
+		t.Fatal("repaired JWT secret was not persisted")
+	}
+}


### PR DESCRIPTION
## Summary

- detach NanoKVM services from the invoking login/session without leaving `nohup.out`
- stop detached processes with SIGTERM and wait for the real process lifetime instead of trusting a transient caller shell
- persist an automatically generated JWT signing secret with restrictive permissions so authenticated sessions survive a server restart
- retain explicit configured JWT secrets unchanged and cover creation, reuse, empty-file repair, and permission behavior

## Consolidation

This PR now supersedes #906. Service lifetime and restart-safe authentication are kept together because the restart path is what exposes the former session invalidation.

## Dependencies

None. The Tailscale updater in #900 has its own daemon stop/start verification and can merge independently in either order.

## Validation

Current review: if a process survives both TERM and KILL, stop/restart now returns failure before deleting runtime files or launching another native owner. Mock-process tests cover normal TERM exit, KILL recovery and refusal for a stuck process. JWT package tests pass again.

- `git diff --check`
- `dash -n` for both `S95nanokvm` scripts
- `CGO_ENABLED=1 go test -race ./config`
- `go vet ./config`
- the original service and JWT changes were release-built and runtime-tested across active-stream server restarts

## Try NanoKVM OS

You are also welcome to try [NanoKVM OS](https://github.com/dormancygrace/NanoKVM-OS), a beta firmware for NanoKVM Cube and PCIe that brings together our video, networking, USB and memory improvements. Feedback from real devices is very welcome! Please read the README for the current beta limitations.