### PR TITLE
feat(tailscale): add signed binary updates

### DIFF
--- a/server/proto/tailscale.go
+++ b/server/proto/tailscale.go
@@ -20,3 +20,14 @@ type GetTailscaleStatusRsp struct {
 type LoginTailscaleRsp struct {
 	Url string `json:"url"`
 }
+
+type GetTailscaleVersionRsp struct {
+	Current string `json:"current"`
+	Latest  string `json:"latest"`
+}
+
+type UpdateTailscaleRsp struct {
+	Current    string `json:"current"`
+	Updated    bool   `json:"updated"`
+	Restarting bool   `json:"restarting"`
+}

--- a/server/router/extensions.go
+++ b/server/router/extensions.go
@@ -26,4 +26,6 @@ func extensionsRouter(r *gin.Engine) {
 	api.POST("/tailscale/start", ts.Start)         // tailscale start
 	api.POST("/tailscale/stop", ts.Stop)           // tailscale stop
 	api.POST("/tailscale/restart", ts.Restart)     // tailscale restart
+	api.GET("/tailscale/version", ts.GetVersion)   // get tailscale version
+	api.POST("/tailscale/update", ts.Update)       // update tailscale
 }

--- a/server/service/extensions/tailscale/cli.go
+++ b/server/service/extensions/tailscale/cli.go
@@ -3,6 +3,7 @@ package tailscale
 import (
 	"NanoKVM-Server/utils"
 	"bufio"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -18,6 +19,16 @@ const (
 )
 
 type Cli struct{}
+
+type TsVersion struct {
+	Current string
+	Latest  string
+}
+
+type tailscaleVersionJSON struct {
+	MajorMinorPatch string `json:"majorMinorPatch"`
+	Upstream        string `json:"upstream"`
+}
 
 type TsStatus struct {
 	BackendState string `json:"BackendState"`
@@ -144,4 +155,74 @@ func (c *Cli) Login() (string, error) {
 func (c *Cli) Logout() error {
 	command := "tailscale logout"
 	return exec.Command("sh", "-c", command).Run()
+}
+
+func (c *Cli) Version(ctx context.Context, includeUpstream bool) (*TsVersion, error) {
+	args := []string{"version", "--json"}
+	if includeUpstream {
+		args = append(args, "--upstream")
+	}
+
+	output, err := exec.CommandContext(ctx, TailscalePath, args...).CombinedOutput()
+	if err != nil {
+		return nil, commandError("get tailscale version", output, err)
+	}
+
+	return parseVersion(output, includeUpstream)
+}
+
+func (c *Cli) Update(ctx context.Context) error {
+	output, err := exec.CommandContext(
+		ctx,
+		TailscalePath,
+		"update",
+		"--yes",
+		"--track=stable",
+	).CombinedOutput()
+	if err != nil {
+		return commandError("update tailscale", output, err)
+	}
+
+	return nil
+}
+
+func (c *Cli) IsRunning() bool {
+	return exec.Command("pidof", "tailscaled").Run() == nil
+}
+
+func parseVersion(output []byte, requireUpstream bool) (*TsVersion, error) {
+	// Some Tailscale builds print a warning before their JSON output.
+	if index := strings.IndexByte(string(output), '{'); index >= 0 {
+		output = output[index:]
+	}
+
+	var version tailscaleVersionJSON
+	if err := json.Unmarshal(output, &version); err != nil {
+		return nil, fmt.Errorf("parse tailscale version: %w", err)
+	}
+	if version.MajorMinorPatch == "" {
+		return nil, errors.New("parse tailscale version: current version is missing")
+	}
+	if requireUpstream && version.Upstream == "" {
+		return nil, errors.New("parse tailscale version: upstream version is missing")
+	}
+
+	return &TsVersion{
+		Current: version.MajorMinorPatch,
+		Latest:  version.Upstream,
+	}, nil
+}
+
+func commandError(action string, output []byte, err error) error {
+	const maxOutputLength = 2048
+
+	message := strings.TrimSpace(string(output))
+	if len(message) > maxOutputLength {
+		message = message[:maxOutputLength]
+	}
+	if message == "" {
+		return fmt.Errorf("%s: %w", action, err)
+	}
+
+	return fmt.Errorf("%s: %w: %s", action, err, message)
 }

--- a/server/service/extensions/tailscale/cli.go
+++ b/server/service/extensions/tailscale/cli.go
@@ -11,11 +11,14 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
+	"time"
 )
 
 const (
 	ScriptPath       = "/etc/init.d/S98tailscaled"
 	ScriptBackupPath = "/kvmapp/system/init.d/S98tailscaled"
+
+	daemonStatePollInterval = 100 * time.Millisecond
 )
 
 type Cli struct{}
@@ -71,6 +74,36 @@ func (c *Cli) Restart() error {
 
 	command := strings.Join(commands, " && ")
 	return exec.Command("sh", "-c", command).Run()
+}
+
+// RestartAfterUpdate waits for the old daemon to exit before starting the new
+// binary. S98tailscaled reports success as soon as start-stop-daemon sends the
+// stop signal, so invoking its restart action directly can briefly run two
+// tailscaled processes after an update.
+func (c *Cli) RestartAfterUpdate(ctx context.Context) error {
+	return restartAfterUpdate(ctx, c.Stop, c.Start, c.IsRunning)
+}
+
+func restartAfterUpdate(ctx context.Context, stop, start func() error, isRunning func() bool) error {
+	if isRunning() {
+		if err := stop(); err != nil && isRunning() {
+			return fmt.Errorf("stop tailscale after update: %w", err)
+		}
+	}
+
+	if err := waitForDaemonState(ctx, false, daemonStatePollInterval, isRunning); err != nil {
+		return fmt.Errorf("wait for tailscaled to stop: %w", err)
+	}
+
+	if err := start(); err != nil {
+		return fmt.Errorf("start tailscale after update: %w", err)
+	}
+
+	if err := waitForDaemonState(ctx, true, daemonStatePollInterval, isRunning); err != nil {
+		return fmt.Errorf("wait for tailscaled to start: %w", err)
+	}
+
+	return nil
 }
 
 func (c *Cli) Stop() error {
@@ -188,6 +221,26 @@ func (c *Cli) Update(ctx context.Context) error {
 
 func (c *Cli) IsRunning() bool {
 	return exec.Command("pidof", "tailscaled").Run() == nil
+}
+
+func waitForDaemonState(ctx context.Context, wantRunning bool, pollInterval time.Duration, isRunning func() bool) error {
+	if isRunning() == wantRunning {
+		return nil
+	}
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if isRunning() == wantRunning {
+				return nil
+			}
+		}
+	}
 }
 
 func parseVersion(output []byte, requireUpstream bool) (*TsVersion, error) {

--- a/server/service/extensions/tailscale/cli_test.go
+++ b/server/service/extensions/tailscale/cli_test.go
@@ -1,9 +1,11 @@
 package tailscale
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestParseVersion(t *testing.T) {
@@ -75,5 +77,86 @@ func TestCommandErrorLimitsOutput(t *testing.T) {
 	err := commandError("update tailscale", []byte(strings.Repeat("x", 4096)), errors.New("failed"))
 	if len(err.Error()) > 2100 {
 		t.Fatalf("commandError() returned an unexpectedly long error: %d bytes", len(err.Error()))
+	}
+}
+
+func TestWaitForDaemonState(t *testing.T) {
+	checks := 0
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	err := waitForDaemonState(ctx, false, time.Millisecond, func() bool {
+		checks++
+		return checks < 3
+	})
+	if err != nil {
+		t.Fatalf("waitForDaemonState() error = %v", err)
+	}
+	if checks != 3 {
+		t.Fatalf("waitForDaemonState() checks = %d, want 3", checks)
+	}
+}
+
+func TestWaitForDaemonStateTimeout(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	err := waitForDaemonState(ctx, false, time.Millisecond, func() bool { return true })
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("waitForDaemonState() error = %v, want deadline exceeded", err)
+	}
+}
+
+func TestRestartAfterUpdateWaitsBetweenStopAndStart(t *testing.T) {
+	running := true
+	stopCalls := 0
+	startCalls := 0
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	err := restartAfterUpdate(
+		ctx,
+		func() error {
+			stopCalls++
+			running = false
+			return nil
+		},
+		func() error {
+			startCalls++
+			if running {
+				t.Fatal("start called while old daemon was still running")
+			}
+			running = true
+			return nil
+		},
+		func() bool { return running },
+	)
+	if err != nil {
+		t.Fatalf("restartAfterUpdate() error = %v", err)
+	}
+	if stopCalls != 1 || startCalls != 1 {
+		t.Fatalf("restartAfterUpdate() stop calls = %d, start calls = %d; want 1, 1", stopCalls, startCalls)
+	}
+}
+
+func TestRestartAfterUpdateDoesNotStartOnStopTimeout(t *testing.T) {
+	startCalls := 0
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	err := restartAfterUpdate(
+		ctx,
+		func() error { return nil },
+		func() error {
+			startCalls++
+			return nil
+		},
+		func() bool { return true },
+	)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("restartAfterUpdate() error = %v, want deadline exceeded", err)
+	}
+	if startCalls != 0 {
+		t.Fatalf("restartAfterUpdate() start calls = %d, want 0", startCalls)
 	}
 }

--- a/server/service/extensions/tailscale/cli_test.go
+++ b/server/service/extensions/tailscale/cli_test.go
@@ -1,0 +1,79 @@
+package tailscale
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestParseVersion(t *testing.T) {
+	tests := []struct {
+		name            string
+		output          string
+		requireUpstream bool
+		current         string
+		latest          string
+		wantErr         bool
+	}{
+		{
+			name:            "current and upstream",
+			output:          `{"majorMinorPatch":"1.94.2","upstream":"1.102.3"}`,
+			requireUpstream: true,
+			current:         "1.94.2",
+			latest:          "1.102.3",
+		},
+		{
+			name:    "current only",
+			output:  `{"majorMinorPatch":"1.102.3"}`,
+			current: "1.102.3",
+		},
+		{
+			name:            "warning before json",
+			output:          "warning from platform integration\n{\"majorMinorPatch\":\"1.94.2\",\"upstream\":\"1.102.3\"}",
+			requireUpstream: true,
+			current:         "1.94.2",
+			latest:          "1.102.3",
+		},
+		{
+			name:    "invalid json",
+			output:  "not json",
+			wantErr: true,
+		},
+		{
+			name:    "missing current",
+			output:  `{"upstream":"1.102.3"}`,
+			wantErr: true,
+		},
+		{
+			name:            "missing required upstream",
+			output:          `{"majorMinorPatch":"1.94.2"}`,
+			requireUpstream: true,
+			wantErr:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			version, err := parseVersion([]byte(tt.output), tt.requireUpstream)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("parseVersion() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseVersion() error = %v", err)
+			}
+			if version.Current != tt.current || version.Latest != tt.latest {
+				t.Fatalf("parseVersion() = %+v, want current=%q latest=%q", version, tt.current, tt.latest)
+			}
+		})
+	}
+}
+
+func TestCommandErrorLimitsOutput(t *testing.T) {
+	err := commandError("update tailscale", []byte(strings.Repeat("x", 4096)), errors.New("failed"))
+	if len(err.Error()) > 2100 {
+		t.Fatalf("commandError() returned an unexpectedly long error: %d bytes", len(err.Error()))
+	}
+}

--- a/server/service/extensions/tailscale/service.go
+++ b/server/service/extensions/tailscale/service.go
@@ -26,7 +26,16 @@ const (
 	restartDelay        = time.Second
 )
 
-var updateMutex sync.Mutex
+var operationMutex sync.Mutex
+
+func beginOperation(c *gin.Context, rsp *proto.Response) bool {
+	if operationMutex.TryLock() {
+		return true
+	}
+
+	rsp.ErrRsp(c, -1, "another tailscale operation is in progress")
+	return false
+}
 
 var StateMap = map[string]proto.TailscaleState{
 	"NoState":          proto.TailscaleNotRunning,
@@ -44,6 +53,10 @@ func NewService() *Service {
 
 func (s *Service) Install(c *gin.Context) {
 	var rsp proto.Response
+	if !beginOperation(c, &rsp) {
+		return
+	}
+	defer operationMutex.Unlock()
 
 	if !isInstalled() {
 		if err := install(); err != nil {
@@ -60,12 +73,10 @@ func (s *Service) Install(c *gin.Context) {
 
 func (s *Service) Uninstall(c *gin.Context) {
 	var rsp proto.Response
-
-	if !updateMutex.TryLock() {
-		rsp.ErrRsp(c, -1, "tailscale update already in progress")
+	if !beginOperation(c, &rsp) {
 		return
 	}
-	defer updateMutex.Unlock()
+	defer operationMutex.Unlock()
 
 	_ = NewCli().Stop()
 	_ = utils.DelGoMemLimit()
@@ -79,6 +90,10 @@ func (s *Service) Uninstall(c *gin.Context) {
 
 func (s *Service) Start(c *gin.Context) {
 	var rsp proto.Response
+	if !beginOperation(c, &rsp) {
+		return
+	}
+	defer operationMutex.Unlock()
 
 	err := NewCli().Start()
 	if err != nil {
@@ -97,6 +112,10 @@ func (s *Service) Start(c *gin.Context) {
 
 func (s *Service) Restart(c *gin.Context) {
 	var rsp proto.Response
+	if !beginOperation(c, &rsp) {
+		return
+	}
+	defer operationMutex.Unlock()
 
 	err := NewCli().Restart()
 	if err != nil {
@@ -111,6 +130,10 @@ func (s *Service) Restart(c *gin.Context) {
 
 func (s *Service) Stop(c *gin.Context) {
 	var rsp proto.Response
+	if !beginOperation(c, &rsp) {
+		return
+	}
+	defer operationMutex.Unlock()
 
 	err := NewCli().Stop()
 	if err != nil {
@@ -285,11 +308,15 @@ func (s *Service) Update(c *gin.Context) {
 		rsp.ErrRsp(c, -1, "tailscale not installed")
 		return
 	}
-	if !updateMutex.TryLock() {
-		rsp.ErrRsp(c, -2, "tailscale update already in progress")
+	if !beginOperation(c, &rsp) {
 		return
 	}
-	defer updateMutex.Unlock()
+	restartPending := false
+	defer func() {
+		if !restartPending {
+			operationMutex.Unlock()
+		}
+	}()
 
 	// Once an update starts, finish it even if the browser disconnects. This is
 	// especially important when NanoKVM itself is reached through Tailscale.
@@ -313,6 +340,10 @@ func (s *Service) Update(c *gin.Context) {
 
 	after, err := cli.Version(ctx, false)
 	if err != nil {
+		if wasRunning {
+			restartPending = true
+			restartTailscaleAfterResponse()
+		}
 		log.Errorf("failed to verify tailscale update: %s", err)
 		rsp.ErrRsp(c, -5, "failed to verify tailscale update")
 		return
@@ -330,13 +361,19 @@ func (s *Service) Update(c *gin.Context) {
 		// The Tailscale updater does not recognize NanoKVM's S98tailscaled
 		// Buildroot init script. Restart after sending the response so updating a
 		// device through its Tailscale address does not fail in the browser.
-		go func() {
-			time.Sleep(restartDelay)
-			if restartErr := NewCli().Restart(); restartErr != nil {
-				log.Errorf("tailscale updated but failed to restart: %s", restartErr)
-			}
-		}()
+		restartPending = true
+		restartTailscaleAfterResponse()
 	}
 
 	log.Infof("tailscale update completed: before=%s after=%s restarting=%t", before.Current, after.Current, restarting)
+}
+
+func restartTailscaleAfterResponse() {
+	go func() {
+		defer operationMutex.Unlock()
+		time.Sleep(restartDelay)
+		if restartErr := NewCli().Restart(); restartErr != nil {
+			log.Errorf("tailscale updated but failed to restart: %s", restartErr)
+		}
+	}()
 }

--- a/server/service/extensions/tailscale/service.go
+++ b/server/service/extensions/tailscale/service.go
@@ -24,6 +24,7 @@ const (
 	versionCheckTimeout = 30 * time.Second
 	updateTimeout       = 10 * time.Minute
 	restartDelay        = time.Second
+	restartTimeout      = 30 * time.Second
 )
 
 var operationMutex sync.Mutex
@@ -372,7 +373,10 @@ func restartTailscaleAfterResponse() {
 	go func() {
 		defer operationMutex.Unlock()
 		time.Sleep(restartDelay)
-		if restartErr := NewCli().Restart(); restartErr != nil {
+
+		ctx, cancel := context.WithTimeout(context.Background(), restartTimeout)
+		defer cancel()
+		if restartErr := NewCli().RestartAfterUpdate(ctx); restartErr != nil {
 			log.Errorf("tailscale updated but failed to restart: %s", restartErr)
 		}
 	}()

--- a/server/service/extensions/tailscale/service.go
+++ b/server/service/extensions/tailscale/service.go
@@ -3,8 +3,11 @@ package tailscale
 import (
 	"NanoKVM-Server/proto"
 	"NanoKVM-Server/utils"
+	"context"
 	"net"
 	"os"
+	"sync"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	log "github.com/sirupsen/logrus"
@@ -17,7 +20,13 @@ const (
 	TailscaledPath = "/usr/sbin/tailscaled"
 
 	GoMemLimit int64 = 75
+
+	versionCheckTimeout = 30 * time.Second
+	updateTimeout       = 10 * time.Minute
+	restartDelay        = time.Second
 )
+
+var updateMutex sync.Mutex
 
 var StateMap = map[string]proto.TailscaleState{
 	"NoState":          proto.TailscaleNotRunning,
@@ -51,6 +60,12 @@ func (s *Service) Install(c *gin.Context) {
 
 func (s *Service) Uninstall(c *gin.Context) {
 	var rsp proto.Response
+
+	if !updateMutex.TryLock() {
+		rsp.ErrRsp(c, -1, "tailscale update already in progress")
+		return
+	}
+	defer updateMutex.Unlock()
 
 	_ = NewCli().Stop()
 	_ = utils.DelGoMemLimit()
@@ -236,4 +251,92 @@ func (s *Service) GetStatus(c *gin.Context) {
 
 	rsp.OkRspWithData(c, &data)
 	log.Debugf("get tailscale status successfully")
+}
+
+func (s *Service) GetVersion(c *gin.Context) {
+	var rsp proto.Response
+
+	if !isInstalled() {
+		rsp.ErrRsp(c, -1, "tailscale not installed")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), versionCheckTimeout)
+	defer cancel()
+
+	version, err := NewCli().Version(ctx, true)
+	if err != nil {
+		log.Errorf("failed to get tailscale version: %s", err)
+		rsp.ErrRsp(c, -2, "failed to get tailscale version")
+		return
+	}
+
+	rsp.OkRspWithData(c, &proto.GetTailscaleVersionRsp{
+		Current: version.Current,
+		Latest:  version.Latest,
+	})
+	log.Debugf("get tailscale version successfully: current=%s latest=%s", version.Current, version.Latest)
+}
+
+func (s *Service) Update(c *gin.Context) {
+	var rsp proto.Response
+
+	if !isInstalled() {
+		rsp.ErrRsp(c, -1, "tailscale not installed")
+		return
+	}
+	if !updateMutex.TryLock() {
+		rsp.ErrRsp(c, -2, "tailscale update already in progress")
+		return
+	}
+	defer updateMutex.Unlock()
+
+	// Once an update starts, finish it even if the browser disconnects. This is
+	// especially important when NanoKVM itself is reached through Tailscale.
+	ctx, cancel := context.WithTimeout(context.Background(), updateTimeout)
+	defer cancel()
+
+	cli := NewCli()
+	before, err := cli.Version(ctx, false)
+	if err != nil {
+		log.Errorf("failed to get current tailscale version: %s", err)
+		rsp.ErrRsp(c, -3, "failed to get current tailscale version")
+		return
+	}
+
+	wasRunning := cli.IsRunning()
+	if err = cli.Update(ctx); err != nil {
+		log.Errorf("failed to update tailscale: %s", err)
+		rsp.ErrRsp(c, -4, "tailscale update failed")
+		return
+	}
+
+	after, err := cli.Version(ctx, false)
+	if err != nil {
+		log.Errorf("failed to verify tailscale update: %s", err)
+		rsp.ErrRsp(c, -5, "failed to verify tailscale update")
+		return
+	}
+
+	updated := before.Current != after.Current
+	restarting := updated && wasRunning
+	rsp.OkRspWithData(c, &proto.UpdateTailscaleRsp{
+		Current:    after.Current,
+		Updated:    updated,
+		Restarting: restarting,
+	})
+
+	if restarting {
+		// The Tailscale updater does not recognize NanoKVM's S98tailscaled
+		// Buildroot init script. Restart after sending the response so updating a
+		// device through its Tailscale address does not fail in the browser.
+		go func() {
+			time.Sleep(restartDelay)
+			if restartErr := NewCli().Restart(); restartErr != nil {
+				log.Errorf("tailscale updated but failed to restart: %s", restartErr)
+			}
+		}()
+	}
+
+	log.Infof("tailscale update completed: before=%s after=%s restarting=%t", before.Current, after.Current, restarting)
 }

--- a/web/src/api/extensions/tailscale.ts
+++ b/web/src/api/extensions/tailscale.ts
@@ -49,3 +49,13 @@ export function login() {
 export function logout() {
   return http.post('/api/extensions/tailscale/logout');
 }
+
+// get installed and latest stable tailscale versions
+export function getVersion() {
+  return http.get('/api/extensions/tailscale/version');
+}
+
+// update tailscale to the latest stable version
+export function update() {
+  return http.post('/api/extensions/tailscale/update', undefined, { timeout: 10 * 60 * 1000 });
+}

--- a/web/src/pages/desktop/menu/settings/tailscale/header.tsx
+++ b/web/src/pages/desktop/menu/settings/tailscale/header.tsx
@@ -9,6 +9,7 @@ import { Memory } from './memory.tsx';
 import { Swap } from './swap.tsx';
 import type { State } from './types.ts';
 import { Uninstall } from './uninstall.tsx';
+import { Update } from './update.tsx';
 
 type HeaderProps = {
   state: State | undefined;
@@ -95,6 +96,7 @@ export const Header = ({ state, onSuccess }: HeaderProps) => {
               <div className="flex min-w-[250px] flex-col">
                 <Memory />
                 <Swap />
+                <Update />
                 <Uninstall onSuccess={onSuccess} />
               </div>
             }

--- a/web/src/pages/desktop/menu/settings/tailscale/update.tsx
+++ b/web/src/pages/desktop/menu/settings/tailscale/update.tsx
@@ -76,25 +76,19 @@ export const Update = () => {
     <>
       <button
         type="button"
-        className="flex h-[40px] w-full cursor-pointer items-center justify-between space-x-6 rounded px-2 text-neutral-300 hover:bg-neutral-700/70 disabled:cursor-default"
+        className="flex h-[40px] w-full cursor-pointer items-center justify-between space-x-6 rounded border-0 bg-transparent px-2 text-left text-neutral-300 hover:bg-neutral-700/70 disabled:cursor-default"
         disabled={isChecking || isUpdating}
         onClick={checkForUpdates}
       >
-        <div className="flex flex-col items-start">
-          <span>{t('settings.update.title')}</span>
-          {version && (
-            <span className="text-xs text-neutral-500">
-              {version.current}
-              {version.current !== version.latest && ` -> ${version.latest}`}
-            </span>
-          )}
-        </div>
+        <span>{t('settings.update.title')}</span>
 
-        {isChecking ? (
-          <LoaderCircleIcon className="animate-spin" size={16} />
-        ) : (
-          <RefreshCwIcon size={16} />
-        )}
+        <span className="flex w-[35px] shrink-0 justify-center">
+          {isChecking ? (
+            <LoaderCircleIcon className="animate-spin" size={16} />
+          ) : (
+            <RefreshCwIcon size={16} />
+          )}
+        </span>
       </button>
 
       <Modal

--- a/web/src/pages/desktop/menu/settings/tailscale/update.tsx
+++ b/web/src/pages/desktop/menu/settings/tailscale/update.tsx
@@ -1,0 +1,121 @@
+import { useState } from 'react';
+import { Button, message, Modal } from 'antd';
+import { RefreshCwIcon } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import semver from 'semver';
+
+import * as api from '@/api/extensions/tailscale.ts';
+
+type Version = {
+  current: string;
+  latest: string;
+};
+
+export const Update = () => {
+  const { t } = useTranslation();
+
+  const [version, setVersion] = useState<Version>();
+  const [isChecking, setIsChecking] = useState(false);
+  const [isUpdating, setIsUpdating] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  async function checkForUpdates() {
+    if (isChecking || isUpdating) return;
+    setIsChecking(true);
+
+    try {
+      const rsp = await api.getVersion();
+      if (rsp.code !== 0 || !rsp.data) {
+        message.error(rsp.msg || t('settings.update.queryFailed'));
+        return;
+      }
+
+      const nextVersion = rsp.data as Version;
+      setVersion(nextVersion);
+
+      const current = semver.valid(nextVersion.current);
+      const latest = semver.valid(nextVersion.latest);
+      if (
+        (current && latest && semver.gte(current, latest)) ||
+        nextVersion.current === nextVersion.latest
+      ) {
+        message.success(t('settings.update.isLatest'));
+        return;
+      }
+
+      setIsModalOpen(true);
+    } catch {
+      message.error(t('settings.update.queryFailed'));
+    } finally {
+      setIsChecking(false);
+    }
+  }
+
+  async function update() {
+    if (isUpdating) return;
+    setIsUpdating(true);
+
+    try {
+      const rsp = await api.update();
+      if (rsp.code !== 0 || !rsp.data) {
+        message.error(rsp.msg || t('settings.update.updateFailed'));
+        return;
+      }
+
+      setVersion({ current: rsp.data.current, latest: rsp.data.current });
+      setIsModalOpen(false);
+      message.success(t('settings.update.isLatest'));
+    } catch {
+      message.error(t('settings.update.updateFailed'));
+    } finally {
+      setIsUpdating(false);
+    }
+  }
+
+  return (
+    <>
+      <div className="flex items-center justify-between py-2">
+        <div className="flex flex-col">
+          <span>{t('settings.update.title')}</span>
+          {version && (
+            <span className="text-xs text-neutral-500">
+              {version.current}
+              {version.current !== version.latest && ` -> ${version.latest}`}
+            </span>
+          )}
+        </div>
+
+        <Button
+          shape="round"
+          size="small"
+          loading={isChecking}
+          disabled={isUpdating}
+          onClick={checkForUpdates}
+        >
+          <div className="flex items-center justify-center px-1.5">
+            <RefreshCwIcon size={16} />
+          </div>
+        </Button>
+      </div>
+
+      <Modal
+        title={t('settings.update.title')}
+        open={isModalOpen}
+        onOk={update}
+        onCancel={() => setIsModalOpen(false)}
+        okText={t('settings.update.confirm')}
+        cancelText={t('settings.update.cancel')}
+        confirmLoading={isUpdating}
+        cancelButtonProps={{ disabled: isUpdating }}
+        closable={!isUpdating}
+        maskClosable={!isUpdating}
+        centered
+      >
+        <div className="flex flex-col space-y-2 py-4">
+          {version && <span>{`${version.current} -> ${version.latest}`}</span>}
+          <span className="text-neutral-500">{t('settings.update.available')}</span>
+        </div>
+      </Modal>
+    </>
+  );
+};

--- a/web/src/pages/desktop/menu/settings/tailscale/update.tsx
+++ b/web/src/pages/desktop/menu/settings/tailscale/update.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
-import { Button, message, Modal } from 'antd';
-import { RefreshCwIcon } from 'lucide-react';
+import { message, Modal } from 'antd';
+import { LoaderCircleIcon, RefreshCwIcon } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import semver from 'semver';
 
@@ -74,8 +74,13 @@ export const Update = () => {
 
   return (
     <>
-      <div className="flex items-center justify-between py-2">
-        <div className="flex flex-col">
+      <button
+        type="button"
+        className="flex h-[40px] w-full cursor-pointer items-center justify-between space-x-6 rounded px-2 text-neutral-300 hover:bg-neutral-700/70 disabled:cursor-default"
+        disabled={isChecking || isUpdating}
+        onClick={checkForUpdates}
+      >
+        <div className="flex flex-col items-start">
           <span>{t('settings.update.title')}</span>
           {version && (
             <span className="text-xs text-neutral-500">
@@ -85,18 +90,12 @@ export const Update = () => {
           )}
         </div>
 
-        <Button
-          shape="round"
-          size="small"
-          loading={isChecking}
-          disabled={isUpdating}
-          onClick={checkForUpdates}
-        >
-          <div className="flex items-center justify-center px-1.5">
-            <RefreshCwIcon size={16} />
-          </div>
-        </Button>
-      </div>
+        {isChecking ? (
+          <LoaderCircleIcon className="animate-spin" size={16} />
+        ) : (
+          <RefreshCwIcon size={16} />
+        )}
+      </button>
 
       <Modal
         title={t('settings.update.title')}


### PR DESCRIPTION
## Summary

Add an explicit Tailscale binary update path to the NanoKVM UI and API.

The existing install endpoint is a no-op once both binaries exist, so an installed Tailscale currently stays on the version it was originally downloaded with. This change uses Tailscale's own updater instead of reimplementing archive replacement:

- query the installed and latest stable versions with `tailscale version --json --upstream`
- update with `tailscale update --yes --track=stable`
- verify the installed version before and after the update
- serialize updates and prevent uninstall from racing an in-progress update
- finish an update if the initiating browser disconnects, with a 10-minute bound
- restart NanoKVM's Buildroot `S98tailscaled` service after the response if the daemon was running
- expose the flow in the existing Tailscale settings popover, reusing existing localized update strings

Tailscale's updater stages both binaries and verifies signed distribution metadata before replacing them. NanoKVM performs its own delayed service restart because the upstream init-script detection does not match `S98tailscaled`; delaying it also lets clients connected through the device's Tailscale address receive the API response first.

## Relation to #700

#700 toggles Tailscale's automatic-update preference and also contains unrelated Ethernet configuration. This PR is intentionally narrow and implements an explicit, user-triggered binary update with version reporting, verification, restart handling, and tests.

## Validation

- `go test ./service/extensions/tailscale`
- `go vet ./service/extensions/tailscale`
- cross-compiled the package tests for `linux/riscv64`
- `pnpm lint` (passes with 13 pre-existing hook warnings)
- `pnpm build`
- NanoKVM device dry run on Tailscale 1.94.2:
  - `tailscale version --json --upstream` reports stable 1.102.3
  - `tailscale update --dry-run --track=stable` succeeds
  - no device binaries were changed during validation

## Audit update (2026-09-03)

- Independent full release-package build passed at commit `c799f5d`: https://github.com/dormancygrace/NanoKVM/actions/runs/33735239605
- Install/start/stop/restart/update/uninstall are now serialized server-side.
- A successful binary replacement still schedules a daemon restart if post-update version verification itself fails.
- Runtime validation subsequently updated the device from Tailscale 1.94.2 to 1.102.3 successfully.

- Re-audited against closed PR #883: the post-update restart now waits for the old daemon to disappear before starting the replacement and verifies the new daemon appeared; a timeout never launches a second tailscaled. Added ordering and timeout tests; 100 repeated package-test runs, go vet, and a linux/riscv64 test compile pass.

## Dependencies

None. PR #899 improves the main NanoKVM service lifetime, but this updater verifies the Tailscale daemon's own stop/start lifecycle and can merge independently in either order.

## Try NanoKVM OS

You are also welcome to try [NanoKVM OS](https://github.com/dormancygrace/NanoKVM-OS), a beta firmware for NanoKVM Cube and PCIe that brings together our video, networking, USB and memory improvements. Feedback from real devices is very welcome! Please read the README for the current beta limitations.