### PR TITLE
fix(release): make stripped builds reproducible

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,10 +53,12 @@ RUN cd /tmp/go_cache \
 FROM base_apt AS sdk
 
 ENV HOME="/home/$DOCKER_USER"
+ARG MAIXCDK_REV=30f4b8b7e3f66ded9cfa64fb081b46e30bc27248
 
 RUN cd ~ \
     && git clone https://github.com/Sipeed/MaixCDK \
     && cd MaixCDK \
+    && git checkout "$MAIXCDK_REV" \
     && python3 -m venv . \
     && . ./bin/activate \
     && pip install -U -r requirements.txt 

--- a/scripts/build-in-container.sh
+++ b/scripts/build-in-container.sh
@@ -64,18 +64,20 @@ cd "$NANOKVM_PATH/support/sg2002"
 echo "::endgroup::"
 
 echo "::group::support: build kvm_system"
+./build kvm_system clean
 ./build kvm_system
 ./build kvm_system add_to_kvmapp
 echo "::endgroup::"
 
 echo "::group::support: build kvm_vision (libkvm.so)"
+./build kvm_vision clean
 ./build kvm_vision
 ./build kvm_vision add_to_kvmapp
 echo "::endgroup::"
 
 echo "::group::server: cross-compile NanoKVM-Server"
 cd "$NANOKVM_PATH/server"
-./build.sh
+GOFLAGS="-ldflags=-s" ./build.sh
 echo "::endgroup::"
 
 # support/sg2002/build reports "Build Error!" without a non-zero exit status for

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -116,10 +116,10 @@ for lib in "$ROOT"/server/dl_lib/*; do
     fi
 done
 
-#    The SDK is built from an unpinned MaixCDK checkout, so its dist could one
-#    day add or rename a library (e.g. an soname bump leaving both .409 and
-#    .410 behind) and we would ship a library set nobody reviewed. Require the
-#    shipped names to be exactly the tracked set, and fail loudly otherwise.
+#    The pinned SDK dist could still add or rename a library when its revision
+#    is deliberately updated (e.g. an soname bump leaving both .409 and .410
+#    behind). Require the shipped names to be exactly the tracked set, and fail
+#    loudly otherwise.
 staged_libs=$(cd "$STAGE/server/dl_lib" && ls -1 | LC_ALL=C sort)
 tracked_libs=$(cd "$ROOT/server/dl_lib" && ls -1 | LC_ALL=C sort)
 if [ "$staged_libs" != "$tracked_libs" ]; then

--- a/support/sg2002/additional/kvm_mmf/src/kvm_mmf.cpp
+++ b/support/sg2002/additional/kvm_mmf/src/kvm_mmf.cpp
@@ -957,7 +957,9 @@ static CVI_S32 _mmf_init(void)
 	 ************************************************/
 	s32Ret = SAMPLE_COMM_VI_GetSizeBySensor(stIniCfg.enSnsType[0], &enPicSize);
 	if (s32Ret != CVI_SUCCESS) {
-		SAMPLE_PRT("SAMPLE_COMM_VI_GetSizeBySensor failed with %#x\n", s32Ret);
+		SAMPLE_PRT("SAMPLE_COMM_VI_GetSizeBySensor failed with %#x "
+			"(parsed sensor=%d, expected LT6911=%d)\n", s32Ret,
+			(int)stIniCfg.enSnsType[0], (int)LONTIUM_LT6911_2M_60FPS_8BIT);
 		return s32Ret;
 	}
 

--- a/support/sg2002/build
+++ b/support/sg2002/build
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-export MAIXCDK_PATH=~/MaixCDK
-export NanoKVM_PATH=~/NanoKVM
+export MAIXCDK_PATH="${MAIXCDK_PATH:-$HOME/MaixCDK}"
+export NanoKVM_PATH="${NanoKVM_PATH:-$HOME/NanoKVM}"
 
 Project_Name="None"
 Project_PATH="None"
@@ -16,9 +16,7 @@ maixcdk_build() {
   
   if [ "$input_value" = "from_zero" ]
   then
-    maixcdk build <<EOF
-2
-EOF
+    maixcdk build -p maixcam
   else
     maixcdk build
   fi
@@ -39,15 +37,31 @@ maixcdk_clean(){
   maixcdk clean
 }
 
+sync_component(){
+  local source="$1"
+  local target="$2"
+
+  case "$target" in
+    "$MAIXCDK_PATH"/components/*) ;;
+    *)
+      echo "Refusing to replace component outside MaixCDK: $target" >&2
+      exit 1
+    ;;
+  esac
+
+  rm -rf -- "$target"
+  cp -rf -- "$source" "$target"
+}
+
 case "$1" in
   update_lib)
     # This script does not run under "set -e", and a release build relies on
     # update_lib to guarantee the SDK components match the source tree. A copy
     # that fails silently here would produce stale libraries, so fail loudly.
     set -e
-    cp -rf $NanoKVM_PATH/support/sg2002/additional/kvm $MAIXCDK_PATH/components
-    cp -rf $NanoKVM_PATH/support/sg2002/additional/kvm_mmf $MAIXCDK_PATH/components
-    cp -rf $NanoKVM_PATH/support/sg2002/additional/vision $MAIXCDK_PATH/components
+    sync_component "$NanoKVM_PATH/support/sg2002/additional/kvm" "$MAIXCDK_PATH/components/kvm"
+    sync_component "$NanoKVM_PATH/support/sg2002/additional/kvm_mmf" "$MAIXCDK_PATH/components/kvm_mmf"
+    sync_component "$NanoKVM_PATH/support/sg2002/additional/vision" "$MAIXCDK_PATH/components/vision"
     cp -f $NanoKVM_PATH/support/sg2002/additional/peripheral/port/maixcam/maix_i2c.cpp $MAIXCDK_PATH/components/peripheral/port/maixcam/maix_i2c.cpp
     cp -f $NanoKVM_PATH/support/sg2002/additional/sophgo-middleware/v2/sample/common/sample_common_sensor.c $MAIXCDK_PATH/components/3rd_party/sophgo-middleware/sophgo-middleware/v2/sample/common/
 
@@ -102,6 +116,7 @@ then
 
       JSON_PATH="$Project_PATH/build/config/project_vars.json"
       Platform_Char="\"PLATFORM\": \"maixcam\""
+      SDK_Char="\"SDK_PATH\": \"$MAIXCDK_PATH\""
 
       if [ ! -e "$MAIXCDK_PATH/components/kvm" ]
       then
@@ -125,7 +140,8 @@ then
       cd $Project_PATH
       if [ -f $JSON_PATH ]
       then
-        if grep -q $Platform_Char $JSON_PATH; then
+        if grep -Fq "$Platform_Char" "$JSON_PATH" &&
+           grep -Fq "$SDK_Char" "$JSON_PATH"; then
           maixcdk_build
         else
           maixcdk_clean


### PR DESCRIPTION
## Summary

- strip the Go server's external symbol table and DWARF data in release builds
- pin the MaixCDK revision used by the container instead of building a moving `main`
- replace synchronized NanoKVM components exactly and reject unsafe component destinations
- honor caller-supplied source/SDK paths and invalidate a cached project when its SDK path changes
- select the `maixcam` platform by name rather than an unstable menu index
- clean both native support projects after component synchronization and before every release compile

Standalone diagnostic/local builds retain their existing symbol behavior. Go's `-s` linker option omits the external symbol table and debug information while preserving the dynamic symbol table required by the runtime libraries.

## Why the clean native build is required

`update_lib` changes the MaixCDK component sources, but an incremental project build can retain object files compiled from the previous component tree. That can produce a successful package containing an ABI-inconsistent `libkvm_mmf.so`. The release orchestrator now treats the synchronized source tree as a new build input and cleans before compiling `kvm_system` and `libkvm.so`.

The pinned MaixCDK revision also contains the sensor enum entries used by the synchronized `sample_common_sensor.c`; older headers shift the LT6911 enum value. The MMF initialization error now reports both parsed and expected sensor values to make a future source/header mismatch immediately visible.

## Measured strip impact

Built from the same source with the same toolchain:

| Artifact | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| `NanoKVM-Server` | 24,192,432 B | 17,060,512 B | 7,131,920 B (29.5%) |
| release `.tar.gz` | 16,593,364 B | 11,205,140 B | 5,388,224 B (32.5%) |

## Safety

- `.dynsym` remains available for dynamic linking and package ABI validation.
- `.gopclntab` remains available for Go runtime stack traces/profiling.
- `.go.buildinfo` remains present.
- component replacement is constrained to `$MAIXCDK_PATH/components/*`.
- the packaged library-name set must exactly match the reviewed tracked set.

## Validation

Current review: native-build failures now propagate even after creation of a dist directory (injected-failure test passes). The incorrect BoringCrypto message and environment setting were removed. Pairwise merges with all other open application PRs pass.

Previous build validation:

- clean Xuantie GCC 10.2 builds of `kvm_system`, `libkvm.so` and `libkvm_mmf.so`
- stripped Go 1.27.1 RISC-V server build (Go crypto; BoringCrypto is unavailable on RISC-V)
- full release package and complete minimal firmware image build
- package topology, RISC-V ELF, runtime symbol, RUNPATH and build-identity checks
- all Go packages and release shell regression suites
- `git diff --check`

## Dependencies

None. SDK-side target debugger removal is complementary and can merge independently.

## Try NanoKVM OS

You are also welcome to try [NanoKVM OS](https://github.com/dormancygrace/NanoKVM-OS), a beta firmware for NanoKVM Cube and PCIe that brings together our video, networking, USB and memory improvements. Feedback from real devices is very welcome! Please read the README for the current beta limitations.