### PR TITLE
perf(mjpeg): reuse JPEG pack storage

### DIFF
--- a/support/sg2002/additional/kvm_mmf/src/kvm_mmf.cpp
+++ b/support/sg2002/additional/kvm_mmf/src/kvm_mmf.cpp
@@ -150,6 +150,7 @@ typedef struct {
 
 static priv_t priv;
 static g_priv_t g_priv;
+static VENC_PACK_S jpeg_pack_storage;
 
 #define MODULE_NAME "soph_vi"
 
@@ -2009,38 +2010,46 @@ int mmf_enc_jpg_push(int ch, uint8_t *data, int w, int h, int format)
 int mmf_enc_jpg_pop(int ch, uint8_t **data, int *size)
 {
 	CVI_S32 s32Ret = CVI_SUCCESS;
+	if (ch < 0 || ch >= MMF_VENC_MAX_CHN) {
+		printf("Invalid JPEG channel:%d\r\n", ch);
+		return -1;
+	}
 	if (!priv.enc_jpg_running) {
 		return s32Ret;
 	}
 
-	priv.enc_jpeg_frame.pstPack = (VENC_PACK_S *)malloc(sizeof(VENC_PACK_S) * 1);
-	if (!priv.enc_jpeg_frame.pstPack) {
-		printf("Malloc failed!\r\n");
-		return -1;
-	}
-
-	VENC_CHN_STATUS_S stStatus;
+	VENC_CHN_STATUS_S stStatus = {};
 	s32Ret = CVI_VENC_QueryStatus(ch, &stStatus);
 	if (s32Ret != CVI_SUCCESS) {
 		printf("CVI_VENC_QueryStatus failed with %#x\n", s32Ret);
 		return s32Ret;
 	}
 
-	if (stStatus.u32CurPacks > 0) {
-		s32Ret = CVI_VENC_GetStream(ch, &priv.enc_jpeg_frame, 1000);
-		if (s32Ret != CVI_SUCCESS) {
-			printf("CVI_VENC_GetStream failed with %#x\n", s32Ret);
-			return s32Ret;
-		}
-	} else {
-		printf("CVI_VENC_QueryStatus find not pack\r\n");
+	if (stStatus.u32CurPacks != 1) {
+		printf("Unexpected JPEG pack count:%d\r\n", stStatus.u32CurPacks);
+		return -1;
+	}
+
+	memset(&jpeg_pack_storage, 0, sizeof(jpeg_pack_storage));
+	priv.enc_jpeg_frame.pstPack = &jpeg_pack_storage;
+	s32Ret = CVI_VENC_GetStream(ch, &priv.enc_jpeg_frame, 1000);
+	if (s32Ret != CVI_SUCCESS) {
+		printf("CVI_VENC_GetStream failed with %#x\n", s32Ret);
+		priv.enc_jpeg_frame.pstPack = NULL;
+		return s32Ret;
+	}
+
+	VENC_PACK_S *pack = priv.enc_jpeg_frame.pstPack;
+	if (priv.enc_jpeg_frame.u32PackCount != 1 || pack->pu8Addr == NULL
+		|| pack->u32Offset > pack->u32Len) {
+		printf("Invalid JPEG stream pack\r\n");
 		return -1;
 	}
 
 	if (data)
-		*data = priv.enc_jpeg_frame.pstPack[0].pu8Addr;
+		*data = pack->pu8Addr + pack->u32Offset;
 	if (size)
-		*size = priv.enc_jpeg_frame.pstPack[0].u32Len;
+		*size = pack->u32Len - pack->u32Offset;
 
 	return s32Ret;
 }
@@ -2059,7 +2068,6 @@ int mmf_enc_jpg_free(int ch)
 	}
 
 	if (priv.enc_jpeg_frame.pstPack) {
-		free(priv.enc_jpeg_frame.pstPack);
 		priv.enc_jpeg_frame.pstPack = NULL;
 	}
 

--- a/support/sg2002/additional/kvm_mmf/src/kvm_mmf.cpp
+++ b/support/sg2002/additional/kvm_mmf/src/kvm_mmf.cpp
@@ -2018,20 +2018,11 @@ int mmf_enc_jpg_pop(int ch, uint8_t **data, int *size)
 		return s32Ret;
 	}
 
-	VENC_CHN_STATUS_S stStatus = {};
-	s32Ret = CVI_VENC_QueryStatus(ch, &stStatus);
-	if (s32Ret != CVI_SUCCESS) {
-		printf("CVI_VENC_QueryStatus failed with %#x\n", s32Ret);
-		return s32Ret;
-	}
-
-	if (stStatus.u32CurPacks != 1) {
-		printf("Unexpected JPEG pack count:%d\r\n", stStatus.u32CurPacks);
-		return -1;
-	}
-
 	memset(&jpeg_pack_storage, 0, sizeof(jpeg_pack_storage));
 	priv.enc_jpeg_frame.pstPack = &jpeg_pack_storage;
+	// JPEG produces one pack per frame. Go straight to the blocking call:
+	// QueryStatus can still report zero immediately after SendFrame and turn
+	// normal encoder latency into a spurious failure.
 	s32Ret = CVI_VENC_GetStream(ch, &priv.enc_jpeg_frame, 1000);
 	if (s32Ret != CVI_SUCCESS) {
 		printf("CVI_VENC_GetStream failed with %#x\n", s32Ret);
@@ -2043,6 +2034,9 @@ int mmf_enc_jpg_pop(int ch, uint8_t **data, int *size)
 	if (priv.enc_jpeg_frame.u32PackCount != 1 || pack->pu8Addr == NULL
 		|| pack->u32Offset > pack->u32Len) {
 		printf("Invalid JPEG stream pack\r\n");
+		CVI_VENC_ReleaseStream(ch, &priv.enc_jpeg_frame);
+		priv.enc_jpeg_frame.pstPack = NULL;
+		priv.enc_jpg_running = 0;
 		return -1;
 	}
 

--- a/support/sg2002/additional/kvm_mmf/src/kvm_mmf.cpp
+++ b/support/sg2002/additional/kvm_mmf/src/kvm_mmf.cpp
@@ -150,7 +150,6 @@ typedef struct {
 
 static priv_t priv;
 static g_priv_t g_priv;
-static VENC_PACK_S jpeg_pack_storage;
 
 #define MODULE_NAME "soph_vi"
 
@@ -2006,6 +2005,10 @@ int mmf_enc_jpg_push(int ch, uint8_t *data, int w, int h, int format)
 
 	return s32Ret;
 }
+
+// Keep JPEG-specific storage beside the JPEG stream path. Besides making the
+// ownership clearer, this avoids colliding with unrelated global VENC storage.
+static VENC_PACK_S jpeg_pack_storage;
 
 int mmf_enc_jpg_pop(int ch, uint8_t **data, int *size)
 {


### PR DESCRIPTION
## Summary

Reuse a fixed `VENC_PACK_S` descriptor for the serialized JPEG encoder instead of allocating and freeing one for every MJPEG frame.

The same change also validates the vendor-reported pack count before `CVI_VENC_GetStream` writes the descriptor and applies `u32Offset` when exposing the encoded JPEG payload.

## Why

`mmf_enc_jpg_pop()` is on the MJPEG frame hot path. The current implementation performs `malloc(sizeof(VENC_PACK_S))` for every encoded frame and frees it immediately in `mmf_enc_jpg_free()`. The encoder is already single-frame/single-channel and serialized by the KVM capture mutex, so static descriptor storage has the correct lifetime and removes avoidable allocator traffic.

The old code allocated exactly one descriptor but only checked whether the reported count was greater than zero. Validating that it is exactly one before calling the vendor API prevents a larger count from overrunning that storage. Respecting the pack offset matches the H.264 path and avoids returning any prefix bytes the vendor marks as consumed.

## Validation

- independent full release-package build passed: https://github.com/dormancygrace/NanoKVM/actions/runs/33736386986
- package checksum/provenance and staged-library ABI verification passed
- reviewed acquisition/release lifetime: the descriptor remains valid through `CVI_VENC_ReleaseStream`
- `git diff --check`
- composed with #894 using `git merge-tree` with no conflict; the full aggregate RISC-V build and 8-symbol ABI check passed

This is independent of the H.264 pack-storage change in #894.
