### PR TITLE
fix(kvm_vision): fully release MMF during shutdown

### DIFF
--- a/support/sg2002/additional/kvm/src/kvm_vision.cpp
+++ b/support/sg2002/additional/kvm/src/kvm_vision.cpp
@@ -58,6 +58,10 @@
 
 pthread_mutex_t vi_mutex;
 pthread_mutex_t hdmi_signal_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_t vi_detection_thread;
+static pthread_t watchdog_thread;
+static uint8_t vi_detection_thread_started = 0;
+static uint8_t watchdog_thread_started = 0;
 
 static char NanoKVM_edit[] = {
 	0x00,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0x00,0x41,0x0C,0x33,0xC2,0x66,0xBA,0x00,0x00,
@@ -1121,7 +1125,7 @@ void* watchdog_sf_feed(void * arg)
 {
     while(true)
     {
-        if(kvmv_cfg.try_exit_thread == 1)
+        if(__atomic_load_n(&kvmv_cfg.try_exit_thread, __ATOMIC_ACQUIRE) == 1)
             break;
         time::sleep_ms(500);
         if (watchdog_sf_is_open()){
@@ -1196,7 +1200,7 @@ void* vi_subsystem_detection(void * arg)
     last_vi_state_refresh_ms = vi_state_shared::monotonic_ms() - vi_state_publish_interval_ms;
     while(true)
     {
-        if(kvmv_cfg.try_exit_thread == 1)
+        if(__atomic_load_n(&kvmv_cfg.try_exit_thread, __ATOMIC_ACQUIRE) == 1)
             break;
 
         uint8_t get_new_hdmi_mode = get_hdmi_mode();
@@ -1686,7 +1690,6 @@ int8_t raw_to_h264(image::Image *raw, kvmv_data_t* ret_stream, uint16_t _qlty)
 
 void kvmv_init(uint8_t _debug_info_en)
 {
-    pthread_t thread;
     pthread_mutex_init(&vi_mutex, NULL);
     if(_debug_info_en == 0) debug_en = 0;
     else                    debug_en = 1;
@@ -1700,20 +1703,26 @@ void kvmv_init(uint8_t _debug_info_en)
         kvmv_data_buffer[i].p_img_data = NULL;
     }
 
-    kvmv_cfg.try_exit_thread = 0;
+    __atomic_store_n(&kvmv_cfg.try_exit_thread, 0, __ATOMIC_RELEASE);
     // debug("[kvmv]kvmv_init - 2\r\n");
 
-    if(kvmv_cfg.thread_is_running == 1){
+    if(kvmv_cfg.thread_is_running == 1 || vi_detection_thread_started == 1){
         debug("[kvmv]thread is running!\r\n");
     } else {
-        if (0 != pthread_create(&thread, NULL, vi_subsystem_detection, NULL)) {
+        if (0 != pthread_create(&vi_detection_thread, NULL, vi_subsystem_detection, NULL)) {
             debug("[kvmv]create vi_subsystem_detection thread failed!\r\n");
             // return -1;
+        } else {
+            vi_detection_thread_started = 1;
         }
+    }
 
-        if (0 != pthread_create(&thread, NULL, watchdog_sf_feed, NULL)) {
+    if (watchdog_thread_started == 0) {
+        if (0 != pthread_create(&watchdog_thread, NULL, watchdog_sf_feed, NULL)) {
             debug("[kvmv]create watchdog_sf_feed thread failed!\r\n");
             // return -1;
+        } else {
+            watchdog_thread_started = 1;
         }
     }
     // debug("[kvmv]kvmv_init - 3\r\n");
@@ -1978,12 +1987,21 @@ void free_all_kvmv_data()
 
 void kvmv_deinit()
 {
+    __atomic_store_n(&kvmv_cfg.try_exit_thread, 1, __ATOMIC_RELEASE);
+    if (vi_detection_thread_started == 1) {
+        pthread_join(vi_detection_thread, NULL);
+        vi_detection_thread_started = 0;
+    }
+    if (watchdog_thread_started == 1) {
+        pthread_join(watchdog_thread, NULL);
+        watchdog_thread_started = 0;
+    }
+
     set_hdmi_capture_enabled(0);
-    pthread_mutex_destroy(&vi_mutex);
-    kvmv_cfg.try_exit_thread = 1;
     cam->close();
     mmf_deinit();
     free_all_kvmv_data();
+    pthread_mutex_destroy(&vi_mutex);
 }
 
 uint8_t kvmv_hdmi_control(uint8_t _en)

--- a/support/sg2002/additional/kvm/src/kvm_vision.cpp
+++ b/support/sg2002/additional/kvm/src/kvm_vision.cpp
@@ -1137,6 +1137,7 @@ void* watchdog_sf_feed(void * arg)
             vision_update_watchdog();
         }
     }
+    return NULL;
 }
 
 void get_hdmi_version()
@@ -1447,6 +1448,7 @@ void* vi_subsystem_detection(void * arg)
 		time::sleep_ms(10);
     }
     kvmv_cfg.thread_is_running = 0;
+    return NULL;
 }
 
 int sync_vi_res()

--- a/support/sg2002/additional/kvm/src/kvm_vision.cpp
+++ b/support/sg2002/additional/kvm/src/kvm_vision.cpp
@@ -2000,8 +2000,15 @@ void kvmv_deinit()
     }
 
     set_hdmi_capture_enabled(0);
-    cam->close();
-    mmf_deinit();
+    /*
+     * kvmv owns the whole MMF process lifetime. JPEG takes an additional MMF
+     * reference while active, so a balanced single decrement can leave all
+     * global JPEG/VENC/VB pools alive when Direct was selected last. There are
+     * no workers left at this point; force the process-wide teardown. MMF
+     * closes encoders before the camera channel so an encoder cannot retain a
+     * frame whose VI producer has already been destroyed.
+     */
+    mmf_try_deinit(true);
     free_all_kvmv_data();
     pthread_mutex_destroy(&vi_mutex);
 }

--- a/support/sg2002/additional/kvm_mmf/src/kvm_mmf.cpp
+++ b/support/sg2002/additional/kvm_mmf/src/kvm_mmf.cpp
@@ -1005,9 +1005,16 @@ _need_exit_sys_and_deinit_vi:
 static void _mmf_deinit(void)
 {
 	UNUSED(cvi_ive_deinit);
-	mmf_del_vi_channel_all();
+	/*
+	 * Encoders can still own input frames from VI. Tear them down before VI so
+	 * those frames are returned while their producer is still alive. JPEG also
+	 * owns a separate MMF reference; forced process teardown has already reset
+	 * the reference count, so its public deinit can safely release its pools
+	 * here without recursively entering this function.
+	 */
 	mmf_del_venc_channel_all();
 	mmf_enc_jpg_deinit(0);
+	mmf_del_vi_channel_all();
 	_try_release_venc_all();
 	_try_release_vpss_all();
 	mmf_vi_deinit();
@@ -1815,11 +1822,11 @@ int mmf_enc_jpg_deinit(int ch)
 		_destroy_vb_pool(priv.enc_jpg_output_pool_id);
 		priv.enc_jpg_output_pool_id = -1;
 		_destroy_vb_pool(priv.enc_jpg_input_pool_id);
-		priv.enc_jpg_output_pool_id = -1;
+		priv.enc_jpg_input_pool_id = -1;
 		break;
 	case PIXEL_FORMAT_NV21:
 		_destroy_vb_pool(priv.enc_jpg_input_pool_id);
-		priv.enc_jpg_output_pool_id = -1;
+		priv.enc_jpg_input_pool_id = -1;
 		break;
 	default:
 		break;


### PR DESCRIPTION
## Summary

- retain and join the HDMI detector and watchdog pthreads before MMF teardown
- make the shared stop flag atomic and return explicitly from both worker entry points
- force process-wide MMF teardown instead of leaving the JPEG-owned reference alive
- destroy VENC/JPEG before VI so an encoder cannot retain a frame from a destroyed producer
- correct the JPEG input-pool bookkeeping typo

## Why

`kvmv_deinit()` previously destroyed shared state while two background workers could still use it. It also called one balanced `mmf_deinit()` even though the camera and lazily initialized JPEG encoder each held an MMF reference. In a mixed Direct/WebRTC + MJPEG lifetime, exiting with H26x selected last therefore skipped global teardown and left JPEG/VENC/VB carveout allocations for the replacement process to duplicate.

## Validation

- `git diff --check`
- complete Xuantie GCC 10.2 RISC-V release build passed (`kvm_system`, `libkvm.so`, server, and all 9 imported `libkvm` ABI symbols)
- hardware test on SG2002 NanoKVM at 1920x1080, 60 fps, 10 Mbit/s CBR, GOP 30:
  - mixed H.265 + MJPEG peak: 43,560,960 bytes (41.543 MiB)
  - SIGTERM with 4 Direct + 4 MJPEG clients: ION returned from 43,560,960 to 0 bytes; VB pool count returned to 0
  - five additional mixed Direct/MJPEG shutdown cycles returned ION to 0 and VB pools to 0 every time
  - simulated 48 MiB heap (27 MiB held out of the 75 MiB carveout): 8 Direct H.265 + 8 MJPEG clients, 16 H.264/H.265 transitions with persistent MJPEG, 10 transitions between 720p and 1080p, and stop/restart all passed
  - 4 WebRTC H.265 + 4 MJPEG and 4 WebRTC H.264 + 4 MJPEG passed; H.265 + MJPEG passed again after a full server restart under the 48 MiB limit
  - each WebRTC/MJPEG shutdown returned to the pressure allocation alone with zero VB pools
  - real multimedia peak remained 43,560,960 bytes, leaving 6,770,688 bytes (6.457 MiB) in a 48 MiB heap
  - no ION, OOM, buffer-allocation, VENC, or WebRTC write failures

The matching NanoKVM-only memory-map reduction is https://github.com/sipeed/LicheeRV-Nano-Build/pull/839.