### PR TITLE
perf(mjpeg): encode captured VI frames directly

### DIFF
--- a/support/sg2002/additional/kvm/src/kvm_vision.cpp
+++ b/support/sg2002/additional/kvm/src/kvm_vision.cpp
@@ -2004,19 +2004,27 @@ int kvmv_read_img(uint16_t _width, uint16_t _height, uint8_t _type, uint16_t _ql
 
 int free_kvmv_data(uint8_t ** _pp_kvm_data)
 {
-        // debug("[kvmv]free_kvmv_data - 1\r\n");
+    if(_pp_kvm_data == NULL){
+        return IMG_NOT_EXIST;
+    }
+
+    pthread_mutex_lock(&vi_mutex);
+    // debug("[kvmv]free_kvmv_data - 1\r\n");
     for(int i = 0; i < kvmv_data_buffer_size; i++){
         if(*_pp_kvm_data == kvmv_data_buffer[i].p_img_data){
             // debug("[kvmv]free buffer : %d\n", *_pp_kvm_data);
             if (*_pp_kvm_data != NULL){
                 kvmv_data_buffer[i].in_use = 0;
                 uint8_t _type = kvmv_data_buffer[i].img_data_type;
+                pthread_mutex_unlock(&vi_mutex);
                 return _type;
             } else {
+                pthread_mutex_unlock(&vi_mutex);
                 return IMG_NOT_EXIST;
             }
         }
     }
+    pthread_mutex_unlock(&vi_mutex);
     return IMG_NOT_EXIST;
 }
 

--- a/support/sg2002/additional/kvm/src/kvm_vision.cpp
+++ b/support/sg2002/additional/kvm/src/kvm_vision.cpp
@@ -1651,6 +1651,9 @@ int8_t frame_to_h264(uint8_t *data, int width, int height, int format, int vi_ch
         : mmf_venc_push(kvm_venc.mmf_venc_chn, data, width, height, format);
     if (push_ret) {
         mmf_del_venc_channel(kvm_venc.mmf_venc_chn);
+        if (vi_ch >= 0) {
+            mmf_vi_frame_release(vi_ch);
+        }
         kvm_venc.enc_h264_init = 0;
         // rtmp->unlock();
 		debug("[kvmv]mmf venc push failed!\n");
@@ -1947,6 +1950,9 @@ int kvmv_read_img(uint16_t _width, uint16_t _height, uint8_t _type, uint16_t _ql
             if(p_kvmv_data == NULL){
                 // buffer full
 			    delete img;
+                if(native_vi_ch >= 0){
+                    mmf_vi_frame_release(native_vi_ch);
+                }
                 *_pp_kvm_data = NULL;
                 pthread_mutex_unlock(&vi_mutex);
                 return IMG_BUFFER_FULL;

--- a/support/sg2002/additional/kvm/src/kvm_vision.cpp
+++ b/support/sg2002/additional/kvm/src/kvm_vision.cpp
@@ -1618,7 +1618,8 @@ void set_frame_detact(uint8_t _frame_detact)
     kvmv_cfg.stream_stop = 0;
 }
 
-int8_t raw_to_h264(image::Image *raw, kvmv_data_t* ret_stream, uint16_t _qlty)
+int8_t frame_to_h264(uint8_t *data, int width, int height, int format, int vi_ch,
+    kvmv_data_t* ret_stream, uint16_t _qlty)
 {
 	uint64_t __attribute__((unused)) start_time;
 	uint64_t __attribute__((unused)) frame_time;
@@ -1627,25 +1628,28 @@ int8_t raw_to_h264(image::Image *raw, kvmv_data_t* ret_stream, uint16_t _qlty)
 		// start_time = time::time_ms();
 		// log::info("getimg: %d \r\n", (int)(time::time_ms()));
     mmf_stream_t _stream = {0};
-    if(kvm_venc.enc_h264_init != 1 || raw->width() != kvm_venc.kvm_venc_cfg.w || raw->height() != kvm_venc.kvm_venc_cfg.h || _qlty != kvm_venc.kvm_venc_cfg.bitrate){
-		debug("[kvmv]init_venc_h264	enc_h264_init = %d; raw->width() = %d | %d raw->height() = %d | %d \n",
+    if(kvm_venc.enc_h264_init != 1 || width != kvm_venc.kvm_venc_cfg.w || height != kvm_venc.kvm_venc_cfg.h || _qlty != kvm_venc.kvm_venc_cfg.bitrate){
+		debug("[kvmv]init_venc_h264	enc_h264_init = %d; width = %d | %d height = %d | %d \n",
 				kvm_venc.enc_h264_init,
-				raw->width(), kvm_venc.kvm_venc_cfg.w,
-				raw->height(), kvm_venc.kvm_venc_cfg.h);
+				width, kvm_venc.kvm_venc_cfg.w,
+				height, kvm_venc.kvm_venc_cfg.h);
 
-		init_venc_h264(raw->width(), raw->height(), _qlty);
-        debug("[kvmv]init_venc_h264 finish enc_h264_init = %d; raw->width() = %d | %d raw->height() = %d | %d \n",
+		init_venc_h264(width, height, _qlty);
+        debug("[kvmv]init_venc_h264 finish enc_h264_init = %d; width = %d | %d height = %d | %d \n",
 				kvm_venc.enc_h264_init,
-				raw->width(), kvm_venc.kvm_venc_cfg.w,
-				raw->height(), kvm_venc.kvm_venc_cfg.h);
+				width, kvm_venc.kvm_venc_cfg.w,
+				height, kvm_venc.kvm_venc_cfg.h);
         // if(kvm_venc.enc_h264_init == 1){
-		// 	init_venc_h264(raw->width(), raw->height(), _qlty);
+		// 	init_venc_h264(width, height, _qlty);
 		// } else {
 		// 	init_venc_h264(default_vpss_width, default_vpss_height, default_h264_qlty);
 		// }
     }
 	// log::info("init(): %d \r\n", (int)(time::time_ms() - start_time));
-    if (mmf_venc_push(kvm_venc.mmf_venc_chn, (uint8_t *)raw->data(), raw->width(), raw->height(), mmf_invert_format_to_mmf(raw->format()))) {
+    int push_ret = vi_ch >= 0
+        ? mmf_venc_push_vi(kvm_venc.mmf_venc_chn, vi_ch)
+        : mmf_venc_push(kvm_venc.mmf_venc_chn, data, width, height, format);
+    if (push_ret) {
         mmf_del_venc_channel(kvm_venc.mmf_venc_chn);
         kvm_venc.enc_h264_init = 0;
         // rtmp->unlock();
@@ -1834,17 +1838,35 @@ int kvmv_read_img(uint16_t _width, uint16_t _height, uint8_t _type, uint16_t _ql
 			kvmv_cfg.reinit_flag = 0;
         }
         // debug("[kvmv]befor read img: %d \r\n", (int)(time::time_ms() - start_time));
-        image::Image *img = cam->read();
+        image::Image *img = NULL;
+        int native_vi_ch = -1;
+        int native_len = 0;
+        int native_width = 0;
+        int native_height = 0;
+        int native_format = 0;
+        if (_type == VENC_H264) {
+            native_vi_ch = cam->get_channel();
+            if (mmf_vi_frame_pop_native(native_vi_ch, &native_len, &native_width,
+                    &native_height, &native_format) != 0) {
+                native_vi_ch = -1;
+            }
+        } else {
+            img = cam->read();
+        }
         // debug("[kvmv]read img: %d \r\n", (int)(time::time_ms() - start_time));
 
-        if(img != NULL){
+        if(img != NULL || native_vi_ch >= 0){
             if(kvmv_cfg.fresh_frame_count != 0){
                 // Do not restart VI after HDMI idle. Reopening the MMF
                 // channel can exhaust the carveout heap when the detector
                 // thread is also transitioning. Consume queued frames
                 // instead; the camera buffer contains at most three frames.
                 kvmv_cfg.fresh_frame_count--;
-                delete img;
+                if (native_vi_ch >= 0) {
+                    mmf_vi_frame_release(native_vi_ch);
+                } else {
+                    delete img;
+                }
                 continue;
             }
 
@@ -1930,8 +1952,9 @@ int kvmv_read_img(uint16_t _width, uint16_t _height, uint8_t _type, uint16_t _ql
                 return IMG_BUFFER_FULL;
             }
             // debug("[kvmv]get_save_buffer: %d \r\n", (int)(time::time_ms() - start_time));
-            ret = raw_to_h264(img, p_kvmv_data, maxmin_data(10000, 500, (int)_qlty));
-            // debug("[kvmv]venc raw_to_h264: %d \r\n", (int)(time::time_ms() - start_time));
+            ret = frame_to_h264(NULL, native_width, native_height, native_format,
+                native_vi_ch, p_kvmv_data, maxmin_data(10000, 500, (int)_qlty));
+            // debug("[kvmv]venc frame_to_h264: %d \r\n", (int)(time::time_ms() - start_time));
 			delete img;
             *_pp_kvm_data = p_kvmv_data->p_img_data;
             *_p_kvmv_data_size = p_kvmv_data->img_data_size;

--- a/support/sg2002/additional/kvm/src/kvm_vision.cpp
+++ b/support/sg2002/additional/kvm/src/kvm_vision.cpp
@@ -1573,6 +1573,7 @@ static int8_t frame_to_jpeg(int vi_ch, kvmv_data_t* dump_to, uint16_t quality)
 {
     int ret = mmf_enc_jpg_push_vi_with_quality(0, vi_ch, quality);
     if (ret != 0) {
+        release_save_buffer(dump_to);
         mmf_vi_frame_release(vi_ch);
         return IMG_VENC_ERROR;
     }
@@ -1582,17 +1583,18 @@ static int8_t frame_to_jpeg(int vi_ch, kvmv_data_t* dump_to, uint16_t quality)
     ret = mmf_enc_jpg_pop(0, &data, &data_size);
     if (ret != 0 || data == NULL || data_size <= 0) {
         mmf_enc_jpg_deinit(0);
+        release_save_buffer(dump_to);
         mmf_vi_frame_release(vi_ch);
         return IMG_VENC_ERROR;
     }
 
-    dump_to->p_img_data = (uint8_t *)malloc(data_size);
-    if (dump_to->p_img_data == NULL) {
+    if (!reserve_save_buffer(dump_to, static_cast<uint32_t>(data_size))) {
         dump_to->img_data_size = 0;
         dump_to->img_data_type = 0;
         if (mmf_enc_jpg_free(0) != 0) {
             mmf_enc_jpg_deinit(0);
         }
+        release_save_buffer(dump_to);
         mmf_vi_frame_release(vi_ch);
         return IMG_BUFFER_FULL;
     }
@@ -1602,10 +1604,9 @@ static int8_t frame_to_jpeg(int vi_ch, kvmv_data_t* dump_to, uint16_t quality)
     dump_to->img_data_type = VENC_MJPEG;
     if (mmf_enc_jpg_free(0) != 0) {
         mmf_enc_jpg_deinit(0);
-        free(dump_to->p_img_data);
-        dump_to->p_img_data = NULL;
         dump_to->img_data_size = 0;
         dump_to->img_data_type = 0;
+        release_save_buffer(dump_to);
         mmf_vi_frame_release(vi_ch);
         return IMG_VENC_ERROR;
     }

--- a/support/sg2002/additional/kvm/src/kvm_vision.cpp
+++ b/support/sg2002/additional/kvm/src/kvm_vision.cpp
@@ -108,6 +108,8 @@ typedef struct {
 	uint8_t* p_img_data = NULL;
     uint8_t img_data_type = 0;
     uint32_t img_data_size = 0;
+    uint32_t img_data_capacity = 0;
+    uint8_t in_use = 0;
 } kvmv_data_t;
 
 typedef struct {
@@ -239,13 +241,42 @@ int maxmin_data(int _max, int _min, int _data)
 
 kvmv_data_t* get_save_buffer()
 {
-    kvmv_data_buffer_index = to_roll(kvmv_data_buffer_index + 1);
-    // debug("[kvmv]kvmv_data_buffer_index = %d\n", kvmv_data_buffer_index);
-    // debug("[kvmv]kvmv_data_buffer.p_img_data = %d\n", kvmv_data_buffer[kvmv_data_buffer_index].p_img_data);
-    if(kvmv_data_buffer[kvmv_data_buffer_index].p_img_data == NULL){
-        return &kvmv_data_buffer[kvmv_data_buffer_index];
+    for(int i = 0; i < kvmv_data_buffer_size; i++){
+        kvmv_data_buffer_index = to_roll(kvmv_data_buffer_index + 1);
+        kvmv_data_t* buffer = &kvmv_data_buffer[kvmv_data_buffer_index];
+        if(buffer->in_use == 0){
+            buffer->in_use = 1;
+            buffer->img_data_type = 0;
+            buffer->img_data_size = 0;
+            return buffer;
+        }
     }
     return NULL;
+}
+
+static void release_save_buffer(kvmv_data_t* buffer)
+{
+    if(buffer != NULL){
+        buffer->in_use = 0;
+    }
+}
+
+static bool reserve_save_buffer(kvmv_data_t* buffer, uint32_t size)
+{
+    if(buffer == NULL || size == 0){
+        return false;
+    }
+    if(buffer->p_img_data != NULL && buffer->img_data_capacity >= size){
+        return true;
+    }
+
+    uint8_t* data = (uint8_t *)realloc(buffer->p_img_data, size);
+    if(data == NULL){
+        return false;
+    }
+    buffer->p_img_data = data;
+    buffer->img_data_capacity = size;
+    return true;
 }
 
 // ====HDMI RES==================================================
@@ -1527,8 +1558,7 @@ bool jpg_dump(kvmv_data_t* dump_to, image::Image *raw)
     if(dump_to == NULL || raw == NULL || raw->data() == NULL || raw->data_size() == 0){
         return false;
     }
-    dump_to->p_img_data = (uint8_t *)malloc(raw->data_size());
-    if(dump_to->p_img_data == NULL){
+    if(raw->data_size() > UINT32_MAX || !reserve_save_buffer(dump_to, (uint32_t)raw->data_size())){
         dump_to->img_data_size = 0;
         dump_to->img_data_type = 0;
         return false;
@@ -1573,11 +1603,23 @@ void init_venc_h264(uint16_t _width, uint16_t _height, uint16_t _qlty)
 int h264_stream_dump(kvmv_data_t* dump_to, mmf_stream_t* dump_from)
 {
     static int8_t I_Frame_index = -1;
+    if(dump_to == NULL || dump_from == NULL){
+        return IMG_VENC_ERROR;
+    }
     // debug("[kvmv]dump_from->count = %d\n", dump_from->count);
     if (dump_from->count == 3) {
-
-        dump_to->p_img_data = (uint8_t *)malloc(dump_from->data_size[0]+dump_from->data_size[1]+dump_from->data_size[2]);
-        dump_to->img_data_size = dump_from->data_size[0]+dump_from->data_size[1]+dump_from->data_size[2];
+        for(int i = 0; i < dump_from->count; i++){
+            if(dump_from->data[i] == NULL || dump_from->data_size[i] <= 0){
+                return IMG_VENC_ERROR;
+            }
+        }
+        uint64_t total_size = (uint64_t)dump_from->data_size[0] +
+                              (uint64_t)dump_from->data_size[1] +
+                              (uint64_t)dump_from->data_size[2];
+        if(total_size > UINT32_MAX || !reserve_save_buffer(dump_to, (uint32_t)total_size)){
+            return IMG_BUFFER_FULL;
+        }
+        dump_to->img_data_size = (uint32_t)total_size;
         dump_to->img_data_type = IMG_H264_TYPE_IF;
         memcpy(dump_to->p_img_data, dump_from->data[0], dump_from->data_size[0]);
         memcpy(dump_to->p_img_data+dump_from->data_size[0], dump_from->data[1], dump_from->data_size[1]);
@@ -1592,7 +1634,12 @@ int h264_stream_dump(kvmv_data_t* dump_to, mmf_stream_t* dump_from)
     } else if (dump_from->count == 1) {
         // debug("[kvmv]dump P-Frame\r\n");
         I_Frame_index = -1;
-        dump_to->p_img_data = (uint8_t *)malloc(dump_from->data_size[0]);
+        if(dump_from->data[0] == NULL || dump_from->data_size[0] <= 0){
+            return IMG_VENC_ERROR;
+        }
+        if(!reserve_save_buffer(dump_to, (uint32_t)dump_from->data_size[0])){
+            return IMG_BUFFER_FULL;
+        }
         dump_to->img_data_size = dump_from->data_size[0];
         dump_to->img_data_type = IMG_H264_TYPE_PF;
         memcpy(dump_to->p_img_data, dump_from->data[0], dump_from->data_size[0]);
@@ -1698,6 +1745,8 @@ void kvmv_init(uint8_t _debug_info_en)
     cam->restart(default_vpss_width, default_vpss_height, image::FMT_YVU420SP);
     for(int i = 0; i < kvmv_data_buffer_size; i++){
         kvmv_data_buffer[i].p_img_data = NULL;
+        kvmv_data_buffer[i].img_data_capacity = 0;
+        kvmv_data_buffer[i].in_use = 0;
     }
 
     kvmv_cfg.try_exit_thread = 0;
@@ -1909,6 +1958,7 @@ int kvmv_read_img(uint16_t _width, uint16_t _height, uint8_t _type, uint16_t _ql
             if(jpg == NULL || !jpg_dump(p_kvmv_data, jpg)){
                 delete jpg;
 			    delete img;
+                release_save_buffer(p_kvmv_data);
                 debug("[kvmv]failed to allocate jpg buffer\n");
                 pthread_mutex_unlock(&vi_mutex);
                 return IMG_BUFFER_FULL;
@@ -1933,6 +1983,13 @@ int kvmv_read_img(uint16_t _width, uint16_t _height, uint8_t _type, uint16_t _ql
             ret = raw_to_h264(img, p_kvmv_data, maxmin_data(10000, 500, (int)_qlty));
             // debug("[kvmv]venc raw_to_h264: %d \r\n", (int)(time::time_ms() - start_time));
 			delete img;
+            if(ret < 0){
+                release_save_buffer(p_kvmv_data);
+                *_pp_kvm_data = NULL;
+                *_p_kvmv_data_size = 0;
+                pthread_mutex_unlock(&vi_mutex);
+                return ret;
+            }
             *_pp_kvm_data = p_kvmv_data->p_img_data;
             *_p_kvmv_data_size = p_kvmv_data->img_data_size;
             pthread_mutex_unlock(&vi_mutex);
@@ -1952,10 +2009,7 @@ int free_kvmv_data(uint8_t ** _pp_kvm_data)
         if(*_pp_kvm_data == kvmv_data_buffer[i].p_img_data){
             // debug("[kvmv]free buffer : %d\n", *_pp_kvm_data);
             if (*_pp_kvm_data != NULL){
-        // debug("[kvmv]free_kvmv_data - 2\r\n");
-                free(*_pp_kvm_data);
-        // debug("[kvmv]free_kvmv_data - 3\r\n");
-                kvmv_data_buffer[i].p_img_data = NULL;
+                kvmv_data_buffer[i].in_use = 0;
                 uint8_t _type = kvmv_data_buffer[i].img_data_type;
                 return _type;
             } else {
@@ -1972,6 +2026,8 @@ void free_all_kvmv_data()
         if(kvmv_data_buffer[i].p_img_data != NULL){
             free(kvmv_data_buffer[i].p_img_data);
             kvmv_data_buffer[i].p_img_data = NULL;
+            kvmv_data_buffer[i].img_data_capacity = 0;
+            kvmv_data_buffer[i].in_use = 0;
         }
     }
 }

--- a/support/sg2002/additional/kvm/src/kvm_vision.cpp
+++ b/support/sg2002/additional/kvm/src/kvm_vision.cpp
@@ -1539,6 +1539,50 @@ bool jpg_dump(kvmv_data_t* dump_to, image::Image *raw)
     return true;
 }
 
+static int8_t frame_to_jpeg(int vi_ch, kvmv_data_t* dump_to, uint16_t quality)
+{
+    int ret = mmf_enc_jpg_push_vi_with_quality(0, vi_ch, quality);
+    if (ret != 0) {
+        mmf_vi_frame_release(vi_ch);
+        return IMG_VENC_ERROR;
+    }
+
+    uint8_t *data = NULL;
+    int data_size = 0;
+    ret = mmf_enc_jpg_pop(0, &data, &data_size);
+    if (ret != 0 || data == NULL || data_size <= 0) {
+        mmf_enc_jpg_deinit(0);
+        mmf_vi_frame_release(vi_ch);
+        return IMG_VENC_ERROR;
+    }
+
+    dump_to->p_img_data = (uint8_t *)malloc(data_size);
+    if (dump_to->p_img_data == NULL) {
+        dump_to->img_data_size = 0;
+        dump_to->img_data_type = 0;
+        if (mmf_enc_jpg_free(0) != 0) {
+            mmf_enc_jpg_deinit(0);
+        }
+        mmf_vi_frame_release(vi_ch);
+        return IMG_BUFFER_FULL;
+    }
+
+    memcpy(dump_to->p_img_data, data, data_size);
+    dump_to->img_data_size = data_size;
+    dump_to->img_data_type = VENC_MJPEG;
+    if (mmf_enc_jpg_free(0) != 0) {
+        mmf_enc_jpg_deinit(0);
+        free(dump_to->p_img_data);
+        dump_to->p_img_data = NULL;
+        dump_to->img_data_size = 0;
+        dump_to->img_data_type = 0;
+        mmf_vi_frame_release(vi_ch);
+        return IMG_VENC_ERROR;
+    }
+    mmf_vi_frame_release(vi_ch);
+    return IMG_MJPEG_TYPE;
+}
+
 uint8_t kvmvenc_gop = default_h264_gop;
 kvm_venc_t kvm_venc;
 mmf_venc_cfg_t cfg;
@@ -1847,7 +1891,7 @@ int kvmv_read_img(uint16_t _width, uint16_t _height, uint8_t _type, uint16_t _ql
         int native_width = 0;
         int native_height = 0;
         int native_format = 0;
-        if (_type == VENC_H264) {
+        if (_type == VENC_H264 || (_type == VENC_MJPEG && kvmv_cfg.frame_detact == 0)) {
             native_vi_ch = cam->get_channel();
             if (mmf_vi_frame_pop_native(native_vi_ch, &native_len, &native_width,
                     &native_height, &native_format) != 0) {
@@ -1925,10 +1969,26 @@ int kvmv_read_img(uint16_t _width, uint16_t _height, uint8_t _type, uint16_t _ql
             kvmv_data_t* p_kvmv_data = get_save_buffer();
             if(p_kvmv_data == NULL){
                 // buffer full
-			    delete img;
+                if (native_vi_ch >= 0) {
+                    mmf_vi_frame_release(native_vi_ch);
+                } else {
+			        delete img;
+                }
                 debug("[kvmv]jpg buffer full\n");
                 pthread_mutex_unlock(&vi_mutex);
                 return IMG_BUFFER_FULL;
+            }
+            if (native_vi_ch >= 0) {
+                int ret = frame_to_jpeg(native_vi_ch, p_kvmv_data,
+                    maxmin_data(99, 51, (int)_qlty));
+                if (ret < 0) {
+                    pthread_mutex_unlock(&vi_mutex);
+                    return ret;
+                }
+                *_pp_kvm_data = p_kvmv_data->p_img_data;
+                *_p_kvmv_data_size = p_kvmv_data->img_data_size;
+                pthread_mutex_unlock(&vi_mutex);
+                return ret;
             }
             image::Image *jpg = img->to_jpeg(maxmin_data(99, 51, (int)_qlty));
             if(jpg == NULL || !jpg_dump(p_kvmv_data, jpg)){

--- a/support/sg2002/additional/kvm_mmf/include/kvm_mmf.hpp
+++ b/support/sg2002/additional/kvm_mmf/include/kvm_mmf.hpp
@@ -45,6 +45,9 @@ void mmf_get_vi_vflip(int ch, bool *en);
 
 // get vi frame
 int mmf_vi_frame_pop(int ch, void **data, int *len, int *width, int *height, int *format);
+// Lease a VI frame without mapping it into CPU address space. The frame can be
+// submitted to an H.264 encoder with mmf_venc_push_vi().
+int mmf_vi_frame_pop_native(int ch, int *len, int *width, int *height, int *format);
 void mmf_vi_frame_free(int ch);
 // Release the current VI frame immediately. mmf_vi_frame_free() defers
 // release so the frame can be sent directly to VENC without a second copy.
@@ -65,6 +68,7 @@ int mmf_add_venc_channel(int ch, mmf_venc_cfg_t *cfg);
 int mmf_del_venc_channel(int ch);
 int mmf_del_venc_channel_all();
 int mmf_venc_push(int ch, uint8_t *data, int w, int h, int format);
+int mmf_venc_push_vi(int ch, int vi_ch);
 int mmf_venc_pop(int ch, mmf_stream_t *stream);
 int mmf_venc_free(int ch);
 

--- a/support/sg2002/additional/kvm_mmf/include/kvm_mmf.hpp
+++ b/support/sg2002/additional/kvm_mmf/include/kvm_mmf.hpp
@@ -62,6 +62,7 @@ int mmf_enc_jpg_init(int ch, int w, int h, int format, int quality);
 int mmf_enc_jpg_deinit(int ch);
 int mmf_enc_jpg_push(int ch, uint8_t *data, int w, int h, int format);
 int mmf_enc_jpg_push_with_quality(int ch, uint8_t *data, int w, int h, int format, int quality);
+int mmf_enc_jpg_push_vi_with_quality(int ch, int vi_ch, int quality);
 int mmf_enc_jpg_pop(int ch, uint8_t **data, int *size);
 int mmf_enc_jpg_free(int ch);
 int mmf_add_venc_channel(int ch, mmf_venc_cfg_t *cfg);

--- a/support/sg2002/additional/kvm_mmf/src/kvm_mmf.cpp
+++ b/support/sg2002/additional/kvm_mmf/src/kvm_mmf.cpp
@@ -150,7 +150,6 @@ typedef struct {
 
 static priv_t priv;
 static g_priv_t g_priv;
-static VENC_PACK_S jpeg_pack_storage;
 
 #define MODULE_NAME "soph_vi"
 
@@ -2087,6 +2086,10 @@ int mmf_enc_jpg_push(int ch, uint8_t *data, int w, int h, int format)
 
 	return s32Ret;
 }
+
+// Keep JPEG-specific storage beside the JPEG stream path. Besides making the
+// ownership clearer, this avoids colliding with unrelated global VENC storage.
+static VENC_PACK_S jpeg_pack_storage;
 
 int mmf_enc_jpg_pop(int ch, uint8_t **data, int *size)
 {

--- a/support/sg2002/additional/kvm_mmf/src/kvm_mmf.cpp
+++ b/support/sg2002/additional/kvm_mmf/src/kvm_mmf.cpp
@@ -150,6 +150,7 @@ typedef struct {
 
 static priv_t priv;
 static g_priv_t g_priv;
+static VENC_PACK_S jpeg_pack_storage;
 
 #define MODULE_NAME "soph_vi"
 
@@ -2046,38 +2047,46 @@ int mmf_enc_jpg_push(int ch, uint8_t *data, int w, int h, int format)
 int mmf_enc_jpg_pop(int ch, uint8_t **data, int *size)
 {
 	CVI_S32 s32Ret = CVI_SUCCESS;
+	if (ch < 0 || ch >= MMF_VENC_MAX_CHN) {
+		printf("Invalid JPEG channel:%d\r\n", ch);
+		return -1;
+	}
 	if (!priv.enc_jpg_running) {
 		return s32Ret;
 	}
 
-	priv.enc_jpeg_frame.pstPack = (VENC_PACK_S *)malloc(sizeof(VENC_PACK_S) * 1);
-	if (!priv.enc_jpeg_frame.pstPack) {
-		printf("Malloc failed!\r\n");
-		return -1;
-	}
-
-	VENC_CHN_STATUS_S stStatus;
+	VENC_CHN_STATUS_S stStatus = {};
 	s32Ret = CVI_VENC_QueryStatus(ch, &stStatus);
 	if (s32Ret != CVI_SUCCESS) {
 		printf("CVI_VENC_QueryStatus failed with %#x\n", s32Ret);
 		return s32Ret;
 	}
 
-	if (stStatus.u32CurPacks > 0) {
-		s32Ret = CVI_VENC_GetStream(ch, &priv.enc_jpeg_frame, 1000);
-		if (s32Ret != CVI_SUCCESS) {
-			printf("CVI_VENC_GetStream failed with %#x\n", s32Ret);
-			return s32Ret;
-		}
-	} else {
-		printf("CVI_VENC_QueryStatus find not pack\r\n");
+	if (stStatus.u32CurPacks != 1) {
+		printf("Unexpected JPEG pack count:%d\r\n", stStatus.u32CurPacks);
+		return -1;
+	}
+
+	memset(&jpeg_pack_storage, 0, sizeof(jpeg_pack_storage));
+	priv.enc_jpeg_frame.pstPack = &jpeg_pack_storage;
+	s32Ret = CVI_VENC_GetStream(ch, &priv.enc_jpeg_frame, 1000);
+	if (s32Ret != CVI_SUCCESS) {
+		printf("CVI_VENC_GetStream failed with %#x\n", s32Ret);
+		priv.enc_jpeg_frame.pstPack = NULL;
+		return s32Ret;
+	}
+
+	VENC_PACK_S *pack = priv.enc_jpeg_frame.pstPack;
+	if (priv.enc_jpeg_frame.u32PackCount != 1 || pack->pu8Addr == NULL
+		|| pack->u32Offset > pack->u32Len) {
+		printf("Invalid JPEG stream pack\r\n");
 		return -1;
 	}
 
 	if (data)
-		*data = priv.enc_jpeg_frame.pstPack[0].pu8Addr;
+		*data = pack->pu8Addr + pack->u32Offset;
 	if (size)
-		*size = priv.enc_jpeg_frame.pstPack[0].u32Len;
+		*size = pack->u32Len - pack->u32Offset;
 
 	return s32Ret;
 }
@@ -2096,7 +2105,6 @@ int mmf_enc_jpg_free(int ch)
 	}
 
 	if (priv.enc_jpeg_frame.pstPack) {
-		free(priv.enc_jpeg_frame.pstPack);
 		priv.enc_jpeg_frame.pstPack = NULL;
 	}
 

--- a/support/sg2002/additional/kvm_mmf/src/kvm_mmf.cpp
+++ b/support/sg2002/additional/kvm_mmf/src/kvm_mmf.cpp
@@ -2055,20 +2055,11 @@ int mmf_enc_jpg_pop(int ch, uint8_t **data, int *size)
 		return s32Ret;
 	}
 
-	VENC_CHN_STATUS_S stStatus = {};
-	s32Ret = CVI_VENC_QueryStatus(ch, &stStatus);
-	if (s32Ret != CVI_SUCCESS) {
-		printf("CVI_VENC_QueryStatus failed with %#x\n", s32Ret);
-		return s32Ret;
-	}
-
-	if (stStatus.u32CurPacks != 1) {
-		printf("Unexpected JPEG pack count:%d\r\n", stStatus.u32CurPacks);
-		return -1;
-	}
-
 	memset(&jpeg_pack_storage, 0, sizeof(jpeg_pack_storage));
 	priv.enc_jpeg_frame.pstPack = &jpeg_pack_storage;
+	// JPEG produces one pack per frame. Go straight to the blocking call:
+	// QueryStatus can still report zero immediately after SendFrame and turn
+	// normal encoder latency into a spurious failure.
 	s32Ret = CVI_VENC_GetStream(ch, &priv.enc_jpeg_frame, 1000);
 	if (s32Ret != CVI_SUCCESS) {
 		printf("CVI_VENC_GetStream failed with %#x\n", s32Ret);
@@ -2080,6 +2071,9 @@ int mmf_enc_jpg_pop(int ch, uint8_t **data, int *size)
 	if (priv.enc_jpeg_frame.u32PackCount != 1 || pack->pu8Addr == NULL
 		|| pack->u32Offset > pack->u32Len) {
 		printf("Invalid JPEG stream pack\r\n");
+		CVI_VENC_ReleaseStream(ch, &priv.enc_jpeg_frame);
+		priv.enc_jpeg_frame.pstPack = NULL;
+		priv.enc_jpg_running = 0;
 		return -1;
 	}
 

--- a/support/sg2002/additional/kvm_mmf/src/kvm_mmf.cpp
+++ b/support/sg2002/additional/kvm_mmf/src/kvm_mmf.cpp
@@ -1976,6 +1976,50 @@ int mmf_enc_jpg_push_with_quality(int ch, uint8_t *data, int w, int h, int forma
 	return s32Ret;
 }
 
+int mmf_enc_jpg_push_vi_with_quality(int ch, int vi_ch, int quality)
+{
+	if (ch < 0 || ch >= MMF_VENC_MAX_CHN || vi_ch < 0 || vi_ch >= MMF_VI_MAX_CHN
+		|| !priv.vi_frame_valid[vi_ch] || !priv.vi_frame_deferred[vi_ch]) {
+		printf("Invalid native JPEG frame. venc:%d vi:%d\r\n", ch, vi_ch);
+		return -1;
+	}
+	if (priv.enc_jpg_running) {
+		return 0;
+	}
+
+	VIDEO_FRAME_INFO_S *frame = &priv.vi_frame[vi_ch];
+	int width = frame->stVFrame.u32Width;
+	int height = frame->stVFrame.u32Height;
+	int format = frame->stVFrame.enPixelFormat;
+	if (format != PIXEL_FORMAT_NV21) {
+		printf("Unsupported native JPEG format:%d\r\n", format);
+		return -1;
+	}
+
+	if (!priv.enc_jpg_is_init || priv.enc_jpg_frame_w != width
+		|| priv.enc_jpg_frame_h != height || priv.enc_jpg_frame_fmt != format
+		|| priv.enc_jpg_quality != quality) {
+		mmf_enc_jpg_deinit(ch);
+		int ret = mmf_enc_jpg_init(ch, width, height, format, quality);
+		if (ret != CVI_SUCCESS) {
+			return ret;
+		}
+	}
+
+	CVI_S32 s32Ret = CVI_VENC_SendFrame(ch, frame, 1000);
+	if (s32Ret != CVI_SUCCESS) {
+		printf("CVI_VENC_SendFrame native JPEG failed with %#x, fallback to copy\n", s32Ret);
+		uint8_t *data = (uint8_t *)_mmf_map_vi_frame(vi_ch);
+		if (data == NULL) {
+			return s32Ret;
+		}
+		return mmf_enc_jpg_push_with_quality(ch, data, width, height, format, quality);
+	}
+
+	priv.enc_jpg_running = 1;
+	return s32Ret;
+}
+
 int mmf_enc_jpg_push(int ch, uint8_t *data, int w, int h, int format)
 {
 	UNUSED(ch);

--- a/support/sg2002/additional/kvm_mmf/src/kvm_mmf.cpp
+++ b/support/sg2002/additional/kvm_mmf/src/kvm_mmf.cpp
@@ -2342,7 +2342,7 @@ static int _mmf_venc_push_copy(int ch, uint8_t *data, int w, int h, int format) 
 		{
 			if (frame_info->stVFrame.u32Stride[0] != (CVI_U32)w) {
 				for (int h0 = 0; h0 < h * 3 / 2; h0 ++) {
-					memcpy((uint8_t *)frame_info->stVFrame.pu8VirAddr[0] + frame_info->stVFrame.u32Stride[0] * h,
+					memcpy((uint8_t *)frame_info->stVFrame.pu8VirAddr[0] + frame_info->stVFrame.u32Stride[0] * h0,
 							((uint8_t *)data) + w * h0, w);
 				}
 			} else {

--- a/support/sg2002/additional/kvm_mmf/src/kvm_mmf.cpp
+++ b/support/sg2002/additional/kvm_mmf/src/kvm_mmf.cpp
@@ -207,6 +207,61 @@ static int _mmf_find_deferred_vi_frame(int width, int height, int format,
 	return -1;
 }
 
+static int _mmf_acquire_vi_frame(int ch, int *len, int *width, int *height,
+	int *format)
+{
+	VIDEO_FRAME_INFO_S *frame = &priv.vi_frame[ch];
+	_mmf_release_vi_frame(ch);
+	memset(frame, 0, sizeof(*frame));
+	if (CVI_VPSS_GetChnFrame(0, ch, frame, 1000) != CVI_SUCCESS) {
+		return -1;
+	}
+
+	int image_size = frame->stVFrame.u32Length[0]
+		+ frame->stVFrame.u32Length[1]
+		+ frame->stVFrame.u32Length[2];
+	if (frame->stVFrame.u64PhyAddr[0] == 0 || image_size <= 0) {
+		SAMPLE_PRT("invalid VI frame address or size\n");
+		CVI_VPSS_ReleaseChnFrame(0, ch, frame);
+		memset(frame, 0, sizeof(*frame));
+		return -1;
+	}
+
+	priv.vi_frame_valid[ch] = true;
+	priv.vi_frame_mapped[ch] = false;
+	priv.vi_frame_deferred[ch] = false;
+	*len = image_size;
+	*width = frame->stVFrame.u32Width;
+	*height = frame->stVFrame.u32Height;
+	*format = frame->stVFrame.enPixelFormat;
+	return 0;
+}
+
+static void *_mmf_map_vi_frame(int ch)
+{
+	if (ch < 0 || ch >= MMF_VI_MAX_CHN || !priv.vi_frame_valid[ch]) {
+		return NULL;
+	}
+
+	VIDEO_FRAME_INFO_S *frame = &priv.vi_frame[ch];
+	if (priv.vi_frame_mapped[ch]) {
+		return frame->stVFrame.pu8VirAddr[0];
+	}
+
+	int image_size = frame->stVFrame.u32Length[0]
+		+ frame->stVFrame.u32Length[1]
+		+ frame->stVFrame.u32Length[2];
+	CVI_VOID *vir_addr = CVI_SYS_MmapCache(frame->stVFrame.u64PhyAddr[0], image_size);
+	if (vir_addr == NULL) {
+		SAMPLE_PRT("CVI_SYS_MmapCache failed for VI frame\n");
+		return NULL;
+	}
+	CVI_SYS_IonInvalidateCache(frame->stVFrame.u64PhyAddr[0], vir_addr, image_size);
+	frame->stVFrame.pu8VirAddr[0] = (CVI_U8 *)vir_addr;
+	priv.vi_frame_mapped[ch] = true;
+	return vir_addr;
+}
+
 static int _is_module_in_use(const char *module_name) {
     FILE *fp;
     char buffer[256];
@@ -1499,48 +1554,30 @@ int mmf_vi_frame_pop(int ch, void **data, int *len, int *width, int *height, int
         return -1;
     }
 
-	int ret = -1;
-	VIDEO_FRAME_INFO_S *frame = &priv.vi_frame[ch];
-	_mmf_release_vi_frame(ch);
-	memset(frame, 0, sizeof(*frame));
-	if (CVI_VPSS_GetChnFrame(0, ch, frame, 1000) == 0) {
-        int image_size = frame->stVFrame.u32Length[0]
-                        + frame->stVFrame.u32Length[1]
-				        + frame->stVFrame.u32Length[2];
-		if (frame->stVFrame.u64PhyAddr[0] == 0 || image_size <= 0) {
-			SAMPLE_PRT("invalid VI frame address or size\n");
-			CVI_VPSS_ReleaseChnFrame(0, ch, frame);
-			memset(frame, 0, sizeof(*frame));
-			return -1;
-		}
+	if (_mmf_acquire_vi_frame(ch, len, width, height, format) != 0) {
+		return -1;
+	}
+	*data = _mmf_map_vi_frame(ch);
+	if (*data == NULL) {
+		_mmf_release_vi_frame(ch);
+		return -1;
+	}
+	return 0;
+}
 
-		CVI_VOID *vir_addr;
-		vir_addr = CVI_SYS_MmapCache(frame->stVFrame.u64PhyAddr[0], image_size);
-		if (vir_addr == NULL) {
-			SAMPLE_PRT("CVI_SYS_MmapCache failed for VI frame\n");
-			CVI_VPSS_ReleaseChnFrame(0, ch, frame);
-			memset(frame, 0, sizeof(*frame));
-			return -1;
-		}
-		CVI_SYS_IonInvalidateCache(frame->stVFrame.u64PhyAddr[0], vir_addr, image_size);
-
-		frame->stVFrame.pu8VirAddr[0] = (CVI_U8 *)vir_addr;		// save virtual address for munmap
-		priv.vi_frame_valid[ch] = true;
-		priv.vi_frame_mapped[ch] = true;
-		priv.vi_frame_deferred[ch] = false;
-		// printf("width: %d, height: %d, total_buf_length: %d, phy:%#lx  vir:%p\n",
-		// 	   frame->stVFrame.u32Width,
-		// 	   frame->stVFrame.u32Height, image_size,
-        //        frame->stVFrame.u64PhyAddr[0], vir_addr);
-
-		*data = vir_addr;
-        *len = image_size;
-        *width = frame->stVFrame.u32Width;
-        *height = frame->stVFrame.u32Height;
-        *format = frame->stVFrame.enPixelFormat;
-		return 0;
-    }
-	return ret;
+int mmf_vi_frame_pop_native(int ch, int *len, int *width, int *height, int *format) {
+	if (ch < 0 || ch >= MMF_VI_MAX_CHN || !priv.vi_chn_is_inited[ch]) {
+		return -1;
+	}
+	if (len == NULL || width == NULL || height == NULL || format == NULL) {
+		printf("invalid param\n");
+		return -1;
+	}
+	if (_mmf_acquire_vi_frame(ch, len, width, height, format) != 0) {
+		return -1;
+	}
+	priv.vi_frame_deferred[ch] = true;
+	return 0;
 }
 
 void mmf_vi_frame_free(int ch) {
@@ -2284,10 +2321,10 @@ int mmf_del_venc_channel_all() {
 	return 0;
 }
 
-int mmf_venc_push(int ch, uint8_t *data, int w, int h, int format) {
+static int _mmf_venc_push_copy(int ch, uint8_t *data, int w, int h, int format) {
 	int res = 0;
 	CVI_S32 s32Ret = CVI_SUCCESS;
-	if (ch >= MMF_VENC_MAX_CHN || data == NULL
+	if (ch < 0 || ch >= MMF_VENC_MAX_CHN || data == NULL
 		|| (format != PIXEL_FORMAT_NV21 && format != PIXEL_FORMAT_RGB_888)) {
 		printf("Invalid param. ch:%d data:%p format:%d\r\n", ch, data, format);
 		return -1;
@@ -2298,23 +2335,6 @@ int mmf_venc_push(int ch, uint8_t *data, int w, int h, int format) {
 	if (frame_info == NULL) {
 		printf("frame info is null!\r\n");
 		return -1;
-	}
-
-	/*
-	 * CameraCviMmf can return an Image backed by the mapped VPSS buffer.
-	 * When that frame is deferred, send it directly to VENC and skip the
-	 * Image -> VENC buffer copy. Non-camera callers still use the old path.
-	 */
-	if (info->type == 2) {
-		VIDEO_FRAME_INFO_S *vi_frame = NULL;
-		if (_mmf_find_deferred_vi_frame(w, h, format, &vi_frame) >= 0) {
-			s32Ret = CVI_VENC_SendFrame(ch, vi_frame, 1000);
-			if (s32Ret == CVI_SUCCESS) {
-				info->is_running = 1;
-				return 0;
-			}
-			printf("CVI_VENC_SendFrame zero-copy failed with %#x, fallback to copy\n", s32Ret);
-		}
 	}
 
 	switch (format) {
@@ -2344,6 +2364,59 @@ int mmf_venc_push(int ch, uint8_t *data, int w, int h, int format) {
 	info->is_running = 1;
 
 	return res;
+}
+
+int mmf_venc_push(int ch, uint8_t *data, int w, int h, int format) {
+	if (ch < 0 || ch >= MMF_VENC_MAX_CHN || data == NULL
+		|| (format != PIXEL_FORMAT_NV21 && format != PIXEL_FORMAT_RGB_888)) {
+		printf("Invalid param. ch:%d data:%p format:%d\r\n", ch, data, format);
+		return -1;
+	}
+
+	venc_info_t *info = (venc_info_t *)&priv.venc[ch];
+	if (info->type == 2) {
+		VIDEO_FRAME_INFO_S *vi_frame = NULL;
+		if (_mmf_find_deferred_vi_frame(w, h, format, &vi_frame) >= 0) {
+			CVI_S32 ret = CVI_VENC_SendFrame(ch, vi_frame, 1000);
+			if (ret == CVI_SUCCESS) {
+				info->is_running = 1;
+				return 0;
+			}
+			printf("CVI_VENC_SendFrame zero-copy failed with %#x, fallback to copy\n", ret);
+		}
+	}
+
+	return _mmf_venc_push_copy(ch, data, w, h, format);
+}
+
+int mmf_venc_push_vi(int ch, int vi_ch) {
+	if (ch < 0 || ch >= MMF_VENC_MAX_CHN || vi_ch < 0 || vi_ch >= MMF_VI_MAX_CHN
+		|| !priv.vi_frame_valid[vi_ch] || !priv.vi_frame_deferred[vi_ch]) {
+		printf("Invalid native frame. venc:%d vi:%d\r\n", ch, vi_ch);
+		return -1;
+	}
+
+	venc_info_t *info = (venc_info_t *)&priv.venc[ch];
+	VIDEO_FRAME_INFO_S *frame = &priv.vi_frame[vi_ch];
+	if (info->type != 2 || frame->stVFrame.enPixelFormat != PIXEL_FORMAT_NV21) {
+		printf("Unsupported native frame. venc_type:%d format:%d\r\n",
+			info->type, frame->stVFrame.enPixelFormat);
+		return -1;
+	}
+
+	CVI_S32 ret = CVI_VENC_SendFrame(ch, frame, 1000);
+	if (ret == CVI_SUCCESS) {
+		info->is_running = 1;
+		return 0;
+	}
+
+	printf("CVI_VENC_SendFrame native failed with %#x, fallback to mapped copy\n", ret);
+	uint8_t *data = (uint8_t *)_mmf_map_vi_frame(vi_ch);
+	if (data == NULL) {
+		return -1;
+	}
+	return _mmf_venc_push_copy(ch, data, frame->stVFrame.u32Width,
+		frame->stVFrame.u32Height, frame->stVFrame.enPixelFormat);
 }
 
 int mmf_venc_pop(int ch, mmf_stream_t *stream) {


### PR DESCRIPTION
## Summary
- feed deferred native VI frames directly to the JPEG hardware encoder when frame detection is disabled
- avoid mapping and copying the full NV21 capture frame before JPEG encoding
- preserve the existing mapped-image path when frame detection needs CPU access
- release deferred VI frames and claimed output slots on every success and error path
- reuse the encoded-frame buffers from #896 instead of allocating native MJPEG output per frame

## Why
At 1920x1080, the current MJPEG path maps and copies roughly 3 MiB of NV21 input for every frame before handing it back to VENC. The hardware encoder can consume the captured VI frame directly, so that memory traffic is avoidable whenever CPU-side frame detection is disabled.

## Dependencies
This is stacked on:
- #896 for reusable encoded-frame buffers
- #898 for native deferred VI frame lifetime
- #902 for blocking JPEG output retrieval and a reusable VENC pack descriptor

Please review/merge those first.

## Validation
- `git diff --check`
- composed with #894 using `git merge-tree` with no conflict after placing JPEG descriptor storage beside the JPEG path
- Full release-package builds passed:
  - initial native-frame version: https://github.com/dormancygrace/NanoKVM/actions/runs/33741334217
  - integration with #896 buffer reuse: https://github.com/dormancygrace/NanoKVM/actions/runs/33747097216
- Controlled on-device A/B at 1920x1080, same HDMI input and same 20-second authenticated MJPEG request:
  - copy path: 312 frames (15.6 FPS), about 22% of one CPU
  - native path: 338 frames (16.9 FPS), about 9% of one CPU
  - observed server CPU reduction: about 59%, with about 8% more delivered frames
- The two A/B packages contained the same accumulated fixes and diagnostics; their semantic diff was the native MJPEG path in this PR.
- Active-stream restart with #899 and #903 completed in 3.1 seconds, and only the current encoder's single 9 MiB `jpeg_ion` allocation remained afterward.