### PR TITLE
fix(oled): power off panel during sleep

### DIFF
--- a/support/sg2002/kvm_system/main/lib/oled_ui/oled_ui.cpp
+++ b/support/sg2002/kvm_system/main/lib/oled_ui/oled_ui.cpp
@@ -5,6 +5,8 @@ using namespace maix::sys;
 
 extern kvm_sys_state_t kvm_sys_state;
 extern kvm_oled_state_t kvm_oled_state;
+void OLED_Display_On(void);
+void OLED_Display_Off(void);
 
 void kvm_init_cube_ui(void)
 {
@@ -490,6 +492,21 @@ void oled_auto_sleep_time_update(void)
 	kvm_oled_state.oled_sleep_start = time::time_ms();
 }
 
+static void oled_set_sleep_state(uint8_t sleeping)
+{
+	if(kvm_oled_state.oled_sleep_state == sleeping){
+		return;
+	}
+
+	if(sleeping){
+		OLED_Clear();
+		OLED_Display_Off();
+	} else {
+		OLED_Display_On();
+	}
+	kvm_oled_state.oled_sleep_state = sleeping;
+}
+
 void oled_auto_sleep(void)
 {
 	uint16_t tmp16;
@@ -533,13 +550,15 @@ void oled_auto_sleep(void)
 	if(kvm_oled_state.page == 0){
 		if(kvm_oled_state.oled_sleep_param < OLED_SLEEP_DELAY_MIN){
 			if(sleep_close_signal == 1){
+				oled_set_sleep_state(0);
 				kvm_sys_state.sub_page = 0;
 			}
 		} else {
 			if((time::time_ms() - kvm_oled_state.oled_sleep_start)/1000 >= kvm_oled_state.oled_sleep_param){
-				// kvm_oled_state.oled_sleep_state = 1;
+				oled_set_sleep_state(1);
 				kvm_sys_state.sub_page = 1;
 			} else {
+				oled_set_sleep_state(0);
 				kvm_sys_state.sub_page = 0;
 			}
 		}


### PR DESCRIPTION
## Summary
- send the SSD1306-compatible display-off command when the OLED sleep timer expires
- restore panel power before waking the main page or opening another page
- avoid repeating power commands while the sleep state is unchanged

## Problem
The existing timeout only calls `OLED_Clear()`. That blanks the framebuffer but leaves the OLED charge pump and panel enabled, so the display never actually powers down.

## Validation

The current revision routes main-page sleep/wake changes through panel power control and wakes the display when another page is selected. The production UI functions pass a mock-panel regression covering sleep, wake and repeated drawing without redundant power commands. A fresh RISC-V `kvm_system` build passes. These new paths have not been retested on physical OLED hardware during this review.

Earlier hardware validation:
- `git diff --check`
- Full release-package build passed: https://github.com/dormancygrace/NanoKVM/actions/runs/33743711425
- Installed the built `kvm_system` binary on an SG2002 NanoKVM with a temporary 10-second timeout.
- `strace` on the OLED I2C file descriptor captured the expected command sequence at expiry:
  - `0x8D 0x10` — disable the charge pump
  - `0xAE` — display off
- The process remained alive after sleep, and the configured timeout was restored to 1800 seconds after testing.

## Dependencies

None.

## Try NanoKVM OS

You are also welcome to try [NanoKVM OS](https://github.com/dormancygrace/NanoKVM-OS), a beta firmware for NanoKVM Cube and PCIe that brings together our video, networking, USB and memory improvements. Feedback from real devices is very welcome! Please read the README for the current beta limitations.