### PR TITLE
fix(auth): preserve sessions across server restarts

### DIFF
--- a/server/config/default.go
+++ b/server/config/default.go
@@ -1,5 +1,7 @@
 package config
 
+import "log"
+
 var defaultConfig = &Config{
 	Proto: "http",
 	Host:  "",
@@ -35,7 +37,12 @@ var defaultConfig = &Config{
 
 func checkDefaultValue() {
 	if instance.JWT.SecretKey == "" {
-		instance.JWT.SecretKey = generateRandomSecretKey()
+		secret, err := loadOrCreateJWTSecret(jwtSecretFile)
+		if err != nil {
+			log.Printf("failed to persist JWT secret: %s", err)
+			secret = generateRandomSecretKey()
+		}
+		instance.JWT.SecretKey = secret
 		instance.JWT.RevokeTokensOnLogout = true
 	}
 

--- a/server/config/jwt.go
+++ b/server/config/jwt.go
@@ -4,8 +4,13 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"time"
 )
+
+const jwtSecretFile = "/etc/kvm/.jwt_secret"
 
 // Generate random string for secret key.
 func generateRandomSecretKey() string {
@@ -18,4 +23,55 @@ func generateRandomSecretKey() string {
 	}
 
 	return base64.URLEncoding.EncodeToString(b)
+}
+
+func loadOrCreateJWTSecret(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err == nil {
+		if secret := strings.TrimSpace(string(data)); secret != "" {
+			if err = os.Chmod(path, 0o600); err != nil {
+				return "", err
+			}
+			return secret, nil
+		}
+	} else if !os.IsNotExist(err) {
+		return "", err
+	}
+
+	secret := generateRandomSecretKey()
+	directory := filepath.Dir(path)
+	if err = os.MkdirAll(directory, 0o755); err != nil {
+		return "", err
+	}
+
+	temporary, err := os.CreateTemp(directory, ".jwt-secret-*")
+	if err != nil {
+		return "", err
+	}
+	temporaryPath := temporary.Name()
+	removeTemporary := true
+	defer func() {
+		_ = temporary.Close()
+		if removeTemporary {
+			_ = os.Remove(temporaryPath)
+		}
+	}()
+
+	if err = temporary.Chmod(0o600); err != nil {
+		return "", err
+	}
+	if _, err = temporary.WriteString(secret + "\n"); err != nil {
+		return "", err
+	}
+	if err = temporary.Sync(); err != nil {
+		return "", err
+	}
+	if err = temporary.Close(); err != nil {
+		return "", err
+	}
+	if err = os.Rename(temporaryPath, path); err != nil {
+		return "", err
+	}
+	removeTemporary = false
+	return secret, nil
 }

--- a/server/config/jwt_test.go
+++ b/server/config/jwt_test.go
@@ -1,0 +1,82 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadOrCreateJWTSecretPersistsValue(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".jwt_secret")
+
+	first, err := loadOrCreateJWTSecret(path)
+	if err != nil {
+		t.Fatalf("create JWT secret: %v", err)
+	}
+	if first == "" {
+		t.Fatal("created an empty JWT secret")
+	}
+
+	second, err := loadOrCreateJWTSecret(path)
+	if err != nil {
+		t.Fatalf("reload JWT secret: %v", err)
+	}
+	if second != first {
+		t.Fatalf("secret changed after reload")
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat JWT secret: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o600 {
+		t.Fatalf("JWT secret mode = %o, want 600", mode)
+	}
+}
+
+func TestLoadOrCreateJWTSecretKeepsConfiguredFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".jwt_secret")
+	if err := os.WriteFile(path, []byte("existing-secret\n"), 0o644); err != nil {
+		t.Fatalf("seed JWT secret: %v", err)
+	}
+
+	secret, err := loadOrCreateJWTSecret(path)
+	if err != nil {
+		t.Fatalf("load JWT secret: %v", err)
+	}
+	if secret != "existing-secret" {
+		t.Fatalf("secret = %q, want existing-secret", secret)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat JWT secret: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o600 {
+		t.Fatalf("JWT secret mode = %o, want 600", mode)
+	}
+}
+
+func TestLoadOrCreateJWTSecretRepairsEmptyFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".jwt_secret")
+	if err := os.WriteFile(path, []byte(" \n"), 0o600); err != nil {
+		t.Fatalf("seed empty JWT secret: %v", err)
+	}
+
+	secret, err := loadOrCreateJWTSecret(path)
+	if err != nil {
+		t.Fatalf("repair JWT secret: %v", err)
+	}
+	if strings.TrimSpace(secret) == "" {
+		t.Fatal("replacement JWT secret is empty")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read repaired JWT secret: %v", err)
+	}
+	if strings.TrimSpace(string(data)) != secret {
+		t.Fatal("repaired JWT secret was not persisted")
+	}
+}

--- a/server/config/jwt_test.go
+++ b/server/config/jwt_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -30,7 +31,7 @@ func TestLoadOrCreateJWTSecretPersistsValue(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat JWT secret: %v", err)
 	}
-	if mode := info.Mode().Perm(); mode != 0o600 {
+	if mode := info.Mode().Perm(); runtime.GOOS != "windows" && mode != 0o600 {
 		t.Fatalf("JWT secret mode = %o, want 600", mode)
 	}
 }
@@ -53,7 +54,7 @@ func TestLoadOrCreateJWTSecretKeepsConfiguredFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat JWT secret: %v", err)
 	}
-	if mode := info.Mode().Perm(); mode != 0o600 {
+	if mode := info.Mode().Perm(); runtime.GOOS != "windows" && mode != 0o600 {
 		t.Fatalf("JWT secret mode = %o, want 600", mode)
 	}
 }


### PR DESCRIPTION
## Summary
- persist the generated JWT signing key in `/etc/kvm/.jwt_secret`
- keep an explicitly configured `jwt.secretKey` authoritative
- create/repair the generated key atomically with mode `0600`
- fall back to an ephemeral key, with a log warning, if persistence fails

## Problem
When `jwt.secretKey` is empty (the default), the server currently generates a new key only in memory on every process start. Every app restart therefore invalidates all otherwise-valid browser sessions and sends the GUI back to the login page.

This was reproduced on an SG2002 NanoKVM while validating service restarts: a session cookie worked before restart and returned unauthorized immediately afterward; logging in again issued a working cookie.

## Validation
- `go test ./config` passes with Go 1.25.0
- unit coverage for create/reload, preserving an existing secret, permission tightening, and repairing an empty file
- `git diff --check`
- Full release-package build passed: https://github.com/dormancygrace/NanoKVM/actions/runs/33748676797
- Installed the built server on an SG2002 NanoKVM:
  - the generated file is 89 bytes and mode `0600`
  - its SHA-256 remained unchanged across a full app restart
  - the cookie issued before restart still returned the authenticated admin account with HTTP 200 after both app restart and device reboot