### PR TITLE
fix(stream): restore persisted screen settings

### DIFF
--- a/server/common/screen.go
+++ b/server/common/screen.go
@@ -1,6 +1,11 @@
 package common
 
-import "sync"
+import (
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+)
 
 type Screen struct {
 	Width   uint16
@@ -15,6 +20,12 @@ var (
 	screen     *Screen
 	screenOnce sync.Once
 )
+
+var screenFileMap = map[string]string{
+	"fps":        "/kvmapp/kvm/fps",
+	"quality":    "/kvmapp/kvm/qlty",
+	"resolution": "/kvmapp/kvm/res",
+}
 
 // ResolutionMap height to width
 var ResolutionMap = map[uint16]uint16{
@@ -41,56 +52,85 @@ var BitRateMap = map[uint16]bool{
 
 func GetScreen() *Screen {
 	screenOnce.Do(func() {
-		screen = &Screen{
-			Width:   0,
-			Height:  0,
-			Quality: 80,
-			FPS:     30,
-			BitRate: 3000,
-			GOP:     30,
-		}
+		screen = loadScreen(os.ReadFile)
 	})
 
 	return screen
 }
 
 func SetScreen(key string, value int) {
+	setScreenValue(GetScreen(), key, value)
+}
+
+func setScreenValue(target *Screen, key string, value int) {
 	switch key {
 	case "resolution":
 		height := uint16(value)
 		if width, ok := ResolutionMap[height]; ok {
-			screen.Width = width
-			screen.Height = height
+			target.Width = width
+			target.Height = height
 		}
 
 	case "quality":
 		if value > 100 {
-			screen.BitRate = uint16(value)
+			target.BitRate = uint16(value)
 		} else {
-			screen.Quality = uint16(value)
+			target.Quality = uint16(value)
 		}
 
 	case "fps":
-		screen.FPS = validateFPS(value)
+		target.FPS = validateFPS(value)
 
 	case "gop":
-		screen.GOP = uint8(value)
+		target.GOP = uint8(value)
 	}
 }
 
 func CheckScreen() {
-	if _, ok := ResolutionMap[screen.Height]; !ok {
-		screen.Width = 1920
-		screen.Height = 1080
+	checkScreen(GetScreen())
+}
+
+func checkScreen(target *Screen) {
+	if _, ok := ResolutionMap[target.Height]; !ok {
+		target.Width = 1920
+		target.Height = 1080
 	}
 
-	if _, ok := QualityMap[screen.Quality]; !ok {
-		screen.Quality = 80
+	if _, ok := QualityMap[target.Quality]; !ok {
+		target.Quality = 80
 	}
 
-	if _, ok := BitRateMap[screen.BitRate]; !ok {
-		screen.BitRate = 3000
+	if _, ok := BitRateMap[target.BitRate]; !ok {
+		target.BitRate = 3000
 	}
+}
+
+func loadScreen(readFile func(string) ([]byte, error)) *Screen {
+	target := &Screen{
+		Width:   0,
+		Height:  0,
+		Quality: 80,
+		FPS:     30,
+		BitRate: 3000,
+		GOP:     30,
+	}
+
+	for key, path := range screenFileMap {
+		data, err := readFile(path)
+		if err != nil {
+			continue
+		}
+
+		value, err := strconv.Atoi(strings.TrimSpace(string(data)))
+		if err != nil {
+			continue
+		}
+
+		setScreenValue(target, key, value)
+	}
+
+	checkScreen(target)
+	return target
 }
 
 func validateFPS(fps int) int {

--- a/server/common/screen_test.go
+++ b/server/common/screen_test.go
@@ -1,0 +1,57 @@
+package common
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestLoadScreenReadsPersistedSettings(t *testing.T) {
+	files := map[string][]byte{
+		"/kvmapp/kvm/fps":  []byte("60\n"),
+		"/kvmapp/kvm/qlty": []byte("5000"),
+		"/kvmapp/kvm/res":  []byte("720"),
+	}
+
+	got := loadScreen(func(path string) ([]byte, error) {
+		data, ok := files[path]
+		if !ok {
+			return nil, errors.New("not found")
+		}
+		return data, nil
+	})
+
+	if got.FPS != 60 {
+		t.Fatalf("FPS = %d, want 60", got.FPS)
+	}
+	if got.BitRate != 5000 {
+		t.Fatalf("BitRate = %d, want 5000", got.BitRate)
+	}
+	if got.Width != 1280 || got.Height != 720 {
+		t.Fatalf("resolution = %dx%d, want 1280x720", got.Width, got.Height)
+	}
+}
+
+func TestLoadScreenKeepsDefaultsForMissingOrInvalidSettings(t *testing.T) {
+	files := map[string][]byte{
+		"/kvmapp/kvm/qlty": []byte("9999"),
+		"/kvmapp/kvm/res":  []byte("invalid"),
+	}
+
+	got := loadScreen(func(path string) ([]byte, error) {
+		data, ok := files[path]
+		if !ok {
+			return nil, errors.New("not found")
+		}
+		return data, nil
+	})
+
+	if got.FPS != 30 {
+		t.Fatalf("FPS = %d, want default 30", got.FPS)
+	}
+	if got.Quality != 80 || got.BitRate != 3000 {
+		t.Fatalf("quality = %d, bitrate = %d; want 80 and 3000", got.Quality, got.BitRate)
+	}
+	if got.Width != 0 || got.Height != 0 {
+		t.Fatalf("resolution = %dx%d, want default 0x0", got.Width, got.Height)
+	}
+}


### PR DESCRIPTION
## Summary

- initialize the screen singleton from persisted FPS, quality/bitrate, and resolution files
- reuse the existing validation rules and keep safe defaults for missing or invalid files
- add unit coverage for persisted and invalid settings

## Problem

The settings files survive a NanoKVM server restart, but the in-memory screen state was always recreated with 30 FPS, 3000 kbit/s, and automatic resolution. The configured values were not applied again until the user changed a setting through the UI/API.

## Validation

- CGO_ENABLED=0 go test ./common
- CGO_ENABLED=0 go vet ./common
- full RISC-V server cross-build with the NanoKVM GCC 10.2 toolchain
- runtime-tested on a C906 NanoKVM: persisted fps=60, qlty=5000, res=0 were applied immediately after process start without a UI/API write; capture reached state=1 and 59-60 FPS
- verified live H.264 playback and an existing authenticated browser session after restart