### PR TITLE
fix(mjpeg): recover from stalled clients

### DIFF
--- a/server/service/stream/mjpeg/mjpeg.go
+++ b/server/service/stream/mjpeg/mjpeg.go
@@ -1,9 +1,11 @@
 package mjpeg
 
 import (
+	"net/http"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	log "github.com/sirupsen/logrus"
 )
 
 var streamer = NewStreamer()
@@ -22,10 +24,29 @@ func Connect(c *gin.Context) {
 	c.Header("Pragma", "no-cache")
 	c.Header("X-Server-Date", time.Now().Format(time.RFC1123))
 
-	streamer.AddClient(c)
-	defer streamer.RemoveClient(c)
+	client := streamer.AddClient(c)
+	defer streamer.RemoveClient(client)
+	controller := newResponseController(c.Writer)
 
-	<-c.Request.Context().Done()
+	for {
+		data, ok := client.next()
+		if !ok {
+			return
+		}
+
+		if err := writeFrame(c, controller, data); err != nil {
+			log.Errorf("failed to write mjpeg frame for client %s: %s", c.Request.RemoteAddr, err)
+			return
+		}
+	}
+}
+
+func newResponseController(writer http.ResponseWriter) *http.ResponseController {
+	if unwrapper, ok := writer.(interface{ Unwrap() http.ResponseWriter }); ok {
+		writer = unwrapper.Unwrap()
+	}
+
+	return http.NewResponseController(writer)
 }
 
 func GetLatestFrame() (LatestFrame, bool) {

--- a/server/service/stream/mjpeg/streamer.go
+++ b/server/service/stream/mjpeg/streamer.go
@@ -4,7 +4,10 @@ import (
 	"NanoKVM-Server/common"
 	"NanoKVM-Server/service/stream"
 	"NanoKVM-Server/service/vm"
+	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -16,11 +19,13 @@ import (
 
 var crlf = []byte("\r\n")
 
+const clientWriteTimeout = 5 * time.Second
+
 type Streamer struct {
 	mutex          sync.Mutex
-	clients        map[*gin.Context]bool
-	clientSnapshot atomic.Pointer[[]*gin.Context]
-	running        int32
+	clients        map[*mjpegClient]struct{}
+	clientSnapshot atomic.Pointer[[]*mjpegClient]
+	running        bool
 	frameMutex     sync.RWMutex
 	latestFrame    LatestFrame
 	cacheRefs      int32
@@ -29,31 +34,89 @@ type Streamer struct {
 
 func NewStreamer() *Streamer {
 	s := &Streamer{
-		clients: make(map[*gin.Context]bool),
+		clients: make(map[*mjpegClient]struct{}),
 	}
 	s.updateClientSnapshotLocked()
 
 	return s
 }
 
-func (s *Streamer) AddClient(c *gin.Context) {
-	s.mutex.Lock()
-	s.clients[c] = true
-	count := s.updateClientSnapshotLocked()
-	s.viewerVersion++
-	version := s.viewerVersion
-	s.mutex.Unlock()
-	vm.UpdateHdmiViewerSnapshot("mjpeg", count, version)
+type mjpegClient struct {
+	ctx    context.Context
+	frames chan []byte
+}
 
-	if atomic.CompareAndSwapInt32(&s.running, 0, 1) {
-		go s.run()
-		log.Debug("mjpeg stream started")
+func newMjpegClient(ctx context.Context) *mjpegClient {
+	return &mjpegClient{
+		ctx:    ctx,
+		frames: make(chan []byte, 1),
 	}
 }
 
-func (s *Streamer) RemoveClient(c *gin.Context) {
+func (c *mjpegClient) next() ([]byte, bool) {
+	select {
+	case <-c.ctx.Done():
+		return nil, false
+	default:
+	}
+
+	select {
+	case data := <-c.frames:
+		return data, true
+	case <-c.ctx.Done():
+		return nil, false
+	}
+}
+
+func (c *mjpegClient) offer(data []byte) {
+	select {
+	case c.frames <- data:
+		return
+	default:
+	}
+
+	// Keep only the newest frame so a slow connection cannot stall capture.
+	select {
+	case <-c.frames:
+	default:
+	}
+	select {
+	case c.frames <- data:
+	default:
+	}
+}
+
+func (s *Streamer) AddClient(c *gin.Context) *mjpegClient {
+	client := newMjpegClient(c.Request.Context())
+
 	s.mutex.Lock()
-	delete(s.clients, c)
+	s.clients[client] = struct{}{}
+	count := s.updateClientSnapshotLocked()
+	s.viewerVersion++
+	version := s.viewerVersion
+	start := !s.running
+	if start {
+		s.running = true
+	}
+	s.mutex.Unlock()
+	vm.UpdateHdmiViewerSnapshot("mjpeg", count, version)
+
+	if start {
+		go s.run()
+		log.Debug("mjpeg stream started")
+	}
+
+	return client
+}
+
+func (s *Streamer) RemoveClient(client *mjpegClient) {
+	s.mutex.Lock()
+	if _, exists := s.clients[client]; !exists {
+		s.mutex.Unlock()
+		return
+	}
+
+	delete(s.clients, client)
 	count := s.updateClientSnapshotLocked()
 	s.viewerVersion++
 	version := s.viewerVersion
@@ -64,7 +127,7 @@ func (s *Streamer) RemoveClient(c *gin.Context) {
 }
 
 func (s *Streamer) updateClientSnapshotLocked() int {
-	clients := make([]*gin.Context, 0, len(s.clients))
+	clients := make([]*mjpegClient, 0, len(s.clients))
 	for c := range s.clients {
 		clients = append(clients, c)
 	}
@@ -73,7 +136,7 @@ func (s *Streamer) updateClientSnapshotLocked() int {
 	return len(clients)
 }
 
-func (s *Streamer) getClients() []*gin.Context {
+func (s *Streamer) getClients() []*mjpegClient {
 	clients := s.clientSnapshot.Load()
 	if clients == nil {
 		return nil
@@ -83,8 +146,6 @@ func (s *Streamer) getClients() []*gin.Context {
 }
 
 func (s *Streamer) run() {
-	defer atomic.StoreInt32(&s.running, 0)
-
 	screen := common.GetScreen()
 	common.CheckScreen()
 	fps := screen.FPS
@@ -97,8 +158,11 @@ func (s *Streamer) run() {
 	for range ticker.C {
 		clients := s.getClients()
 		if len(clients) == 0 {
-			log.Debug("mjpeg stream stopped due to no clients")
-			return
+			if s.stopIfIdle() {
+				log.Debug("mjpeg stream stopped due to no clients")
+				return
+			}
+			continue
 		}
 
 		data, result := vision.ReadMjpeg(screen.Width, screen.Height, screen.Quality)
@@ -112,10 +176,7 @@ func (s *Streamer) run() {
 		}
 
 		for _, client := range clients {
-			if err := writeFrame(client, data); err != nil {
-				log.Errorf("failed to write mjpeg frame for client %s: %s", client.Request.RemoteAddr, err)
-				s.RemoveClient(client)
-			}
+			client.offer(data)
 		}
 
 		if screen.FPS != fps && screen.FPS != 0 {
@@ -125,6 +186,18 @@ func (s *Streamer) run() {
 
 		stream.GetFrameRateCounter().Update()
 	}
+}
+
+func (s *Streamer) stopIfIdle() bool {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	if len(s.clients) > 0 {
+		return false
+	}
+
+	s.running = false
+	return true
 }
 
 func (s *Streamer) setLatestFrame(data []byte, width uint16, height uint16) {
@@ -192,7 +265,7 @@ func (s *Streamer) getLatestFrame() (LatestFrame, bool) {
 	}, true
 }
 
-func writeFrame(c *gin.Context, data []byte) (err error) {
+func writeFrame(c *gin.Context, controller *http.ResponseController, data []byte) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = c.Request.Context().Err()
@@ -201,6 +274,10 @@ func writeFrame(c *gin.Context, data []byte) (err error) {
 			}
 		}
 	}()
+
+	if err = controller.SetWriteDeadline(time.Now().Add(clientWriteTimeout)); err != nil && !errors.Is(err, http.ErrNotSupported) {
+		return err
+	}
 
 	header := "--frame\r\nContent-Type: image/jpeg\r\nContent-Length: " + strconv.Itoa(len(data)) + "\r\n\r\n"
 	if _, err = c.Writer.WriteString(header); err != nil {
@@ -215,6 +292,5 @@ func writeFrame(c *gin.Context, data []byte) (err error) {
 		return err
 	}
 
-	c.Writer.Flush()
-	return nil
+	return controller.Flush()
 }

--- a/server/service/stream/mjpeg/streamer_test.go
+++ b/server/service/stream/mjpeg/streamer_test.go
@@ -1,0 +1,114 @@
+package mjpeg
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+type controlledResponseWriter struct {
+	header    http.Header
+	deadline  time.Time
+	flushErr  error
+	writeSize int
+}
+
+func (w *controlledResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *controlledResponseWriter) Write(data []byte) (int, error) {
+	w.writeSize += len(data)
+	return len(data), nil
+}
+
+func (w *controlledResponseWriter) WriteHeader(_ int) {}
+
+func (w *controlledResponseWriter) SetWriteDeadline(deadline time.Time) error {
+	w.deadline = deadline
+	return nil
+}
+
+func (w *controlledResponseWriter) FlushError() error {
+	return w.flushErr
+}
+
+func TestClientOfferKeepsNewestFrame(t *testing.T) {
+	client := newMjpegClient(context.Background())
+	client.offer([]byte("old"))
+	client.offer([]byte("new"))
+
+	frame, ok := client.next()
+	if !ok {
+		t.Fatal("client unexpectedly closed")
+	}
+	if got := string(frame); got != "new" {
+		t.Fatalf("got frame %q, want newest frame", got)
+	}
+}
+
+func TestClientNextStopsWhenContextIsCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	client := newMjpegClient(ctx)
+	cancel()
+
+	if _, ok := client.next(); ok {
+		t.Fatal("next returned a frame after cancellation")
+	}
+}
+
+func TestStopIfIdleKeepsStreamerRunningWhenClientArrives(t *testing.T) {
+	streamer := NewStreamer()
+	client := newMjpegClient(context.Background())
+
+	streamer.mutex.Lock()
+	streamer.running = true
+	streamer.clients[client] = struct{}{}
+	streamer.updateClientSnapshotLocked()
+	streamer.mutex.Unlock()
+
+	if streamer.stopIfIdle() {
+		t.Fatal("streamer stopped with an active client")
+	}
+	if !streamer.running {
+		t.Fatal("streamer running flag was cleared with an active client")
+	}
+}
+
+func TestStopIfIdleClearsRunningFlag(t *testing.T) {
+	streamer := NewStreamer()
+	streamer.running = true
+
+	if !streamer.stopIfIdle() {
+		t.Fatal("idle streamer did not stop")
+	}
+	if streamer.running {
+		t.Fatal("idle streamer running flag was not cleared")
+	}
+}
+
+func TestWriteFrameUsesUnderlyingDeadlineAndFlushError(t *testing.T) {
+	flushErr := errors.New("flush failed")
+	underlying := &controlledResponseWriter{
+		header:   make(http.Header),
+		flushErr: flushErr,
+	}
+	context, _ := gin.CreateTestContext(underlying)
+	context.Request = httptest.NewRequest(http.MethodGet, "/api/stream/mjpeg", nil)
+
+	err := writeFrame(context, newResponseController(context.Writer), []byte("frame"))
+	if !errors.Is(err, flushErr) {
+		t.Fatalf("writeFrame error = %v, want %v", err, flushErr)
+	}
+	if underlying.deadline.IsZero() {
+		t.Fatal("write deadline was not set on the underlying response writer")
+	}
+	if underlying.writeSize == 0 {
+		t.Fatal("frame was not written before flush")
+	}
+}

--- a/web/src/pages/desktop/screen/mjpeg.tsx
+++ b/web/src/pages/desktop/screen/mjpeg.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
 import { useAtomValue } from 'jotai';
 
@@ -10,13 +10,39 @@ import { resolutionAtom } from '@/jotai/screen.ts';
 
 import { ScreenViewport } from './viewport.tsx';
 
+const INITIAL_RETRY_DELAY = 1000;
+const MAX_RETRY_DELAY = 10000;
+const STREAM_HEALTH_INTERVAL = 1000;
+
 export const Mjpeg = () => {
   const resolution = useAtomValue(resolutionAtom);
   const mouseStyle = useAtomValue(mouseStyleAtom);
   const [hasError, setHasError] = useState(false);
   const [streamNonce, setStreamNonce] = useState(0);
+  const image = useRef<HTMLImageElement>(null);
+  const retryDelay = useRef(INITIAL_RETRY_DELAY);
+  const retryTimer = useRef<number>();
   const streamURL = `${getBaseUrl('http')}/api/stream/mjpeg`;
   const streamSrc = hasError ? undefined : `${streamURL}?v=${streamNonce}`;
+
+  const reconnect = useCallback(() => {
+    if (retryTimer.current !== undefined) {
+      return;
+    }
+
+    setHasError(true);
+
+    retryTimer.current = window.setTimeout(() => {
+      retryTimer.current = undefined;
+      setStreamNonce((current) => current + 1);
+      setHasError(false);
+    }, retryDelay.current);
+    retryDelay.current = Math.min(retryDelay.current * 2, MAX_RETRY_DELAY);
+  }, []);
+
+  const resetRetryDelay = useCallback(() => {
+    retryDelay.current = INITIAL_RETRY_DELAY;
+  }, []);
 
   useEffect(() => {
     // stop frame detect for a while
@@ -24,20 +50,37 @@ export const Mjpeg = () => {
     if (enabled) {
       stopFrameDetect(10);
     }
+    window.clearTimeout(retryTimer.current);
+    retryTimer.current = undefined;
+    retryDelay.current = INITIAL_RETRY_DELAY;
     setHasError(false);
     setStreamNonce((current) => current + 1);
+
+    return () => window.clearTimeout(retryTimer.current);
   }, [resolution]);
+
+  useEffect(() => {
+    const healthTimer = window.setInterval(() => {
+      if (image.current?.complete && image.current.naturalWidth === 0 && !hasError) {
+        reconnect();
+      }
+    }, STREAM_HEALTH_INTERVAL);
+
+    return () => window.clearInterval(healthTimer);
+  }, [hasError, reconnect]);
 
   return (
     <ScreenViewport>
       <img
+        ref={image}
         id="screen"
         className={clsx('block touch-none select-none', mouseStyle)}
         style={{
           visibility: hasError ? 'hidden' : 'visible'
         }}
         src={streamSrc}
-        onError={() => setHasError(true)}
+        onLoad={resetRetryDelay}
+        onError={reconnect}
         alt="screen"
       />
     </ScreenViewport>


### PR DESCRIPTION
## Summary

- isolate every MJPEG response writer from the shared capture loop with a one-frame latest-value queue
- bound stalled writes and preserve HTTP/2 flush errors by unwrapping Gin's response writer
- detect Chrome's silent `multipart/x-mixed-replace` termination and reconnect with bounded exponential backoff
- keep MJPEG capture start/stop transitions race-free while clients reconnect

## Why

A slow or half-dead MJPEG connection previously blocked the single capture goroutine while it wrote a frame. One reproduced five-second TCP reset left the image at `complete=true` with a 0x0 natural size, stopped capture at 0 FPS, and retained a roughly 1.16 MiB send queue. Reloading did not recover because the shared writer remained blocked.

Each client now writes from its own capacity-one queue. New frames replace stale queued frames, so one connection cannot stall capture for every viewer. The browser also retries when Chrome closes a multipart stream without firing `onError`.

## Validation

- `go test -race ./service/stream/mjpeg` with an isolated test stub for the RISC-V `libkvm.so`
- release-equivalent RISC-V build via `server/build.sh`
- `pnpm exec prettier --check src/pages/desktop/screen/mjpeg.tsx`
- `pnpm lint` (0 errors; 13 pre-existing warnings elsewhere)
- `pnpm build`
- runtime A/B on NanoKVM at 1920x1080, lossless MJPEG, 60 FPS setting:
  - before: TCP reset produced a permanent black 0x0 image and capture fell to 0 FPS
  - after: capture continued at 40-48 FPS and the GUI automatically reconnected (`v=1` to `v=3`, repeated as `v=6`) without a page reload
- rebooted with the exact final backend/frontend builds, then restored H.264 WebRTC and verified a live 1920x1080 stream at 58-60 FPS