### PR TITLE
perf(system): load only the matching Wi-Fi driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ VISION_BUILD_CMD := . ./home/build/MaixCDK/bin/activate && cd /home/build/NanoKV
 RELEASE_BUILD_CMD := /home/build/NanoKVM/scripts/build-in-container.sh
 
 .PHONY: help check-root builder-image rebuild-image check-image shell app support vision \
-        web release-build package release all clean
+        test-wifi-modules web release-build package release all clean
 
 # Default target
 all: app support
@@ -42,6 +42,7 @@ help:
 	@echo "  app           - Build Go application server"
 	@echo "  support       - Build kvm_system daemon"
 	@echo "  vision        - Build video libraries (libkvm.so)"
+	@echo "  test-wifi-modules - Test Wi-Fi module selection"
 	@echo "  web           - Build the frontend into web/dist"
 	@echo "  all           - Build both app and support (default)"
 	@echo "  release-build - Build every riscv64 release artifact in one pass"
@@ -103,6 +104,9 @@ support: check-root builder-image
 vision: check-root builder-image
 	@echo "Building vision..."
 	@$(DOCKER_RUN_BASE) $(DOCKER_TTY) $(IMAGE_NAME) /bin/bash -c '$(VISION_BUILD_CMD)'
+
+test-wifi-modules:
+	@sh tools/test-s25wifimod.sh
 
 # Build every riscv64 release artifact in one container pass
 release-build: check-root builder-image

--- a/kvmapp/system/init.d/S25wifimod
+++ b/kvmapp/system/init.d/S25wifimod
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+KO_DIR="${NANOKVM_KO_DIR:-/mnt/system/ko}"
+SDIO_DEVICES_DIR="${NANOKVM_SDIO_DEVICES_DIR:-/sys/bus/sdio/devices}"
+INSMOD="${NANOKVM_INSMOD:-insmod}"
+
+load_aic8800() {
+	"$INSMOD" "$KO_DIR/3rd/aic8800_bsp.ko"
+	"$INSMOD" "$KO_DIR/3rd/aic8800_fdrv.ko"
+}
+
+load_rtl8733bs() {
+	"$INSMOD" "$KO_DIR/3rd/8733bs.ko"
+}
+
+if [ "$1" = "start" ]
+then
+	. /etc/profile
+	printf "load wifi kernel module: "
+	"$INSMOD" "$KO_DIR/cfg80211.ko"
+
+	sdio_aliases=""
+	for alias_file in "$SDIO_DEVICES_DIR"/*/modalias
+	do
+		[ -r "$alias_file" ] || continue
+		sdio_aliases="$sdio_aliases $(cat "$alias_file")"
+	done
+
+	load_aic=0
+	load_rtl=0
+	case "$sdio_aliases" in
+		*v5449d0145*|*v544Ad0146*|*vC8A1d0082*|*vC8A1dC08D*)
+			load_aic=1
+			;;
+	esac
+	case "$sdio_aliases" in
+		*v024CdB73A*|*v024CdB733*)
+			load_rtl=1
+			;;
+	esac
+
+	# Preserve support for new or unrecognised boards. This is the old boot
+	# behaviour, but known boards avoid retaining an unused multi-megabyte
+	# driver for the lifetime of the system.
+	if [ "$load_aic" -eq 0 ] && [ "$load_rtl" -eq 0 ]
+	then
+		load_aic=1
+		load_rtl=1
+	fi
+
+	[ "$load_aic" -eq 0 ] || load_aic8800
+	[ "$load_rtl" -eq 0 ] || load_rtl8733bs
+
+	echo "OK"
+	exit 0
+fi

--- a/support/sg2002/kvm_system/main/lib/system_init/system_init.cpp
+++ b/support/sg2002/kvm_system/main/lib/system_init/system_init.cpp
@@ -98,6 +98,7 @@ void new_app_init(void)
 	system("cp -f /kvmapp/system/init.d/S01fs /etc/init.d/");
 	system("cp -f /kvmapp/system/init.d/S03usbdev /etc/init.d/");
 	system("cp -f /kvmapp/system/init.d/S15kvmhwd /etc/init.d/");
+	system("cp -f /kvmapp/system/init.d/S25wifimod /etc/init.d/");
 	system("cp -f /kvmapp/system/init.d/S30eth /etc/init.d/");
 	system("cp -f /kvmapp/system/init.d/S50sshd /etc/init.d/");
 	if(kvm_wifi_exist()) {

--- a/tools/test-s25wifimod.sh
+++ b/tools/test-s25wifimod.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+SCRIPT="$ROOT/kvmapp/system/init.d/S25wifimod"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT HUP INT TERM
+
+mkdir -p "$WORK/ko/3rd" "$WORK/bin"
+
+cat > "$WORK/bin/insmod" <<'EOF'
+#!/bin/sh
+basename "$1" >> "$NANOKVM_INSMOD_LOG"
+EOF
+chmod +x "$WORK/bin/insmod"
+
+run_case() {
+	name=$1
+	alias_value=$2
+	expected=$3
+	devices="$WORK/$name/devices"
+	log="$WORK/$name/insmod.log"
+
+	mkdir -p "$devices/card:0000:1"
+	printf '%s\n' "$alias_value" > "$devices/card:0000:1/modalias"
+	: > "$log"
+
+	NANOKVM_KO_DIR="$WORK/ko" \
+	NANOKVM_SDIO_DEVICES_DIR="$devices" \
+	NANOKVM_INSMOD="$WORK/bin/insmod" \
+	NANOKVM_INSMOD_LOG="$log" \
+		sh "$SCRIPT" start >/dev/null
+
+	actual=$(cat "$log")
+	if [ "$actual" != "$expected" ]
+	then
+		echo "$name: unexpected modules" >&2
+		echo "expected:" >&2
+		printf '%s\n' "$expected" >&2
+		echo "actual:" >&2
+		printf '%s\n' "$actual" >&2
+		exit 1
+	fi
+}
+
+run_case aic 'sdio:c07v5449d0145' 'cfg80211.ko
+aic8800_bsp.ko
+aic8800_fdrv.ko'
+
+run_case rtl 'sdio:c07v024CdB73A' 'cfg80211.ko
+8733bs.ko'
+
+run_case unknown 'sdio:c07vFFFFdFFFF' 'cfg80211.ko
+aic8800_bsp.ko
+aic8800_fdrv.ko
+8733bs.ko'
+
+echo "S25wifimod tests passed"


### PR DESCRIPTION
## Summary

- install a versioned `S25wifimod` from the application package
- select the AIC8800 or RTL8733BS driver from the enumerated SDIO modalias
- retain the previous load-both behavior for unknown or not-yet-enumerated hardware
- add isolated shell coverage for AIC, Realtek, and fallback paths

## Why

The stock image loads both vendor Wi-Fi stacks on every boot. On an AIC8800D80 NanoKVM, `8733bs` remained loaded with use count zero and occupied 2,735,515 bytes of kernel module memory.

A live A/B test on that device showed:

| state | MemAvailable |
| --- | ---: |
| both Wi-Fi drivers loaded | 80,768 KiB |
| unused `8733bs` unloaded | 83,312 KiB |

That is 2,544 KiB returned on a device with 158 MiB total RAM. The active `aic8800_fdrv` link remained associated with `wlan0`; a post-change ping test had 0% packet loss.

## Compatibility

Known SDIO IDs are taken from the shipped modules:

- AIC8800: `5449:0145`, `544A:0146`, `C8A1:0082`, `C8A1:C08D`
- RTL8733BS: `024C:B73A`, `024C:B733`

If no known modalias is present, both stacks are loaded exactly as on the current image. This keeps future/unknown boards on the conservative path.

## Verification

- `sh -n kvmapp/system/init.d/S25wifimod`
- `sh tools/test-s25wifimod.sh`
- dry-run on AIC8800D80 hardware selected only `cfg80211`, `aic8800_bsp`, and `aic8800_fdrv`
- RISC-V `kvm_system` build passed with the project Xuantie GCC 10.2 toolchain
- live unload test preserved Wi-Fi association and had 0% ping loss