### PR TITLE
perf(network): consolidate network and Wi-Fi runtime handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ help:
 	@echo "  app           - Build Go application server"
 	@echo "  support       - Build kvm_system daemon"
 	@echo "  vision        - Build video libraries (libkvm.so)"
+	@echo "  test-wifi-modules - Test Wi-Fi module selection"
+	@echo "  test-wifi-runtime - Test Wi-Fi runtime state and credential permissions"
 	@echo "  web           - Build the frontend into web/dist"
 	@echo "  all           - Build both app and support (default)"
 	@echo "  release-build - Build every riscv64 release artifact in one pass"
@@ -103,6 +105,14 @@ support: check-root builder-image
 vision: check-root builder-image
 	@echo "Building vision..."
 	@$(DOCKER_RUN_BASE) $(DOCKER_TTY) $(IMAGE_NAME) /bin/bash -c '$(VISION_BUILD_CMD)'
+
+.PHONY: test-wifi-modules test-wifi-runtime
+test-wifi-modules:
+	@sh tools/test-s25wifimod.sh
+
+test-wifi-runtime:
+	@sh tools/test-s30wifi-runtime.sh
+	@cd server && go test ./service/network
 
 # Build every riscv64 release artifact in one container pass
 release-build: check-root builder-image

--- a/kvmapp/system/init.d/S25wifimod
+++ b/kvmapp/system/init.d/S25wifimod
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+KO_DIR="${NANOKVM_KO_DIR:-/mnt/system/ko}"
+SDIO_DEVICES_DIR="${NANOKVM_SDIO_DEVICES_DIR:-/sys/bus/sdio/devices}"
+INSMOD="${NANOKVM_INSMOD:-insmod}"
+
+load_aic8800() {
+	"$INSMOD" "$KO_DIR/3rd/aic8800_bsp.ko"
+	"$INSMOD" "$KO_DIR/3rd/aic8800_fdrv.ko"
+}
+
+load_rtl8733bs() {
+	"$INSMOD" "$KO_DIR/3rd/8733bs.ko"
+}
+
+if [ "$1" = "start" ]
+then
+	. /etc/profile
+	printf "load wifi kernel module: "
+	"$INSMOD" "$KO_DIR/cfg80211.ko"
+
+	sdio_aliases=""
+	for alias_file in "$SDIO_DEVICES_DIR"/*/modalias
+	do
+		[ -r "$alias_file" ] || continue
+		sdio_aliases="$sdio_aliases $(cat "$alias_file")"
+	done
+
+	load_aic=0
+	load_rtl=0
+	case "$sdio_aliases" in
+		*v5449d0145*|*v544Ad0146*|*vC8A1d0082*|*vC8A1dC08D*)
+			load_aic=1
+			;;
+	esac
+	case "$sdio_aliases" in
+		*v024CdB73A*|*v024CdB733*)
+			load_rtl=1
+			;;
+	esac
+
+	# Preserve support for new or unrecognised boards. This is the old boot
+	# behaviour, but known boards avoid retaining an unused multi-megabyte
+	# driver for the lifetime of the system.
+	if [ "$load_aic" -eq 0 ] && [ "$load_rtl" -eq 0 ]
+	then
+		load_aic=1
+		load_rtl=1
+	fi
+
+	[ "$load_aic" -eq 0 ] || load_aic8800
+	[ "$load_rtl" -eq 0 ] || load_rtl8733bs
+
+	echo "OK"
+	exit 0
+fi

--- a/kvmapp/system/init.d/S30wifi
+++ b/kvmapp/system/init.d/S30wifi
@@ -2,11 +2,42 @@
 
 . /etc/profile
 
-APFLAG_FILE=/tmp/wifiap
+: "${NANOKVM_WIFI_BOOT_DIR:=/boot}"
+: "${NANOKVM_WIFI_ETC_DIR:=/etc/kvm}"
+: "${NANOKVM_WIFI_KVM_DIR:=/kvmapp/kvm}"
+: "${NANOKVM_WIFI_RUN_DIR:=/run/nanokvm-wifi}"
+: "${NANOKVM_WIFI_AP_FLAG:=/tmp/wifiap}"
+: "${NANOKVM_WIFI_UID_FILE:=/sys/class/cvi-base/base_uid}"
+: "${NANOKVM_WPA_PASSPHRASE:=wpa_passphrase}"
+: "${NANOKVM_WPA_SUPPLICANT:=wpa_supplicant}"
+: "${NANOKVM_UDHCPC:=udhcpc}"
+: "${NANOKVM_HOSTAPD:=hostapd}"
+: "${NANOKVM_UDHCPD:=udhcpd}"
+: "${NANOKVM_IFCONFIG:=ifconfig}"
+: "${NANOKVM_IP:=ip}"
+: "${NANOKVM_KILLALL:=killall}"
+: "${NANOKVM_CHOWN:=chown}"
+: "${NANOKVM_WIFI_DHCP_PID:=/run/udhcpc.wlan0.pid}"
+
+WIFI_SSID_FILE=$NANOKVM_WIFI_ETC_DIR/wifi.ssid
+WIFI_PASS_FILE=$NANOKVM_WIFI_ETC_DIR/wifi.pass
+BOOT_SSID_FILE=$NANOKVM_WIFI_BOOT_DIR/wifi.ssid
+BOOT_PASS_FILE=$NANOKVM_WIFI_BOOT_DIR/wifi.pass
+WPA_CONFIG=$NANOKVM_WIFI_RUN_DIR/wpa_supplicant.conf
+HOSTAPD_CONFIG=$NANOKVM_WIFI_RUN_DIR/hostapd.conf
+UDHCPD_CONFIG=$NANOKVM_WIFI_RUN_DIR/udhcpd.conf
+UDHCPD_PID=$NANOKVM_WIFI_RUN_DIR/udhcpd.pid
+UDHCPD_LEASES=$NANOKVM_WIFI_RUN_DIR/udhcpd.leases
+WLAN_DHCP_PID=$NANOKVM_WIFI_DHCP_PID
+
+prepare_run_dir() {
+    mkdir -p "$NANOKVM_WIFI_RUN_DIR" || return 1
+    chmod 700 "$NANOKVM_WIFI_RUN_DIR" || return 1
+}
 
 gen_hostapd_conf() {
-    ssid="${1}"
-    pass="${2}"
+    ssid=$1
+    pass=$2
     echo "ctrl_interface=/var/run/hostapd"
     echo "ctrl_interface_group=0"
     echo "ssid=${ssid}"
@@ -25,62 +56,83 @@ gen_hostapd_conf() {
 }
 
 gen_udhcpd_conf() {
-    interface=${1}
-    ipv4_prefix=${2}
+    interface=$1
+    ipv4_prefix=$2
     echo "start ${ipv4_prefix}.100"
     echo "end ${ipv4_prefix}.200"
     echo "interface ${interface}"
-    echo "pidfile /var/run/udhcpd.${interface}.pid"
-    echo "lease_file /var/lib/misc/udhcpd.${interface}.leases"
+    echo "pidfile ${UDHCPD_PID}"
+    echo "lease_file ${UDHCPD_LEASES}"
     echo "option subnet 255.255.255.0"
     echo "option lease 864000"
 }
 
-gen_dnsmasq_conf() {
-    ipv4_prefix=${1}
-    echo "bind-interfaces"
-    echo "interface=wlan0"
-    echo "address=/config.kvm/${ipv4_prefix}.1"
-    echo "no-hosts"
-    echo "dhcp-range=${ipv4_prefix}.2,${ipv4_prefix}.254"
-    echo "dhcp-option=6,${ipv4_prefix}.1"
-    echo "dhcp-option=3,${ipv4_prefix}.1"
-    echo "dhcp-authoritative"
+import_boot_credentials() {
+    [ -e "$BOOT_SSID_FILE" ] && [ -e "$BOOT_PASS_FILE" ] || return 0
+
+    echo "Updating WiFi credentials from /boot to /etc/kvm/"
+    mkdir -p "$NANOKVM_WIFI_ETC_DIR" || return 1
+    rm -f "$WIFI_SSID_FILE" "$WIFI_PASS_FILE"
+    mv "$BOOT_SSID_FILE" "$WIFI_SSID_FILE" || return 1
+    mv "$BOOT_PASS_FILE" "$WIFI_PASS_FILE" || return 1
+    "$NANOKVM_CHOWN" root:root "$WIFI_SSID_FILE" "$WIFI_PASS_FILE" || return 1
+    chmod 600 "$WIFI_SSID_FILE" "$WIFI_PASS_FILE" || return 1
+}
+
+write_wpa_config() {
+    ssid=$1
+    pass=$2
+    config_tmp=$WPA_CONFIG.tmp.$$
+
+    # Supplying the password over stdin keeps it out of the process list.
+    # wpa_passphrase includes a plaintext #psk comment; do not retain it.
+    psk_config=$(printf '%s\n' "$pass" | "$NANOKVM_WPA_PASSPHRASE" "$ssid") || return 1
+
+    umask 077
+    {
+        echo "ctrl_interface=/var/run/wpa_supplicant"
+        printf '%s\n' "$psk_config" | sed '/^[[:space:]]*#psk=/d'
+    } > "$config_tmp" || {
+        rm -f "$config_tmp"
+        return 1
+    }
+    mv "$config_tmp" "$WPA_CONFIG" || return 1
 }
 
 start() {
     echo "wifi mode: sta"
-    ssid=""
-    pass=""
-    if [ -e /boot/wifi.ssid ] && [ -e /boot/wifi.pass ]; then
-        echo "Updating WiFi credentials from /boot to /etc/kvm/"
+    import_boot_credentials || return 1
 
-        rm -f /etc/kvm/wifi.ssid /etc/kvm/wifi.pass
+    if [ ! -s "$WIFI_SSID_FILE" ] || [ ! -s "$WIFI_PASS_FILE" ]; then
+        echo "WiFi credentials are not configured; leaving wlan0 idle"
+        return 0
+    fi
 
-        mv /boot/wifi.ssid /etc/kvm/wifi.ssid
-        mv /boot/wifi.pass /etc/kvm/wifi.pass
+    # Credentials created by older releases were world-readable. Tighten them
+    # on every start so upgrading fixes existing installations immediately.
+    "$NANOKVM_CHOWN" root:root "$WIFI_SSID_FILE" "$WIFI_PASS_FILE" || return 1
+    chmod 600 "$WIFI_SSID_FILE" "$WIFI_PASS_FILE" || return 1
 
-        chown root:root /etc/kvm/wifi.ssid /etc/kvm/wifi.pass
-        chmod 644 /etc/kvm/wifi.ssid /etc/kvm/wifi.pass
-    fi
-    if [ -e /etc/kvm/wifi.ssid ]; then
-        ssid=$(cat /etc/kvm/wifi.ssid)
-    fi
-    if [ -e /etc/kvm/wifi.pass ]; then
-        pass=$(cat /etc/kvm/wifi.pass)
-    fi
-    echo "ctrl_interface=/var/run/wpa_supplicant" >/etc/wpa_supplicant.conf
-    wpa_passphrase "$ssid" "$pass" >>/etc/wpa_supplicant.conf
-    wpa_supplicant -B -i wlan0 -c /etc/wpa_supplicant.conf
-    if [ ! -e /boot/wifi.nodhcp ]; then
-        (udhcpc -i wlan0 -t 10 -T 1 -A 5 -b -p /run/udhcpc.wlan0.pid) &
+    ssid=$(cat "$WIFI_SSID_FILE") || return 1
+    pass=$(cat "$WIFI_PASS_FILE") || return 1
+    prepare_run_dir || return 1
+    write_wpa_config "$ssid" "$pass" || {
+        echo "Could not generate WiFi configuration" >&2
+        return 1
+    }
+
+    "$NANOKVM_WPA_SUPPLICANT" -B -i wlan0 -c "$WPA_CONFIG" || return 1
+    if [ ! -e "$NANOKVM_WIFI_BOOT_DIR/wifi.nodhcp" ]; then
+        "$NANOKVM_UDHCPC" -i wlan0 -t 10 -T 1 -A 5 -b -p "$WLAN_DHCP_PID" &
     fi
 }
 
 ap_start() {
     echo "wifi mode: ap"
-    id2=$(printf "%d" 0x$(sha512sum /sys/class/cvi-base/base_uid | head -c 2))
-    id3=$(printf "%d" 0x$(sha512sum /sys/class/cvi-base/base_uid | head -c 4 | tail -c 2))
+    prepare_run_dir || return 1
+
+    id2=$(printf "%d" "0x$(sha512sum "$NANOKVM_WIFI_UID_FILE" | head -c 2)")
+    id3=$(printf "%d" "0x$(sha512sum "$NANOKVM_WIFI_UID_FILE" | head -c 4 | tail -c 2)")
     if [ "$id2" = "$id3" ]; then
         id2=$((id2 + 1))
     fi
@@ -90,66 +142,50 @@ ap_start() {
     if [ "$id3" -ge 255 ]; then
         id3=254
     fi
-    ssid=""
-    pass=""
-    if [ -e /kvmapp/kvm/ap.ssid ]; then
-        ssid=$(cat /kvmapp/kvm/ap.ssid)
+
+    ssid=
+    pass=
+    if [ -e "$NANOKVM_WIFI_KVM_DIR/ap.ssid" ]; then
+        ssid=$(cat "$NANOKVM_WIFI_KVM_DIR/ap.ssid")
     fi
-    if [ -e /kvmapp/kvm/ap.pass ]; then
-        pass=$(cat /kvmapp/kvm/ap.pass)
+    if [ -e "$NANOKVM_WIFI_KVM_DIR/ap.pass" ]; then
+        pass=$(cat "$NANOKVM_WIFI_KVM_DIR/ap.pass")
     fi
-    gen_hostapd_conf "$ssid" "$pass" >/etc/hostapd.conf
+
+    umask 077
+    gen_hostapd_conf "$ssid" "$pass" > "$HOSTAPD_CONFIG" || return 1
     ipv4_prefix=10.$id3.$id2
-    if [ ! -e /etc/udhcpd.wlan0.conf ]; then
-        gen_udhcpd_conf wlan0 "${ipv4_prefix}" >/etc/udhcpd.wlan0.conf
-    fi
-    # gen_dnsmasq_conf "${ipv4_prefix}"  > /etc/dnsmasq.conf
+    gen_udhcpd_conf wlan0 "$ipv4_prefix" > "$UDHCPD_CONFIG" || return 1
 
-    # iptables --policy INPUT ACCEPT
-    # iptables --policy FORWARD ACCEPT
-    # iptables --policy OUTPUT ACCEPT
-    # iptables -F
-    # iptables -t nat -F
-    # iptables -t nat -A PREROUTING -i wlan0 -p udp --dport 53 -j DNAT --to ${ipv4_prefix}.1
+    "$NANOKVM_IFCONFIG" wlan0 up || return 1
+    "$NANOKVM_IP" route del default dev wlan0 2>/dev/null || true
+    "$NANOKVM_IP" addr flush dev wlan0 || return 1
+    "$NANOKVM_IP" addr add "$ipv4_prefix.1/24" dev wlan0 || return 1
+    "$NANOKVM_HOSTAPD" -B -i wlan0 "$HOSTAPD_CONFIG" || return 1
+    "$NANOKVM_UDHCPD" -S "$UDHCPD_CONFIG" || return 1
 
-    ifconfig wlan0 up
-    ip route del default || true
-    ip add flush dev wlan0
-    ip addr add $ipv4_prefix.1/24 dev wlan0
-    # dnsmasq --pid-file=/tmp/dnsmasq.run -C /etc/dnsmasq.conf
-    hostapd -B -i wlan0 /etc/hostapd.conf
-    udhcpd -S /etc/udhcpd.wlan0.conf
-
-    if [ ! -f "$APFLAG_FILE" ]; then
-        touch "$APFLAG_FILE"
-    fi
-
+    touch "$NANOKVM_WIFI_AP_FLAG"
 }
 
 stop() {
-    ps -ef | grep hostapd | grep -v grep | awk '{print $1}' | xargs kill -2 || true
-    ps -ef | grep "udhcpd -S /etc/udhcpd.wlan0.conf" | grep -v grep | awk '{print $1}' | xargs kill -2 || true
-    killall wpa_supplicant || true
-    if [ -e /run/udhcpc.wlan0.pid ]; then
-        kill $(cat /run/udhcpc.wlan0.pid) || true
-        rm -f /run/udhcpc.wlan0.pid
-    fi
-    if [ -e /var/run/udhcpd.wlan0.pid ]; then
-        kill $(cat /var/run/udhcpd.wlan0.pid) || true
-        rm -f /var/run/udhcpd.wlan0.pid
-    fi
-    if [ -e /tmp/dnsmasq.run ]; then
-        kill $(cat /tmp/dnsmasq.run) || true
-        rm -f /tmp/dnsmasq.run
-    fi
-    # if [ -e /etc/wpa_supplicant.conf]
-    # then
-    # 	echo > /etc/wpa_supplicant.conf
-    # fi
-    airmon-ng stop wlan0mon || true
+    "$NANOKVM_KILLALL" hostapd 2>/dev/null || true
+    "$NANOKVM_KILLALL" udhcpd 2>/dev/null || true
+    "$NANOKVM_KILLALL" wpa_supplicant 2>/dev/null || true
 
-    if [ -f "$APFLAG_FILE" ]; then
-        rm "$APFLAG_FILE"
+    if [ -e "$WLAN_DHCP_PID" ]; then
+        pid=$(cat "$WLAN_DHCP_PID")
+        case "$pid" in
+            ''|*[!0-9]*) ;;
+            *) kill "$pid" 2>/dev/null || true ;;
+        esac
+        rm -f "$WLAN_DHCP_PID"
+    fi
+
+    rm -f "$UDHCPD_PID" "$UDHCPD_LEASES" "$WPA_CONFIG" \
+        "$HOSTAPD_CONFIG" "$UDHCPD_CONFIG" "$NANOKVM_WIFI_AP_FLAG"
+
+    if [ -e /sys/class/net/wlan0mon ] && command -v airmon-ng >/dev/null 2>&1; then
+        airmon-ng stop wlan0mon || true
     fi
 }
 
@@ -158,13 +194,12 @@ restart() {
     start
 }
 
-if [ "${1}" = "start" ]; then
-    start
-elif [ "${1}" = "stop" ]; then
-    stop
-elif [ "${1}" = "ap" ]; then
-    stop
-    ap_start
-elif [ "${1}" = "restart" ]; then
-    restart
-fi
+case "${1:-}" in
+    start) start ;;
+    stop) stop ;;
+    ap)
+        stop
+        ap_start
+        ;;
+    restart) restart ;;
+esac

--- a/server/service/network/wifi.go
+++ b/server/service/network/wifi.go
@@ -166,12 +166,12 @@ func (s *Service) DisconnectWifi(c *gin.Context) {
 }
 
 func connect(ssid string, password string) error {
-	if err := os.WriteFile(WiFiSSID, []byte(ssid), 0o644); err != nil {
+	if err := writePrivateFile(WiFiSSID, []byte(ssid)); err != nil {
 		log.Errorf("failed to save wifi ssid: %s", err)
 		return err
 	}
 
-	if err := os.WriteFile(WiFiPasswd, []byte(password), 0o644); err != nil {
+	if err := writePrivateFile(WiFiPasswd, []byte(password)); err != nil {
 		log.Errorf("failed to save wifi password: %s", err)
 		return err
 	}
@@ -182,6 +182,16 @@ func connect(ssid string, password string) error {
 	}
 
 	return nil
+}
+
+func writePrivateFile(path string, data []byte) error {
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return err
+	}
+
+	// WriteFile preserves the mode of an existing file, so explicitly tighten
+	// credentials created by older releases with mode 0644.
+	return os.Chmod(path, 0o600)
 }
 
 func isSupported() bool {

--- a/server/service/network/wifi_test.go
+++ b/server/service/network/wifi_test.go
@@ -1,0 +1,48 @@
+package network
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWritePrivateFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing bool
+	}{
+		{name: "new file"},
+		{name: "tighten existing file", existing: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "wifi.pass")
+			if test.existing {
+				if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			if err := writePrivateFile(path, []byte("new secret")); err != nil {
+				t.Fatal(err)
+			}
+
+			content, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(content) != "new secret" {
+				t.Fatalf("unexpected content: %q", content)
+			}
+
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if mode := info.Mode().Perm(); mode != 0o600 {
+				t.Fatalf("mode = %04o, want 0600", mode)
+			}
+		})
+	}
+}

--- a/support/sg2002/kvm_system/main/lib/system_init/system_init.cpp
+++ b/support/sg2002/kvm_system/main/lib/system_init/system_init.cpp
@@ -98,6 +98,7 @@ void new_app_init(void)
 	system("cp -f /kvmapp/system/init.d/S01fs /etc/init.d/");
 	system("cp -f /kvmapp/system/init.d/S03usbdev /etc/init.d/");
 	system("cp -f /kvmapp/system/init.d/S15kvmhwd /etc/init.d/");
+	system("cp -f /kvmapp/system/init.d/S25wifimod /etc/init.d/");
 	system("cp -f /kvmapp/system/init.d/S30eth /etc/init.d/");
 	system("cp -f /kvmapp/system/init.d/S50sshd /etc/init.d/");
 	if(kvm_wifi_exist()) {

--- a/support/sg2002/kvm_system/main/lib/system_state/system_state.cpp
+++ b/support/sg2002/kvm_system/main/lib/system_state/system_state.cpp
@@ -1,15 +1,106 @@
 #include "config.h"
 #include "system_state.h"
 #include "vi_state_shared.hpp"
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <time.h>
+#include <sys/wait.h>
 #include <sys/socket.h>
 #include <net/if.h>
 #include <sys/ioctl.h>
+#include <unistd.h>
 
 using namespace maix;
 using namespace maix::sys;
 
 extern kvm_sys_state_t kvm_sys_state;
 extern kvm_oled_state_t kvm_oled_state;
+
+namespace {
+
+constexpr uint64_t NETWORK_PROBE_INTERVAL_MS = 10000U;
+
+uint64_t monotonic_ms()
+{
+	struct timespec now = {};
+	if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) {
+		return 0;
+	}
+	return static_cast<uint64_t>(now.tv_sec) * 1000U
+			+ static_cast<uint64_t>(now.tv_nsec) / 1000000U;
+}
+
+bool network_probe_due(uint64_t& last_probe_ms)
+{
+	const uint64_t now_ms = monotonic_ms();
+	if (now_ms == 0U) {
+		return true;
+	}
+	if (last_probe_ms != 0U && now_ms - last_probe_ms < NETWORK_PROBE_INTERVAL_MS) {
+		return false;
+	}
+	last_probe_ms = now_ms;
+	return true;
+}
+
+int read_default_gateway(const char* interface_name, uint8_t* output, size_t output_size)
+{
+	if (interface_name == NULL || output == NULL || output_size == 0U) {
+		return 0;
+	}
+	output[0] = 0;
+
+	FILE* fp = fopen("/proc/net/route", "r");
+	if (fp == NULL) {
+		return 0;
+	}
+
+	char line[256];
+	(void)fgets(line, sizeof(line), fp); // header
+	while (fgets(line, sizeof(line), fp) != NULL) {
+		char route_interface[IFNAMSIZ] = {0};
+		unsigned long destination = 0;
+		unsigned long gateway = 0;
+		unsigned long flags = 0;
+		if (sscanf(line, "%15s %lx %lx %lx", route_interface, &destination, &gateway, &flags) != 4) {
+			continue;
+		}
+		if (strcmp(route_interface, interface_name) != 0 || destination != 0 || (flags & 0x1U) == 0) {
+			continue;
+		}
+
+		struct in_addr address = {};
+		address.s_addr = static_cast<in_addr_t>(gateway);
+		const char* result = inet_ntop(AF_INET, &address,
+				reinterpret_cast<char*>(output), output_size);
+		fclose(fp);
+		return result == NULL ? 0 : 1;
+	}
+
+	fclose(fp);
+	return 0;
+}
+
+void publish_wifi_state(uint8_t state)
+{
+	static int last_state = -1;
+	if (last_state == state) {
+		return;
+	}
+
+	FILE* fp = fopen("/kvmapp/kvm/wifi_state", "w");
+	if (fp == NULL) {
+		return;
+	}
+	const bool write_ok = fputc(state == 0 ? '0' : '1', fp) != EOF;
+	const bool close_ok = fclose(fp) == 0;
+	if (write_ok && close_ok) {
+		last_state = state;
+	}
+}
+
+} // namespace
 
 int get_nic_state(const char* interface_name)
 {
@@ -109,90 +200,69 @@ int get_ip_addr(ip_addr_t ip_type)
 			return 1;
 		case ETH_ROUTE: // eth_route
 			if(access("/etc/kvm/gateway", F_OK) != 0){
-				// 不存在gateway文件
-				memset( kvm_sys_state.eth_route, 0, sizeof( kvm_sys_state.eth_route ) );
-				char Cmd[100]={0};
-				memset( Cmd, 0, sizeof( Cmd ) );
-				sprintf( Cmd,"ip route | grep -i '^default' | grep -i 'eth0' | awk '{print $3}'");
-				FILE* fp = popen( Cmd, "r" );
-				if ( NULL == fp )
-				{
-					pclose(fp);
-					return 0;
-				}
-				memset( kvm_sys_state.eth_route, 0, sizeof( kvm_sys_state.eth_route ) );
-				while ( NULL != fgets( (char*)kvm_sys_state.eth_route,sizeof( kvm_sys_state.eth_route ),fp ))
-				{
-					// printf("ip=%s\n",kvm_sys_state.eth_route);
-					break;
-				}
-				if(kvm_sys_state.eth_route[0] == 0){
-					// 开机时未插入ETH
-					pclose(fp);
-					return 0;
-				}
-				for(int i = 0; i < 40; i++){
-					if(kvm_sys_state.eth_route[i] == 10){
-						kvm_sys_state.eth_route[i] = ' ';
-						break;
-					}
-				}
-				pclose(fp);
-				return 1;
+				return read_default_gateway("eth0", kvm_sys_state.eth_route,
+						sizeof(kvm_sys_state.eth_route));
 			} else {
-				int file_size;
 				FILE *fp = fopen("/etc/kvm/gateway", "r");
-				fseek(fp, 0, SEEK_END);
-				file_size = ftell(fp); 
-				fseek(fp, 0, SEEK_SET);
-				fread(kvm_sys_state.eth_route, sizeof(char), file_size, fp);
+				if (fp == NULL) {
+					return 0;
+				}
+				memset(kvm_sys_state.eth_route, 0, sizeof(kvm_sys_state.eth_route));
+				if (fgets((char*)kvm_sys_state.eth_route, sizeof(kvm_sys_state.eth_route), fp) == NULL) {
+					fclose(fp);
+					return 0;
+				}
 				fclose(fp);
+				kvm_sys_state.eth_route[strcspn((char*)kvm_sys_state.eth_route, "\r\n")] = 0;
 				return 1;
 			}
 		case WiFi_ROUTE: // wifi_route
-			memset( kvm_sys_state.wifi_route, 0, sizeof( kvm_sys_state.wifi_route ) );
-			char Cmd[100]={0};
-			memset( Cmd, 0, sizeof( Cmd ) );
-			sprintf( Cmd,"ip route | grep -i '^default' | grep -i 'wlan0' | awk '{print $3}'");
-			FILE* fp = popen( Cmd, "r" );
-			if ( NULL == fp )
-			{
-				pclose(fp);
-				return 0;
-			}
-			memset( kvm_sys_state.wifi_route, 0, sizeof( kvm_sys_state.wifi_route ) );
-			while ( NULL != fgets( (char*)kvm_sys_state.wifi_route,sizeof( kvm_sys_state.wifi_route ),fp ))
-			{
-				// printf("ip=%s\n",kvm_sys_state.wifi_route);
-				break;
-			}
-			if(kvm_sys_state.wifi_route[0] == 0){
-				// 开机时未插入ETH
-				pclose(fp);
-				return 0;
-			}
-			for(int i = 0; i < 40; i++){
-				if(kvm_sys_state.wifi_route[i] == 10){
-					kvm_sys_state.wifi_route[i] = ' ';
-					break;
-				}
-			}
-			pclose(fp);
-			return 1;
+			return read_default_gateway("wlan0", kvm_sys_state.wifi_route,
+					sizeof(kvm_sys_state.wifi_route));
 	}
 	return 0;
 }
 
 int chack_net_state(ip_addr_t use_ip_type)
 {
-	char Cmd[100]={0};
-	if		(use_ip_type == ETH_ROUTE)  sprintf( Cmd,"ping -I eth0 -w 1 %s > /dev/null", kvm_sys_state.eth_route);
-	else if	(use_ip_type == WiFi_ROUTE) sprintf( Cmd,"ping -I wlan0 -w 1 %s > /dev/null", kvm_sys_state.wifi_route);
-	else return -1;	// 不支持的端口
-	if(system(Cmd) == 0){	// 256：不通； = 0：通
-		return 1;
+	const char* interface_name = NULL;
+	const char* gateway = NULL;
+	if (use_ip_type == ETH_ROUTE) {
+		interface_name = "eth0";
+		gateway = (char*)kvm_sys_state.eth_route;
+	} else if (use_ip_type == WiFi_ROUTE) {
+		interface_name = "wlan0";
+		gateway = (char*)kvm_sys_state.wifi_route;
+	} else {
+		return -1;
 	}
-	return 0;
+
+	const pid_t pid = fork();
+	if (pid < 0) {
+		return 0;
+	}
+	if (pid == 0) {
+		const int null_fd = open("/dev/null", O_WRONLY);
+		if (null_fd >= 0) {
+			(void)dup2(null_fd, STDOUT_FILENO);
+			(void)dup2(null_fd, STDERR_FILENO);
+			if (null_fd > STDERR_FILENO) {
+				(void)close(null_fd);
+			}
+		}
+		execl("/bin/ping", "ping", "-I", interface_name, "-c", "1", "-W", "1", gateway, (char*)NULL);
+		_exit(127);
+	}
+
+	int status = 0;
+	pid_t wait_result;
+	do {
+		wait_result = waitpid(pid, &status, 0);
+	} while (wait_result < 0 && errno == EINTR);
+	if (wait_result != pid) {
+		return 0;
+	}
+	return WIFEXITED(status) && WEXITSTATUS(status) == 0 ? 1 : 0;
 }
 
 void patch_eth_wifi(void)
@@ -395,6 +465,7 @@ void kvm_update_hdmi_res(void)
 void kvm_update_eth_state(void)
 {	
 	static uint8_t nic_state = 0;
+	static uint64_t last_probe_ms = 0;
 	nic_state = get_nic_state("eth0");
 
 	if(nic_state == NIC_STATE_RUNNING){
@@ -412,7 +483,9 @@ void kvm_update_eth_state(void)
 			if(kvm_sys_state.eth_route[0] == 0){
 				get_ip_addr(ETH_ROUTE);
 			} else {
-				if(chack_net_state(ETH_ROUTE)){
+				if(!network_probe_due(last_probe_ms)) {
+					return;
+				} else if(chack_net_state(ETH_ROUTE)){
 					// Ping successful
 					kvm_sys_state.eth_state = 3;
 				} else {
@@ -432,6 +505,7 @@ void kvm_update_eth_state(void)
 
 void kvm_update_wifi_state(void)
 {	
+	static uint64_t last_probe_ms = 0;
 	// No WiFi module (check for existence?) -> Module exists & not connected (check if connected) ->
 	if(kvm_sys_state.wifi_state == -2) return;
 	switch (kvm_sys_state.wifi_state){
@@ -449,11 +523,11 @@ void kvm_update_wifi_state(void)
 			// break;	// Start checking the connection directly.
 		case 0:
 		// WiFi is available but not connected.
-			system("echo 0 > /kvmapp/kvm/wifi_state");
+			publish_wifi_state(0);
 			if (get_ip_addr(WiFi_IP) && get_ip_addr(WiFi_ROUTE)){
 				// IP+Route has been acquired
 				if(kvm_sys_state.ping_allow){
-					if (chack_net_state(WiFi_ROUTE)){
+					if (network_probe_due(last_probe_ms) && chack_net_state(WiFi_ROUTE)){
 						// Ping successful
 						kvm_sys_state.wifi_state = 1;
 					}
@@ -465,10 +539,10 @@ void kvm_update_wifi_state(void)
 			break;
 		case 1:
 		// Connected to the network & continuously checking if it can ping successfully.
-			system("echo 1 > /kvmapp/kvm/wifi_state");
+			publish_wifi_state(1);
 			get_ip_addr(WiFi_IP);
 			if(kvm_sys_state.ping_allow){
-				if (kvm_sys_state.wifi_route[0] != 0){
+				if (kvm_sys_state.wifi_route[0] != 0 && network_probe_due(last_probe_ms)){
 					if (chack_net_state(WiFi_ROUTE) == 0){
 						// Ping successful
 						kvm_sys_state.wifi_state = 0;

--- a/tools/test-s25wifimod.sh
+++ b/tools/test-s25wifimod.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+SCRIPT="$ROOT/kvmapp/system/init.d/S25wifimod"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT HUP INT TERM
+
+mkdir -p "$WORK/ko/3rd" "$WORK/bin"
+
+cat > "$WORK/bin/insmod" <<'EOF'
+#!/bin/sh
+basename "$1" >> "$NANOKVM_INSMOD_LOG"
+EOF
+chmod +x "$WORK/bin/insmod"
+
+run_case() {
+	name=$1
+	alias_value=$2
+	expected=$3
+	devices="$WORK/$name/devices"
+	log="$WORK/$name/insmod.log"
+
+	mkdir -p "$devices/card:0000:1"
+	printf '%s\n' "$alias_value" > "$devices/card:0000:1/modalias"
+	: > "$log"
+
+	NANOKVM_KO_DIR="$WORK/ko" \
+	NANOKVM_SDIO_DEVICES_DIR="$devices" \
+	NANOKVM_INSMOD="$WORK/bin/insmod" \
+	NANOKVM_INSMOD_LOG="$log" \
+		sh "$SCRIPT" start >/dev/null
+
+	actual=$(cat "$log")
+	if [ "$actual" != "$expected" ]
+	then
+		echo "$name: unexpected modules" >&2
+		echo "expected:" >&2
+		printf '%s\n' "$expected" >&2
+		echo "actual:" >&2
+		printf '%s\n' "$actual" >&2
+		exit 1
+	fi
+}
+
+run_case aic 'sdio:c07v5449d0145' 'cfg80211.ko
+aic8800_bsp.ko
+aic8800_fdrv.ko'
+
+run_case rtl 'sdio:c07v024CdB73A' 'cfg80211.ko
+8733bs.ko'
+
+run_case unknown 'sdio:c07vFFFFdFFFF' 'cfg80211.ko
+aic8800_bsp.ko
+aic8800_fdrv.ko
+8733bs.ko'
+
+echo "S25wifimod tests passed"

--- a/tools/test-s30wifi-runtime.sh
+++ b/tools/test-s30wifi-runtime.sh
@@ -1,0 +1,185 @@
+#!/bin/sh
+
+set -eu
+
+ROOT=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+SCRIPT=$ROOT/kvmapp/system/init.d/S30wifi
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/nanokvm-s30wifi.XXXXXX")
+trap 'rm -rf "$TMP_ROOT"' EXIT HUP INT TERM
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+assert_file() {
+    [ -f "$1" ] || fail "missing file: $1"
+}
+
+assert_absent() {
+    [ ! -e "$1" ] || fail "unexpected path: $1"
+}
+
+assert_contains() {
+    pattern=$1
+    file=$2
+    grep -F -- "$pattern" "$file" >/dev/null || fail "$file does not contain: $pattern"
+}
+
+assert_not_contains() {
+    pattern=$1
+    file=$2
+    if grep -F -- "$pattern" "$file" >/dev/null; then
+        fail "$file contains: $pattern"
+    fi
+}
+
+new_case() {
+    name=$1
+    CASE_DIR=$TMP_ROOT/$name
+    BOOT_DIR=$CASE_DIR/boot
+    ETC_DIR=$CASE_DIR/etc/kvm
+    KVM_DIR=$CASE_DIR/kvm
+    RUN_DIR=$CASE_DIR/run
+    AP_FLAG=$CASE_DIR/wifiap
+    UID_FILE=$CASE_DIR/base_uid
+    DHCP_PID=$RUN_DIR/udhcpc.wlan0.pid
+    CALL_LOG=$CASE_DIR/calls.log
+    BIN_DIR=$CASE_DIR/bin
+    mkdir -p "$BOOT_DIR" "$ETC_DIR" "$KVM_DIR" "$BIN_DIR"
+    printf 'test-device-uid\n' > "$UID_FILE"
+    : > "$CALL_LOG"
+
+    cat > "$BIN_DIR/wpa_passphrase" <<'EOF'
+#!/bin/sh
+read -r password
+printf 'wpa_passphrase args=%s stdin=%s\n' "$*" "$password" >> "$CALL_LOG"
+[ "${WPA_FAIL:-0}" -eq 0 ] || exit 1
+printf '%s\n' 'network={' "    ssid=\"$1\"" "    #psk=\"$password\"" \
+    '    psk=0123456789abcdef' '}'
+EOF
+
+    for command in wpa_supplicant udhcpc hostapd udhcpd ifconfig ip killall chown
+    do
+        cat > "$BIN_DIR/$command" <<EOF
+#!/bin/sh
+printf '%s args=%s\n' '$command' "\$*" >> "\$CALL_LOG"
+exit 0
+EOF
+        chmod +x "$BIN_DIR/$command"
+    done
+    chmod +x "$BIN_DIR/wpa_passphrase"
+}
+
+run_action() (
+    action=$1
+    export CALL_LOG WPA_FAIL
+    export NANOKVM_WIFI_BOOT_DIR="$BOOT_DIR"
+    export NANOKVM_WIFI_ETC_DIR="$ETC_DIR"
+    export NANOKVM_WIFI_KVM_DIR="$KVM_DIR"
+    export NANOKVM_WIFI_RUN_DIR="$RUN_DIR"
+    export NANOKVM_WIFI_AP_FLAG="$AP_FLAG"
+    export NANOKVM_WIFI_UID_FILE="$UID_FILE"
+    export NANOKVM_WIFI_DHCP_PID="$DHCP_PID"
+    export NANOKVM_WPA_PASSPHRASE="$BIN_DIR/wpa_passphrase"
+    export NANOKVM_WPA_SUPPLICANT="$BIN_DIR/wpa_supplicant"
+    export NANOKVM_UDHCPC="$BIN_DIR/udhcpc"
+    export NANOKVM_HOSTAPD="$BIN_DIR/hostapd"
+    export NANOKVM_UDHCPD="$BIN_DIR/udhcpd"
+    export NANOKVM_IFCONFIG="$BIN_DIR/ifconfig"
+    export NANOKVM_IP="$BIN_DIR/ip"
+    export NANOKVM_KILLALL="$BIN_DIR/killall"
+    export NANOKVM_CHOWN="$BIN_DIR/chown"
+    "$SCRIPT" "$action"
+)
+
+# With no credentials, boot must not launch idle WPA/DHCP processes or create
+# persistent/runtime configuration.
+new_case no_credentials
+run_action start
+[ ! -s "$CALL_LOG" ] || fail "commands ran without credentials: $(cat "$CALL_LOG")"
+assert_absent "$RUN_DIR"
+
+# Boot credentials are imported once, tightened to mode 0600, and used to build
+# a mode-0600 runtime config without the plaintext comment emitted by
+# wpa_passphrase. The password is provided on stdin, not in argv.
+new_case sta
+printf 'Office WiFi\n' > "$BOOT_DIR/wifi.ssid"
+printf 'secret123\n' > "$BOOT_DIR/wifi.pass"
+run_action start
+assert_absent "$BOOT_DIR/wifi.ssid"
+assert_absent "$BOOT_DIR/wifi.pass"
+assert_file "$ETC_DIR/wifi.ssid"
+assert_file "$ETC_DIR/wifi.pass"
+[ "$(stat -c '%a' "$ETC_DIR/wifi.ssid")" = 600 ] || fail 'SSID mode is not 0600'
+[ "$(stat -c '%a' "$ETC_DIR/wifi.pass")" = 600 ] || fail 'password mode is not 0600'
+[ "$(stat -c '%a' "$RUN_DIR")" = 700 ] || fail 'runtime directory mode is not 0700'
+[ "$(stat -c '%a' "$RUN_DIR/wpa_supplicant.conf")" = 600 ] || fail 'WPA config mode is not 0600'
+assert_contains 'ctrl_interface=/var/run/wpa_supplicant' "$RUN_DIR/wpa_supplicant.conf"
+assert_contains 'psk=0123456789abcdef' "$RUN_DIR/wpa_supplicant.conf"
+assert_not_contains '#psk=' "$RUN_DIR/wpa_supplicant.conf"
+assert_not_contains 'secret123' "$RUN_DIR/wpa_supplicant.conf"
+assert_contains 'wpa_passphrase args=Office WiFi stdin=secret123' "$CALL_LOG"
+assert_contains "wpa_supplicant args=-B -i wlan0 -c $RUN_DIR/wpa_supplicant.conf" "$CALL_LOG"
+assert_contains "udhcpc args=-i wlan0 -t 10 -T 1 -A 5 -b -p $DHCP_PID" "$CALL_LOG"
+
+# A static Wi-Fi configuration suppresses the DHCP client only.
+new_case nodhcp
+printf 'Office\n' > "$ETC_DIR/wifi.ssid"
+printf 'secret123\n' > "$ETC_DIR/wifi.pass"
+touch "$BOOT_DIR/wifi.nodhcp"
+run_action start
+assert_contains 'wpa_supplicant args=-B -i wlan0' "$CALL_LOG"
+assert_not_contains 'udhcpc args=' "$CALL_LOG"
+
+# Invalid credentials must not leave a partial config or launch networking.
+new_case invalid_credentials
+printf 'Office\n' > "$ETC_DIR/wifi.ssid"
+printf 'short\n' > "$ETC_DIR/wifi.pass"
+WPA_FAIL=1
+if run_action start; then
+    fail 'wpa_passphrase failure was ignored'
+fi
+WPA_FAIL=0
+assert_absent "$RUN_DIR/wpa_supplicant.conf"
+assert_not_contains 'wpa_supplicant args=' "$CALL_LOG"
+assert_not_contains 'udhcpc args=' "$CALL_LOG"
+
+# AP configuration and DHCP leases stay in tmpfs. Entering AP mode only removes
+# a wlan0 default route and uses the valid `ip addr flush` spelling.
+new_case ap
+printf 'NanoKVM\n' > "$KVM_DIR/ap.ssid"
+printf '87654321\n' > "$KVM_DIR/ap.pass"
+run_action ap
+assert_file "$RUN_DIR/hostapd.conf"
+assert_file "$RUN_DIR/udhcpd.conf"
+[ "$(stat -c '%a' "$RUN_DIR/hostapd.conf")" = 600 ] || fail 'hostapd config mode is not 0600'
+[ "$(stat -c '%a' "$RUN_DIR/udhcpd.conf")" = 600 ] || fail 'udhcpd config mode is not 0600'
+assert_contains "pidfile $RUN_DIR/udhcpd.pid" "$RUN_DIR/udhcpd.conf"
+assert_contains "lease_file $RUN_DIR/udhcpd.leases" "$RUN_DIR/udhcpd.conf"
+assert_contains 'ip args=route del default dev wlan0' "$CALL_LOG"
+assert_contains 'ip args=addr flush dev wlan0' "$CALL_LOG"
+assert_not_contains 'ip args=add flush' "$CALL_LOG"
+assert_file "$AP_FLAG"
+
+# Stop uses direct process names rather than three process pipelines and removes
+# every ephemeral state file.
+new_case stop
+mkdir -p "$RUN_DIR"
+for file in udhcpd.pid udhcpd.leases wpa_supplicant.conf hostapd.conf udhcpd.conf
+do
+    : > "$RUN_DIR/$file"
+done
+printf 'not-a-pid\n' > "$DHCP_PID"
+touch "$AP_FLAG"
+run_action stop
+assert_contains 'killall args=hostapd' "$CALL_LOG"
+assert_contains 'killall args=udhcpd' "$CALL_LOG"
+assert_contains 'killall args=wpa_supplicant' "$CALL_LOG"
+for file in udhcpc.wlan0.pid udhcpd.pid udhcpd.leases wpa_supplicant.conf hostapd.conf udhcpd.conf
+do
+    assert_absent "$RUN_DIR/$file"
+done
+assert_absent "$AP_FLAG"
+
+echo 'S30wifi runtime-state tests passed'


### PR DESCRIPTION
## Summary

- reduce idle network probing without changing gateway reachability semantics
- load only the Wi-Fi driver matching the detected SDIO device, with a safe unknown-hardware fallback
- keep transient Wi-Fi state and generated configuration off persistent storage while preserving credentials and the existing API contract
- cover AIC/RTL module selection, runtime state, credential permissions, and failure paths with shell and Go tests

## Consolidation

This PR now also supersedes #891 and #909. The three network/Wi-Fi changes are kept together in this PR.

## Dependencies

None. The CVITEK Ethernet carrier fix in sipeed/LicheeRV-Nano-Build#837 is complementary kernel work, but either PR can merge independently and in either order.

## Validation

Current review: stopping Wi-Fi now targets only the AP's DHCP PID, preserving a separate USB-network DHCP server. PID 0, PID 1 and malformed PID files are rejected. Module-selection, runtime-state, credential-permission and Go network tests pass, including the new DHCP isolation cases.

- `git diff --check`
- `tools/test-s25wifimod.sh`
- `tools/test-s30wifi-runtime.sh`
- `CGO_ENABLED=1 go test -race ./service/network`
- `go vet ./service/network`
- the component branches were previously release-built and hardware-tested with AIC Wi-Fi, IPv4/IPv6 connectivity, Ethernet insertion/removal, and no redundant persistent `wifi_state` writes

## Try NanoKVM OS

You are also welcome to try [NanoKVM OS](https://github.com/dormancygrace/NanoKVM-OS), a beta firmware for NanoKVM Cube and PCIe that brings together our video, networking, USB and memory improvements. Feedback from real devices is very welcome! Please read the README for the current beta limitations.