### PR TITLE
fix(kvm_vision): report no signal during HDMI detection

### DIFF
--- a/support/sg2002/additional/kvm/src/kvm_vision.cpp
+++ b/support/sg2002/additional/kvm/src/kvm_vision.cpp
@@ -1790,6 +1790,14 @@ int kvmv_read_img(uint16_t _width, uint16_t _height, uint8_t _type, uint16_t _ql
     if(mutex_res != 0){
         return -5;
     }
+    /* Auto-detection remains in vi_detect_state == 1 while HDMI is absent so
+       that a newly connected source is discovered.  Report the cable state
+       before that transient state; otherwise callers see an endless -4
+       ("Modifying image resolution") even though no signal is present. */
+    if (__atomic_load_n(&kvmv_cfg.hdmi_cable_state, __ATOMIC_ACQUIRE) == 0){
+        pthread_mutex_unlock(&vi_mutex);
+        return -1;
+    }
     if (kvmv_cfg.hdmi_res_err == ERROR_RES){
         pthread_mutex_unlock(&vi_mutex);
         return -7;


### PR DESCRIPTION
## Summary

- report `IMG_NOT_EXIST` when the HDMI detector already knows that no signal is present
- keep `-4` (resolution change in progress) for real auto-detection transitions with an active signal

## Why

Automatic detection deliberately remains in `vi_detect_state == 1` while HDMI is absent so a later cable insertion can be discovered. `kvmv_read_img` checked that internal retry state before the detected cable state, so every stream mode exposed an endless "Switching resolution..." warning instead of "No HDMI".

The signal flag is already published atomically by the detector. Reading it while holding the existing `vi_mutex` also prevents stale resolution and unsupported-resolution errors from taking priority after a disconnect.

This is the follow-up to the no-signal UI behavior discussed in #812.

## Validation

- `git diff --check`
- full SG2002 `kvm_vision` target build with Xuantie GCC 10.2.0 and `-march=rv64imafdcv0p7xthead`
- verified the resulting stripped RISC-V LP64D shared object and exported `kvmv_read_img`
- runtime A/B on NanoKVM: unplugged HDMI changed the UI from the stale "Switching resolution..." warning to "No HDMI"; inserting HDMI then restored live 1920x1080 H.264 at 30 FPS without a service or kernel error